### PR TITLE
Changed SyncSource setter access modifier, see Issue #494

### DIFF
--- a/src/net/RTP/MediaStreamTrack.cs
+++ b/src/net/RTP/MediaStreamTrack.cs
@@ -37,8 +37,12 @@ namespace SIPSorcery.Net
         /// <summary>
         /// The value used in the RTP Synchronisation Source header field for media packets
         /// sent using this media stream.
+		/// Be careful that the RTP Synchronisation Source header field should not be changed
+		/// unless specific implementations require it. By default this value is chosen randomly,
+		/// with the intent that no two synchronization sources within the same RTP session
+		/// will have the same SSRC.
         /// </summary>
-        public uint Ssrc { get; internal set; }
+        public uint Ssrc { get; set; }
 
 
         


### PR DESCRIPTION
Working with a proprietary protocol built over SIP that uses the SSRC in a meaningful way, so I had to remove the `internal` access modifier in order to change it as specified by the protocol. 

**Warning**
Be careful that the RTP Synchronisation Source header field should not be changed unless specific implementations require it. By default this value is chosen randomly, with the intent that no two synchronization sources within the same RTP session will have the same SSRC.