### PR TITLE
Force DNS to wait sending Final Response with retransmits disabled

### DIFF
--- a/src/core/SIPTransactions/SIPTransactionEngine.cs
+++ b/src/core/SIPTransactions/SIPTransactionEngine.cs
@@ -433,7 +433,13 @@ namespace SIPSorcery.SIP
                                                         {
                                                             // Sending a single final response on a non-INVITE tx. The same response
                                                             // will be automatically resent if the same request is received.
-                                                            sendResult = m_sipTransport.SendResponseAsync(transaction.TransactionFinalResponse).Result;
+
+                                                            // If retransmits are disabled we must wait for DNS when sending. By default the DNS lookup mechanism
+                                                            // will silently do nothing if the lookup result is not in the cache and relies on the result
+                                                            // being ready for a subsequent SIP retransmit. This mechanism won't work if SIP retransmits are disabled.
+                                                            bool waitForDns = DisableRetransmitSending;
+
+                                                            sendResult = m_sipTransport.SendResponseAsync(transaction.TransactionFinalResponse, waitForDns).Result;
                                                             transaction.DeliveryPending = false;
                                                         }
                                                         break;


### PR DESCRIPTION
I think we need this additional change to fully address the DisableRetransmit issue