### PR TITLE
Forces DNS to wait sending SIP messages with retransmits disabled

### DIFF
--- a/src/core/SIPTransactions/SIPTransactionEngine.cs
+++ b/src/core/SIPTransactions/SIPTransactionEngine.cs
@@ -512,7 +512,12 @@ namespace SIPSorcery.SIP
             }
             else
             {
-                return m_sipTransport.SendResponseAsync(transaction.ReliableProvisionalResponse);
+                // If retransmits are disabled we must wait for DNS when sending. By default the DNS lookup mechanism
+                // will silently do nothing if the lookup result is not in the cache and relies on the result
+                // being ready for a subsequent SIP retransmit. This mechanism won't work if SIP retransmits are disabled.
+                bool waitForDns = DisableRetransmitSending;
+
+                return m_sipTransport.SendResponseAsync(transaction.ReliableProvisionalResponse, waitForDns);
             }
         }
 
@@ -543,7 +548,12 @@ namespace SIPSorcery.SIP
             }
             else
             {
-                return m_sipTransport.SendResponseAsync(transaction.TransactionFinalResponse);
+                // If retransmits are disabled we must wait for DNS when sending. By default the DNS lookup mechanism
+                // will silently do nothing if the lookup result is not in the cache and relies on the result
+                // being ready for a subsequent SIP retransmit. This mechanism won't work if SIP retransmits are disabled.
+                bool waitForDns = DisableRetransmitSending;
+
+                return m_sipTransport.SendResponseAsync(transaction.TransactionFinalResponse, waitForDns);
             }
         }
 
@@ -587,7 +597,12 @@ namespace SIPSorcery.SIP
                 }
                 else
                 {
-                    result = m_sipTransport.SendRequestAsync(req);
+                    // If retransmits are disabled we must wait for DNS when sending. By default the DNS lookup mechanism
+                    // will silently do nothing if the lookup result is not in the cache and relies on the result
+                    // being ready for a subsequent SIP retransmit. This mechanism won't work if SIP retransmits are disabled.
+                    bool waitForDns = DisableRetransmitSending;
+
+                    result = m_sipTransport.SendRequestAsync(req, waitForDns);
                 }
 
                 return result;


### PR DESCRIPTION
As discussed in #520 there is a problem if SIP retransmits have been disabled and a DNS result has not been cached. This PR adds a small fix to force a SIP send to wait for the DNS lookup if transaction retransmits have been disabled.