### PR TITLE
Add Server header value for deserialization

### DIFF
--- a/src/core/SIP/SIPHeader.cs
+++ b/src/core/SIP/SIPHeader.cs
@@ -1975,6 +1975,12 @@ namespace SIPSorcery.SIP
                             }
                         }
                         #endregion
+                        #region Server
+                        else if (headerNameLower == SIPHeaders.SIP_HEADER_SERVER.ToLower())
+                        {
+                            sipHeader.Server = headerValue;
+                        }
+                        #endregion
                         else
                         {
                             sipHeader.UnknownHeaders.Add(headerLine);


### PR DESCRIPTION
While writing tests for some issues with the Server header, it turned out that the SIPHeader class does not deserialize the Server header field properly (it just doesn't). 

I don't know if that was on purpose since the field itself is not something I want to use since it leaks information, but if not, let's fix it.

The current behaviour will put the Server header key+value into the Unknown headers list