### PR TITLE
Re-invite with auth when holding/unholding

### DIFF
--- a/src/SIPSorcery.csproj
+++ b/src/SIPSorcery.csproj
@@ -51,7 +51,8 @@
     <RepositoryType>git</RepositoryType>
     <RepositoryBranch>master</RepositoryBranch>
     <PackageTags>SIP WebRTC VoIP RTP SDP STUN ICE SIPSorcery</PackageTags>
-    <PackageReleaseNotes>-v5.2.1: Make sure bye is retried with auth if challenged
+    <PackageReleaseNotes>-v5.2.2: Make sure hold/unhold re-invite is resent on auth challenge from server
+-v5.2.1: Make sure bye is retried with auth if challenged
 -v5.2.0: Stable release with new WebRTC Data Channel implementation.
 -v5.1.8-pre: Bug fix. Fixed RTCPeerConnection setting of DisableExtendedMasterSecretKey.
 -v5.1.7-pre: Added MSRP SDP parsing, thanks to @jacekdzija.
@@ -83,9 +84,9 @@
 -v5.0.0: Stable release.
     </PackageReleaseNotes>
     <NeutralLanguage>en</NeutralLanguage>
-    <Version>5.2.1</Version>
-    <AssemblyVersion>5.2.1.0</AssemblyVersion>
-    <FileVersion>5.2.1.0</FileVersion>
+    <Version>5.2.2</Version>
+    <AssemblyVersion>5.2.2.0</AssemblyVersion>
+    <FileVersion>5.2.2.0</FileVersion>
   </PropertyGroup>
 
 </Project>

--- a/src/app/SIPUserAgents/Behaviours/SIPAuthChallenge.cs
+++ b/src/app/SIPUserAgents/Behaviours/SIPAuthChallenge.cs
@@ -1,0 +1,36 @@
+﻿//-----------------------------------------------------------------------------
+// Filename: SIPAuthChallenge.cs
+//
+// Description: Common logic when having to add auth to SIP Requests
+//
+// History:
+// 10 May 2021 : Created 
+//
+// License: 
+// BSD 3-Clause "New" or "Revised" License, see included LICENSE.md file.
+//-----------------------------------------------------------------------------
+using System.Linq;
+using SIPSorcery.SIP;
+
+
+namespace SIPSorcery.App.SIPUserAgents.Behaviours
+{
+    public static class SIPAuthChallenge
+    {
+        public static SIPRequest AddAuthenticationHeaderToRequest(SIPRequest previousSipRequest, SIPResponse sipResponse, string username, string password)
+        {
+            // Resend Invite with credentials.
+            SIPAuthorisationDigest authRequest = sipResponse.Header.AuthenticationHeader.SIPDigest;
+            SIPURI contactUri = sipResponse.Header.Contact.Any() ? sipResponse.Header.Contact[0].ContactURI : sipResponse.Header.From.FromURI;
+            
+            authRequest.SetCredentials(username, password, contactUri.ToString(), previousSipRequest.Method.ToString());
+
+            previousSipRequest.Header.AuthenticationHeader = new SIPAuthenticationHeader(authRequest);
+            previousSipRequest.Header.AuthenticationHeader.SIPDigest.Response = authRequest.Digest;
+            previousSipRequest.Header.Vias.TopViaHeader.Branch = CallProperties.CreateBranchId();
+            previousSipRequest.Header.CSeq = previousSipRequest.Header.CSeq + 1;
+
+            return previousSipRequest;
+        }
+    }
+}

