### PR TITLE
Remove redundant Tx Request Received events and handlers

### DIFF
--- a/src/core/SIPTransactions/SIPNonInviteTransaction.cs
+++ b/src/core/SIPTransactions/SIPNonInviteTransaction.cs
@@ -31,7 +31,6 @@ namespace SIPSorcery.SIP
             : base(sipTransport, sipRequest, outboundProxy)
         {
             TransactionType = SIPTransactionTypesEnum.NonInvite;
-            TransactionRequestReceived += SIPNonInviteTransaction_TransactionRequestReceived;
             TransactionInformationResponseReceived += SIPNonInviteTransaction_TransactionInformationResponseReceived;
             TransactionFinalResponseReceived += SIPNonInviteTransaction_TransactionFinalResponseReceived;
             TransactionFailed += SIPNonInviteTransaction_TransactionFailed;

--- a/src/core/SIPTransactions/SIPTransaction.cs
+++ b/src/core/SIPTransactions/SIPTransaction.cs
@@ -210,7 +210,6 @@ namespace SIPSorcery.SIP
         protected bool PrackSupported = false;
 
         // These are the events that will normally be required by upper level transaction users such as registration or call agents.
-        protected event SIPTransactionRequestReceivedDelegate TransactionRequestReceived;
         protected event SIPTransactionResponseReceivedDelegate TransactionInformationResponseReceived;
         protected event SIPTransactionResponseReceivedDelegate TransactionFinalResponseReceived;
         protected event SIPTransactionFailedDelegate TransactionFailed;
@@ -282,12 +281,6 @@ namespace SIPSorcery.SIP
         public static string GetRequestTransactionId(string branchId, SIPMethodsEnum method)
         {
             return Crypto.GetSHAHashAsString(branchId + method.ToString());
-        }
-
-        public void GotRequest(SIPEndPoint localSIPEndPoint, SIPEndPoint remoteEndPoint, SIPRequest sipRequest)
-        {
-            TransactionTraceMessage?.Invoke(this, $"Transaction received Request {localSIPEndPoint}<-{remoteEndPoint}: {sipRequest.StatusLine}");
-            TransactionRequestReceived?.Invoke(localSIPEndPoint, remoteEndPoint, this, sipRequest);
         }
 
         public Task<SocketError> GotResponse(SIPEndPoint localSIPEndPoint, SIPEndPoint remoteEndPoint, SIPResponse sipResponse)

--- a/src/core/SIPTransactions/UACInviteTransaction.cs
+++ b/src/core/SIPTransactions/UACInviteTransaction.cs
@@ -65,7 +65,6 @@ namespace SIPSorcery.SIP
             TransactionFinalResponseReceived += UACInviteTransaction_TransactionFinalResponseReceived;
             TransactionInformationResponseReceived += UACInviteTransaction_TransactionInformationResponseReceived;
             TransactionFailed += UACInviteTransaction_TransactionFailed;
-            TransactionRequestReceived += UACInviteTransaction_TransactionRequestReceived;
         }
 
         public void SendInviteRequest()

--- a/src/core/SIPTransactions/UASInviteTransaction.cs
+++ b/src/core/SIPTransactions/UASInviteTransaction.cs
@@ -39,7 +39,6 @@ namespace SIPSorcery.SIP
         }
 
         public event SIPTransactionCancelledDelegate UASInviteTransactionCancelled;
-        public event SIPTransactionRequestReceivedDelegate NewCallReceived;
         public event SIPTransactionFailedDelegate UASInviteTransactionFailed;
 
         /// <summary>

--- a/test/integration/core/SIPDnsUnitTest.cs
+++ b/test/integration/core/SIPDnsUnitTest.cs
@@ -240,7 +240,7 @@ namespace SIPSorcery.SIP.IntegrationTests
 
             try
             {
-                LookupClientOptions clientOptions = new LookupClientOptions(IPAddress.Loopback)
+                LookupClientOptions clientOptions = new LookupClientOptions(IPAddress.Parse("127.0.0.2"))
                 {
                     Retries = 3,
                     Timeout = TimeSpan.FromSeconds(1),

--- a/test/unit/core/SIPTransactions/SIPTransactionEngineUnitTest.cs
+++ b/test/unit/core/SIPTransactions/SIPTransactionEngineUnitTest.cs
@@ -123,13 +123,13 @@ namespace SIPSorcery.SIP.UnitTests
                     logger.LogDebug("Server Transport Request In: " + sipRequest.Method + ".");
                     serverTransaction = new UASInviteTransaction(serverTransport, sipRequest, null);
                     SetTransactionTraceEvents(serverTransaction);
-                    serverTransaction.NewCallReceived += (lep, rep, sipTransaction, newCallRequest) =>
-                    {
-                        logger.LogDebug("Server new call received.");
-                        var busyResponse = SIPResponse.GetResponse(newCallRequest, SIPResponseStatusCodesEnum.BusyHere, null);
-                        (sipTransaction as UASInviteTransaction).SendFinalResponse(busyResponse);
-                        return Task.FromResult(SocketError.Success);
-                    };
+                    //serverTransaction.NewCallReceived += (lep, rep, sipTransaction, newCallRequest) =>
+                    //{
+                    //    logger.LogDebug("Server new call received.");
+                    //    var busyResponse = SIPResponse.GetResponse(newCallRequest, SIPResponseStatusCodesEnum.BusyHere, null);
+                    //    (sipTransaction as UASInviteTransaction).SendFinalResponse(busyResponse);
+                    //    return Task.FromResult(SocketError.Success);
+                    //};
                     serverTransaction.TransactionStateChanged += (tx) =>
                     {
                         if (serverTransaction.TransactionState == SIPTransactionStatesEnum.Confirmed)
@@ -140,7 +140,8 @@ namespace SIPSorcery.SIP.UnitTests
                             }
                         }
                     };
-                    //serverTransaction.GotRequest(localEndPoint, remoteEndPoint, sipRequest);
+                    SIPResponse busyHereResponse = SIPResponse.GetResponse(sipRequest, SIPResponseStatusCodesEnum.BusyHere, null);
+                    serverTransaction.SendFinalResponse(busyHereResponse);
 
                     return Task.FromResult(0);
                 };

--- a/test/unit/core/SIPTransactions/SIPTransactionEngineUnitTest.cs
+++ b/test/unit/core/SIPTransactions/SIPTransactionEngineUnitTest.cs
@@ -132,7 +132,7 @@ namespace SIPSorcery.SIP.UnitTests
                     };
                     serverTransaction.TransactionStateChanged += (tx) =>
                     {
-                        if (tx.TransactionState == SIPTransactionStatesEnum.Confirmed)
+                        if (serverTransaction.TransactionState == SIPTransactionStatesEnum.Confirmed)
                         {
                             if (!uasConfirmedTask.TrySetResult(true))
                             {
@@ -140,7 +140,7 @@ namespace SIPSorcery.SIP.UnitTests
                             }
                         }
                     };
-                    serverTransaction.GotRequest(localEndPoint, remoteEndPoint, sipRequest);
+                    //serverTransaction.GotRequest(localEndPoint, remoteEndPoint, sipRequest);
 
                     return Task.FromResult(0);
                 };


### PR DESCRIPTION
#520 highlights that SIP transaction classes were not using, and don't need, the transaction request received events and handlers. This PR removes the redundant logic.

Transactions are only ever created by supplying a SIP request to a constructor. There is no need to have a separate method to pass a SIP request to a transaction instance.