### PR TITLE
Testing calling against remote SIP provider - Fixes.

### DIFF
--- a/src/app/Media/Sources/AudioExtrasSource.cs
+++ b/src/app/Media/Sources/AudioExtrasSource.cs
@@ -547,5 +547,10 @@ namespace SIPSorcery.Media
                 }
             }
         }
+
+        public void Close()
+        {
+            _streamSourceReader?.Close();
+        }
     }
 }

--- a/src/app/SIPUserAgents/SIPUserAgent.cs
+++ b/src/app/SIPUserAgents/SIPUserAgent.cs
@@ -1476,7 +1476,7 @@ namespace SIPSorcery.SIP.App
             }
             else
             {
-                logger.LogInformation($"Call attempt to {m_uac.CallDescriptor.Uri} received a trying response {sipResponse.ShortDescription}.");
+                logger.LogInformation($"Call attempt to {uac.CallDescriptor.Uri} received a trying response {sipResponse.ShortDescription}.");
             }
         }
 
@@ -1505,7 +1505,7 @@ namespace SIPSorcery.SIP.App
             }
             else
             {
-                logger.LogInformation($"Call attempt to {m_uac.CallDescriptor.Uri} received a ringing response {sipResponse.ShortDescription}.");
+                logger.LogInformation($"Call attempt to {uac.CallDescriptor.Uri} received a ringing response {sipResponse.ShortDescription}.");
             }
         }
 
@@ -1543,7 +1543,7 @@ namespace SIPSorcery.SIP.App
                     m_sipDialogue = uac.SIPDialogue;
                     m_sipDialogue.DialogueState = SIPDialogueStateEnum.Confirmed;
 
-                    logger.LogInformation($"Call attempt to {m_uac.CallDescriptor.Uri} was answered; no media update from early media.");
+                    logger.LogInformation($"Call attempt to {uac.CallDescriptor.Uri} was answered; no media update from early media.");
 
                     ClientCallAnswered?.Invoke(uac, sipResponse);
                 }
@@ -1558,7 +1558,7 @@ namespace SIPSorcery.SIP.App
                         m_sipDialogue = uac.SIPDialogue;
                         m_sipDialogue.DialogueState = SIPDialogueStateEnum.Confirmed;
 
-                        logger.LogInformation($"Call attempt to {m_uac.CallDescriptor.Uri} was answered.");
+                        logger.LogInformation($"Call attempt to {uac.CallDescriptor.Uri} was answered.");
 
                         ClientCallAnswered?.Invoke(uac, sipResponse);
                     }
@@ -1652,8 +1652,11 @@ namespace SIPSorcery.SIP.App
         /// </summary>
         private void CallEnded()
         {
-            m_uac = null;
-            m_uas = null;
+            // SCB - Which call has ended?
+            // The UserAgent should be re-used for all calls. Only the sipdialogue associated with the call
+            // needs to be cleared up.
+            //m_uac = null;
+            //m_uas = null;
             m_callDescriptor = null;
 
             IsOnLocalHold = false;


### PR DESCRIPTION
SIPUserAgent - 

Whilst doing periodic calls of 25 second duration every minute, we were getting intermittent exceptions on event callbacks. Typically, the cause was the m_uac class variable being null at the time of the callback.

There was also an incident where during InitiateCallAsync, m_uac became null. The only explanation being that a late BYE from the SIP provider to the previous call was received during the call setup for the new call. I changed CallEnded to not set m_uac = null, and this has been tested for 100 hours (6000+ calls) without any issues observed. 