### PR TITLE
Replace ContainsKey with TryGetValue in SctpDataSender.

### DIFF
--- a/src/net/SCTP/SctpDataSender.cs
+++ b/src/net/SCTP/SctpDataSender.cs
@@ -196,9 +196,9 @@ namespace SIPSorcery.Net
                     uint maxTSNDistance = SctpDataReceiver.GetDistance(_cumulativeAckTSN, TSN);
                     bool processGapReports = true;
 
-                    if (_unconfirmedChunks.ContainsKey(sack.CumulativeTsnAck))
+                    if (_unconfirmedChunks.TryGetValue(sack.CumulativeTsnAck, out var result))
                     {
-                        _lastAckedDataChunkSize = _unconfirmedChunks[sack.CumulativeTsnAck].UserData.Length;
+                        _lastAckedDataChunkSize = result.UserData.Length;
                     }
 
                     if (!_gotFirstSACK)
@@ -456,10 +456,8 @@ namespace SIPSorcery.Net
 
                     while (chunksSent < burstSize && haveMissing)
                     {
-                        if (_unconfirmedChunks.ContainsKey(misses.Current.Key))
+                        if (_unconfirmedChunks.TryGetValue(misses.Current.Key, out var missingChunk))
                         {
-                            var missingChunk = _unconfirmedChunks[misses.Current.Key];
-
                             missingChunk.LastSentAt = now;
                             missingChunk.SendCount += 1;
 


### PR DESCRIPTION
A couple places in `SctpDataSender` are calling `ContainsKey` followed by getting the item in a separate call.

However, the item is not guaranteed to still be in the dictionary after the first check.

This change replaces the checking and getting with an atomic `TryGetValue` call.