### PR TITLE
Implement `RTCDataChannel.bufferedAmount`.

### DIFF
--- a/src/net/SCTP/SctpAssociation.cs
+++ b/src/net/SCTP/SctpAssociation.cs
@@ -118,6 +118,11 @@ namespace SIPSorcery.Net
         /// </remarks>
         private Timer _t1Cookie;
 
+        /// <summary>
+        /// The total size (in bytes) of outgoing user data queued in the <see cref="SctpDataSender"/>.
+        /// </summary>
+        public ulong SendBufferedAmount => _dataSender?.BufferedAmount ?? 0;
+
         public uint VerificationTag { get; private set; }
 
         /// <summary>

--- a/src/net/SCTP/SctpDataSender.cs
+++ b/src/net/SCTP/SctpDataSender.cs
@@ -147,7 +147,7 @@ namespace SIPSorcery.Net
         /// <summary>
         /// The total size (in bytes) of queued user data that will be sent to the peer.
         /// </summary>
-        public ulong BufferedAmount => (ulong)_sendQueue.Sum(x => x.UserData.Length);
+        public ulong BufferedAmount => (ulong)_sendQueue.Sum(x => x.UserData?.Length ?? 0);
 
         /// <summary>
         /// The Transaction Sequence Number (TSN) that will be used in the next DATA chunk sent.

--- a/src/net/SCTP/SctpDataSender.cs
+++ b/src/net/SCTP/SctpDataSender.cs
@@ -145,6 +145,11 @@ namespace SIPSorcery.Net
         internal ConcurrentDictionary<uint, int> _missingChunks = new ConcurrentDictionary<uint, int>();
 
         /// <summary>
+        /// The total size (in bytes) of queued user data that will be sent to the peer.
+        /// </summary>
+        public ulong BufferedAmount => (ulong)_sendQueue.Sum(x => x.UserData.Length);
+
+        /// <summary>
         /// The Transaction Sequence Number (TSN) that will be used in the next DATA chunk sent.
         /// </summary>
         public uint TSN { get; internal set; }

--- a/src/net/WebRTC/RTCDataChannel.cs
+++ b/src/net/WebRTC/RTCDataChannel.cs
@@ -65,7 +65,7 @@ namespace SIPSorcery.Net
 
         public RTCDataChannelState readyState { get; internal set; } = RTCDataChannelState.connecting;
 
-        public ulong bufferedAmount { get; set; }
+        public ulong bufferedAmount => _transport?.RTCSctpAssociation?.SendBufferedAmount ?? 0;
 
         public ulong bufferedAmountLowThreshold { get; set; }
         public string binaryType { get; set; }


### PR DESCRIPTION
This change implements `RTCDataChannel.bufferedAmount`, where buffered amount is determined by summing the queued data in  the underlying `SctpDataSender`.