### PR TITLE
* Add initial support to Renegotiation Logic

### DIFF
--- a/src/net/RTP/MediaStreamTrack.cs
+++ b/src/net/RTP/MediaStreamTrack.cs
@@ -44,12 +44,13 @@ namespace SIPSorcery.Net
         /// </summary>
         public uint Ssrc { get; set; }
 
-
-        
         /// <summary>
         /// The last seqnum received from the remote peer for this stream.
         /// </summary>
         public ushort LastRemoteSeqNum { get; internal set; }
+
+        // The value used in the RTP Sequence Number header field for media packets.
+        public ushort SeqNum { get { return (ushort)m_seqNum; } internal set { m_seqNum = value; } }
 
         /// <summary>
         /// The value used in the RTP Timestamp header field for media packets

--- a/src/net/SDP/SDPMediaAnnouncement.cs
+++ b/src/net/SDP/SDPMediaAnnouncement.cs
@@ -189,11 +189,14 @@ namespace SIPSorcery.Net
             Port = port;
             MediaStreamStatus = DEFAULT_STREAM_STATUS;
 
-            foreach (var fmt in mediaFormats)
+            if (mediaFormats != null)
             {
-                if (!MediaFormats.ContainsKey(fmt.ID))
+                foreach (var fmt in mediaFormats)
                 {
-                    MediaFormats.Add(fmt.ID, fmt);
+                    if (!MediaFormats.ContainsKey(fmt.ID))
+                    {
+                        MediaFormats.Add(fmt.ID, fmt);
+                    }
                 }
             }
         }
@@ -203,11 +206,14 @@ namespace SIPSorcery.Net
             Media = mediaType;
             Port = port;
 
-            foreach (var fmt in appMediaFormats)
+            if (appMediaFormats != null)
             {
-                if (!ApplicationMediaFormats.ContainsKey(fmt.ID))
+                foreach (var fmt in appMediaFormats)
                 {
-                    ApplicationMediaFormats.Add(fmt.ID, fmt);
+                    if (!ApplicationMediaFormats.ContainsKey(fmt.ID))
+                    {
+                        ApplicationMediaFormats.Add(fmt.ID, fmt);
+                    }
                 }
             }
         }


### PR DESCRIPTION
* This PulRequest add a basic initial support to Renegotiation Logic.

Take a note relative to Event "onnegotiationneeded" because in JavaScript this event is called after "process.nextTick()"

As in pure c# we don't have the same concept of "Process", as Process inself act as a "GameLoop" I created a new Task to emit this event after user AddTrack/RemoveTrack.... This way user can change multiple tracks before event get fired, but the drawback of doing this is because the onnegotiationneeded will be fired in another thread, so the user need to take care about multi-thread access in objects.