### PR TITLE
Make compatible with the client code

### DIFF
--- a/src/net/STUN/STUNServer.cs
+++ b/src/net/STUN/STUNServer.cs
@@ -215,6 +215,7 @@ namespace SIPSorcery.Net
                 // Add MappedAddress attribute to indicate the socket the request was received from.
                 STUNAddressAttribute mappedAddressAtt = new STUNAddressAttribute(STUNAttributeTypesEnum.MappedAddress, receivedEndPoint.Port, receivedEndPoint.Address);
                 stunResponse.Attributes.Add(mappedAddressAtt);
+                stunResponse.AddXORMappedAddressAttribute(receivedEndPoint.Address, receivedEndPoint.Port);//Compatible with the client code
 
                 // Add SourceAddress attribute to indicate the socket used to send the response.
                 if (primary)


### PR DESCRIPTION
The stun client code is using XORMappedAddress , while the STUNServer.cs return MappedAddress only
Fix this compatible issue by adding XORMappedAddress header to STUNServer.cs