--- a/src/app/SIPUserAgents/Behaviours/SIPAuthChallenge.cs
+++ b/src/app/SIPUserAgents/Behaviours/SIPAuthChallenge.cs
@@ -21,7 +21,7 @@ namespace SIPSorcery.App.SIPUserAgents.Behaviours
         {
             // Resend Invite with credentials.
             SIPAuthorisationDigest authRequest = sipResponse.Header.AuthenticationHeader.SIPDigest;
-            SIPURI contactUri = sipResponse.Header.Contact.Any() ? sipResponse.Header.Contact[0].ContactURI : sipResponse.Header.From.FromURI;
+            SIPURI contactUri = previousSipRequest.Header.Contact.Any() ? previousSipRequest.Header.Contact[0].ContactURI : previousSipRequest.Header.From.FromURI;
             
             authRequest.SetCredentials(username, password, contactUri.ToString(), previousSipRequest.Method.ToString());
 

--- a/src/app/SIPUserAgents/Behaviours/SIPAuthChallenge.cs
+++ b/src/app/SIPUserAgents/Behaviours/SIPAuthChallenge.cs
@@ -21,9 +21,8 @@ namespace SIPSorcery.App.SIPUserAgents.Behaviours
         {
             // Resend Invite with credentials.
             SIPAuthorisationDigest authRequest = sipResponse.Header.AuthenticationHeader.SIPDigest;
-            SIPURI contactUri = previousSipRequest.Header.Contact.Any() ? previousSipRequest.Header.Contact[0].ContactURI : previousSipRequest.Header.From.FromURI;
             
-            authRequest.SetCredentials(username, password, contactUri.ToString(), previousSipRequest.Method.ToString());
+            authRequest.SetCredentials(username, password, previousSipRequest.URI.ToString(), previousSipRequest.Method.ToString());
 
             previousSipRequest.Header.AuthenticationHeader = new SIPAuthenticationHeader(authRequest);
             previousSipRequest.Header.AuthenticationHeader.SIPDigest.Response = authRequest.Digest;

--- a/src/app/SIPUserAgents/SIPClientUserAgent.cs
+++ b/src/app/SIPUserAgents/SIPClientUserAgent.cs
@@ -22,7 +22,7 @@ using System.Net;
 using System.Net.Sockets;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
-using SIPSorcery.app.SIPUserAgents.Behaviours;
+using SIPSorcery.App.SIPUserAgents.Behaviours;
 using SIPSorcery.Sys;
 
 namespace SIPSorcery.SIP.App

--- a/src/app/SIPUserAgents/SIPClientUserAgent.cs
+++ b/src/app/SIPUserAgents/SIPClientUserAgent.cs
@@ -22,6 +22,7 @@ using System.Net;
 using System.Net.Sockets;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using SIPSorcery.app.SIPUserAgents.Behaviours;
 using SIPSorcery.Sys;
 
 namespace SIPSorcery.SIP.App
@@ -74,8 +75,6 @@ namespace SIPSorcery.SIP.App
         {
             get { return m_sipCallDescriptor; }
         }
-
-        public SIPCallDescriptor SipCallDescriptor { get => m_sipCallDescriptor; set => m_sipCallDescriptor = value; }
 
         /// <summary>
         /// Determines whether the agent will operate with support for reliable provisional responses as per RFC3262.
@@ -391,18 +390,11 @@ namespace SIPSorcery.SIP.App
 
                             // Resend INVITE with credentials.
                             string username = (m_sipCallDescriptor.AuthUsername != null && m_sipCallDescriptor.AuthUsername.Trim().Length > 0) ? m_sipCallDescriptor.AuthUsername : m_sipCallDescriptor.Username;
-                            SIPAuthorisationDigest authRequest = sipResponse.Header.AuthenticationHeader.SIPDigest;
-                            authRequest.SetCredentials(username, m_sipCallDescriptor.Password, m_sipCallDescriptor.Uri, SIPMethodsEnum.INVITE.ToString());
-
-                            SIPRequest authInviteRequest = m_serverTransaction.TransactionRequest;
-                            authInviteRequest.Header.AuthenticationHeader = new SIPAuthenticationHeader(authRequest);
-                            authInviteRequest.Header.AuthenticationHeader.SIPDigest.Response = authRequest.Digest;
-                            authInviteRequest.Header.Vias.TopViaHeader.Branch = CallProperties.CreateBranchId();
-                            authInviteRequest.Header.CSeq = authInviteRequest.Header.CSeq + 1;
+                            var updatedInviteRequest = SIPAuthChallenge.AddAuthenticationHeaderToRequest(m_serverTransaction.TransactionRequest, sipResponse, username, m_sipCallDescriptor.Password);
 
                             // Create a new UAC transaction to establish the authenticated server call.
                             var originalCallTransaction = m_serverTransaction;
-                            m_serverTransaction = new UACInviteTransaction(m_sipTransport, authInviteRequest, m_outboundProxy);
+                            m_serverTransaction = new UACInviteTransaction(m_sipTransport, updatedInviteRequest, m_outboundProxy);
                             if (m_serverTransaction.CDR != null)
                             {
                                 m_serverTransaction.CDR.Updated();

--- a/src/app/SIPUserAgents/SIPServerUserAgent.cs
+++ b/src/app/SIPUserAgents/SIPServerUserAgent.cs
@@ -19,7 +19,7 @@ using System.Linq;
 using System.Net.Sockets;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
-using SIPSorcery.app.SIPUserAgents.Behaviours;
+using SIPSorcery.App.SIPUserAgents.Behaviours;
 using SIPSorcery.Net;
 using SIPSorcery.Sys;
 

--- a/src/app/SIPUserAgents/SIPServerUserAgent.cs
+++ b/src/app/SIPUserAgents/SIPServerUserAgent.cs
@@ -19,6 +19,7 @@ using System.Linq;
 using System.Net.Sockets;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using SIPSorcery.app.SIPUserAgents.Behaviours;
 using SIPSorcery.Net;
 using SIPSorcery.Sys;
 
@@ -474,19 +475,9 @@ namespace SIPSorcery.SIP.App
 
                 if ((sipResponse.Status == SIPResponseStatusCodesEnum.ProxyAuthenticationRequired || sipResponse.Status == SIPResponseStatusCodesEnum.Unauthorised) && SIPAccount != null)
                 {
-                    // Resend BYE with credentials.
-                    SIPAuthorisationDigest authRequest = sipResponse.Header.AuthenticationHeader.SIPDigest;
-                    SIPURI contactUri = sipResponse.Header.Contact.Any() ? sipResponse.Header.Contact[0].ContactURI : sipResponse.Header.From.FromURI;
+                    var updatedSipRequest = SIPAuthChallenge.AddAuthenticationHeaderToRequest(sipTransaction.TransactionRequest, sipResponse, SIPAccount.SIPUsername, SIPAccount.SIPPassword);
 
-                    authRequest.SetCredentials(SIPAccount.SIPUsername, SIPAccount.SIPPassword, contactUri.ToString(), SIPMethodsEnum.BYE.ToString());
-
-                    SIPRequest authByeRequest = byeTransaction.TransactionRequest;
-                    authByeRequest.Header.AuthenticationHeader = new SIPAuthenticationHeader(authRequest);
-                    authByeRequest.Header.AuthenticationHeader.SIPDigest.Response = authRequest.Digest;
-                    authByeRequest.Header.Vias.TopViaHeader.Branch = CallProperties.CreateBranchId();
-                    authByeRequest.Header.CSeq = authByeRequest.Header.CSeq + 1;
-
-                    SIPNonInviteTransaction authByeTransaction = new SIPNonInviteTransaction(m_sipTransport, authByeRequest, null);
+                    SIPNonInviteTransaction authByeTransaction = new SIPNonInviteTransaction(m_sipTransport, updatedSipRequest, null);
                     authByeTransaction.SendRequest();
                 }
 

--- a/src/app/SIPUserAgents/SIPUserAgent.cs
+++ b/src/app/SIPUserAgents/SIPUserAgent.cs
@@ -30,7 +30,7 @@ using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
-using SIPSorcery.app.SIPUserAgents.Behaviours;
+using SIPSorcery.App.SIPUserAgents.Behaviours;
 using SIPSorcery.Net;
 using SIPSorcery.Sys;
 


### PR DESCRIPTION
This simply adds the necessary logic to create an invite message if the user agent receives a 407 during a hold/unhold