### PR TITLE
Resent BYE with auth upon 407 challenge

### DIFF
--- a/src/SIPSorcery.csproj
+++ b/src/SIPSorcery.csproj
@@ -83,9 +83,9 @@
 -v5.0.0: Stable release.
     </PackageReleaseNotes>
     <NeutralLanguage>en</NeutralLanguage>
-    <Version>5.2.2</Version>
-    <AssemblyVersion>5.2.2.0</AssemblyVersion>
-    <FileVersion>5.2.2.0</FileVersion>
+    <Version>5.2.1</Version>
+    <AssemblyVersion>5.2.1.0</AssemblyVersion>
+    <FileVersion>5.2.1.0</FileVersion>
   </PropertyGroup>
 
 </Project>

--- a/src/SIPSorcery.csproj
+++ b/src/SIPSorcery.csproj
@@ -51,7 +51,8 @@
     <RepositoryType>git</RepositoryType>
     <RepositoryBranch>master</RepositoryBranch>
     <PackageTags>SIP WebRTC VoIP RTP SDP STUN ICE SIPSorcery</PackageTags>
-    <PackageReleaseNotes>-v5.2.0: Stable release with new WebRTC Data Channel implementation.
+    <PackageReleaseNotes>-v5.2.1: Make sure bye is retried with auth if challenged
+-v5.2.0: Stable release with new WebRTC Data Channel implementation.
 -v5.1.8-pre: Bug fix. Fixed RTCPeerConnection setting of DisableExtendedMasterSecretKey.
 -v5.1.7-pre: Added MSRP SDP parsing, thanks to @jacekdzija.
 -v5.1.6-pre: SCTP rewrite and data channel improvements.
@@ -82,9 +83,9 @@
 -v5.0.0: Stable release.
     </PackageReleaseNotes>
     <NeutralLanguage>en</NeutralLanguage>
-    <Version>5.2.0</Version>
-    <AssemblyVersion>5.2.0.0</AssemblyVersion>
-    <FileVersion>5.2.0.0</FileVersion>
+    <Version>5.2.2</Version>
+    <AssemblyVersion>5.2.2.0</AssemblyVersion>
+    <FileVersion>5.2.2.0</FileVersion>
   </PropertyGroup>
 
 </Project>

--- a/src/app/SIPUserAgents/SIPClientUserAgent.cs
+++ b/src/app/SIPUserAgents/SIPClientUserAgent.cs
@@ -42,7 +42,7 @@ namespace SIPSorcery.SIP.App
         private bool m_hungupOnCancel;                              // Set to true if a call has been cancelled AND and then an OK response was received AND a BYE has been sent to hang it up. This variable is used to stop another BYE transaction being generated.
         private int m_serverAuthAttempts;                           // Used to determine if credentials for a server leg call fail.
         internal SIPNonInviteTransaction m_cancelTransaction;       // If the server call is cancelled this transaction contains the CANCEL in case it needs to be resent.
-        internal SIPNonInviteTransaction m_byeTransaction;       // If the server call is cancelled this transaction contains the CANCEL in case it needs to be resent.
+        internal SIPNonInviteTransaction m_byeTransaction;          // If the server call is hungup this transaction contains the BYE in case it needs to be resent.
         private SIPEndPoint m_outboundProxy;                        // If the system needs to use an outbound proxy for every request this will be set and overrides any user supplied values.
         private SIPDialogue m_sipDialogue;
 

--- a/src/app/SIPUserAgents/SIPServerUserAgent.cs
+++ b/src/app/SIPUserAgents/SIPServerUserAgent.cs
@@ -49,7 +49,8 @@ namespace SIPSorcery.SIP.App
         public SIPDialogue SIPDialogue { get; private set; }
 
         protected ISIPAccount m_sipAccount;
