### PR TITLE
Fix support for rtp sequence wraparound (65535 > 0) in H264 reconstruction

### DIFF
--- a/src/net/RTP/Packetisation/H264Depacketiser.cs
+++ b/src/net/RTP/Packetisation/H264Depacketiser.cs
@@ -86,7 +86,10 @@ namespace SIPSorcery.Net
                 //Reorder to prevent UDP incorrect package order
                 if (temporary_rtp_payloads.Count > 1)
                 {
-                    temporary_rtp_payloads.Sort((a, b) => { return a.Key.CompareTo(b.Key); });
+                    temporary_rtp_payloads.Sort((a, b) => { 
+                        // Detect wraparound of sequence to sort packets correctly (Assumption that no more then 2000 packets per frame)
+                        return (Math.Abs(b.Key - a.Key) > (0xFFFF - 2000)) ? -a.Key.CompareTo(b.Key) : a.Key.CompareTo(b.Key);                        
+                         });
                 }
 
                 // End Marker is set. Process the list of RTP Packets (forming 1 RTP frame) and save the NALs to a file


### PR DESCRIPTION
I encountered issue with sequence "warp around" during rebuilding fragmented H264 NAL - as parts were incorrectly sorted due to sequence change {65534,65535,0,1} were sorted as {0,1,65534,65535} leading to invalid frame reconstruction.

The above change in the code fixes this for me

PS: I used 2000 as the max number of fragments in the fragmented frame to detect 