### PR TITLE
expose peer connection interface

### DIFF
--- a/src/net/WebRTC/IRTCPeerConnection.cs
+++ b/src/net/WebRTC/IRTCPeerConnection.cs
@@ -333,7 +333,7 @@ namespace SIPSorcery.Net
         connected
     }
 
-    interface IRTCPeerConnection
+    public interface IRTCPeerConnection
     {
         //IRTCPeerConnection(RTCConfiguration configuration = null);
         RTCSessionDescriptionInit createOffer(RTCOfferOptions options = null);


### PR DESCRIPTION
In order for a third party app to be built around the RTCPeerConnection, I aim to leverage the interface to inject behaviors throught Mocks. In order to do so, I need a public accessible interface.

Is this acceptable ?