-        private SIPNonInviteTransaction m_byeTransaction;
+
+        private SIPNonInviteTransaction m_byeTransaction;       // If the server call is hungup this transaction contains the BYE in case it needs to be resent.
 
         public ISIPAccount SIPAccount
         {

--- a/src/app/SIPUserAgents/SIPServerUserAgent.cs
+++ b/src/app/SIPUserAgents/SIPServerUserAgent.cs
@@ -49,6 +49,8 @@ namespace SIPSorcery.SIP.App
         public SIPDialogue SIPDialogue { get; private set; }
 
         protected ISIPAccount m_sipAccount;
+        private SIPNonInviteTransaction m_byeTransaction;
+
         public ISIPAccount SIPAccount
         {
             get { return m_sipAccount; }
@@ -61,6 +63,7 @@ namespace SIPSorcery.SIP.App
             set { m_isAuthenticated = value; }
         }
 
+        public bool IsHangingUp => m_byeTransaction?.DeliveryPending ?? false;
         public bool IsCancelled => m_isCancelled;
         public SIPRequest CallRequest => m_uasTransaction.TransactionRequest;
         public string CallDestination => m_uasTransaction.TransactionRequest.URI.User;
@@ -446,9 +449,9 @@ namespace SIPSorcery.SIP.App
                         else
                         {
                             var byeRequest = SIPDialogue.GetInDialogRequest(SIPMethodsEnum.BYE);
-                            SIPNonInviteTransaction byeTransaction = new SIPNonInviteTransaction(m_sipTransport, byeRequest, m_outboundProxy);
-                            byeTransaction.NonInviteTransactionFinalResponseReceived += ByeServerFinalResponseReceived;
-                            byeTransaction.SendRequest();
+                            m_byeTransaction = new SIPNonInviteTransaction(m_sipTransport, byeRequest, m_outboundProxy);
+                            m_byeTransaction.NonInviteTransactionFinalResponseReceived += ByeServerFinalResponseReceived;
+                            m_byeTransaction.SendRequest();
                         }
                     }
                     catch (Exception excp)

--- a/src/app/SIPUserAgents/SIPUserAgent.cs
+++ b/src/app/SIPUserAgents/SIPUserAgent.cs
@@ -96,12 +96,6 @@ namespace SIPSorcery.SIP.App
         private SIPDialogue m_sipDialogue;
 
         /// <summary>
-        /// When a call is hungup a reference is kept to the BYE transaction so it can
-        /// be monitored for delivery.
-        /// </summary>
-        private SIPNonInviteTransaction m_byeTransaction;
-
-        /// <summary>
         /// Holds the call descriptor for an in progress client (outbound) call.
         /// </summary>
         private SIPCallDescriptor m_callDescriptor;
@@ -198,7 +192,11 @@ namespace SIPSorcery.SIP.App
                 {
                     return true;
                 }
-                else if (m_byeTransaction != null && m_byeTransaction.DeliveryPending)
+                else if (m_uac != null && m_uac.IsHangingUp)
+                {
+                    return true;
+                }
+                else if (m_uas != null && m_uas.IsHangingUp)
                 {
                     return true;
                 }

--- a/src/app/SIPUserAgents/SIPUserAgent.cs
+++ b/src/app/SIPUserAgents/SIPUserAgent.cs
@@ -192,11 +192,7 @@ namespace SIPSorcery.SIP.App
                 {
                     return true;
                 }
-                else if (m_uac != null && m_uac.IsHangingUp)
-                {
-                    return true;
-                }
-                else if (m_uas != null && m_uas.IsHangingUp)
+                else if ((m_uac != null && m_uac.IsHangingUp) || (m_uas != null && m_uas.IsHangingUp))
                 {
                     return true;
                 }


### PR DESCRIPTION
Fixes #477

These changes make use of the Client/Server UserAgent Hangup code to enable resend of the BYE with the necessary authentication headers.

Took advantage of the ISIPAccount interface which the server agent already optionally received to propagate the username/password

Added IsHangingUp to both Client/Server UserAgent in order to help the SIPUserAgent get the proper information 

Removed the m_byeTransaction from the SIPUserAgent since it is not needed anymore