### PR TITLE
return public access modifier

### DIFF
--- a/src/core/SIP/SIPTransport.cs
+++ b/src/core/SIP/SIPTransport.cs
@@ -601,7 +601,7 @@ namespace SIPSorcery.SIP
         /// If no response is received then periodic retransmits are made for up to T1 x 64 seconds (defaults to 30 seconds with 11 retransmits).
         /// </summary>
         /// <param name="sipTransaction">The SIP transaction encapsulating the SIP request or response that needs to be sent reliably.</param>
-        internal void AddTransaction(SIPTransaction sipTransaction)
+        public void AddTransaction(SIPTransaction sipTransaction)
         {
             if (sipTransaction == null)
             {


### PR DESCRIPTION
Please, check if i'm doing right:
1 option: earlier i've used  SendTransaction like this:
` SIPNonInviteTransaction nonInviteTransaction = new  SIPNonInviteTransaction ();
_sipTransport.SendTransaction((SIPTransaction) nonInviteTransaction ); // now this method has become AddTransaction`
because i've returned public access modifier to AddTransaction, i can continue use it like this (PR should be accepted)
OR
2 option: i should change my code and use methods of  SIPNonInviteTransaction : SendRequest or SendResponce?
(in this case PR should be declined)
Greate thanks for Your help!
