### PR TITLE
Replicate mediaid tags for generated answer

### DIFF
--- a/src/net/RTP/RTPSession.cs
+++ b/src/net/RTP/RTPSession.cs
@@ -570,7 +570,9 @@ namespace SIPSorcery.Net
                 foreach (var localTrack in localTracks)
                 {
                     if (localTrack != null && localTrack.StreamStatus == MediaStreamStatusEnum.Inactive)
+                    {
                         localTrack.StreamStatus = localTrack.DefaultStreamStatus;
+                    }
                 }
 
                 var offerSdp = GetSessionDesciption(localTracks, connectionAddress);
@@ -1162,7 +1164,9 @@ namespace SIPSorcery.Net
             if (localTrack != null)
             {
                 if (localTrack.StreamStatus == MediaStreamStatusEnum.Inactive)
+                {
                     localTrack.StreamStatus = localTrack.DefaultStreamStatus;
+                }
 
                 if (remoteTrackStatus == MediaStreamStatusEnum.Inactive)
                 {

--- a/src/net/RTP/RTPSession.cs
+++ b/src/net/RTP/RTPSession.cs
@@ -1257,7 +1257,7 @@ namespace SIPSorcery.Net
 
             foreach (var track in tracks)
             {
-                int mindex = RemoteDescription == null ? mediaIndex++ : RemoteDescription.GetIndexForMediaType(track.Kind);
+                (int mindex, string midTag) = RemoteDescription == null ? (mediaIndex++, mediaIndex.ToString()) : RemoteDescription.GetIndexForMediaType(track.Kind);
 
                 int rtpPort = 0; // A port of zero means the media type is not supported.
                 if (track.Capabilities != null && track.Capabilities.Count() > 0 && track.StreamStatus != MediaStreamStatusEnum.Inactive)

--- a/src/net/SDP/SDP.cs
+++ b/src/net/SDP/SDP.cs
@@ -128,6 +128,7 @@ namespace SIPSorcery.Net
         public const int IGNORE_RTP_PORT_NUMBER = 9;
         public const string TELEPHONE_EVENT_ATTRIBUTE = "telephone-event";
         public const int MEDIA_INDEX_NOT_PRESENT = -1;
+        public const string MEDIA_INDEX_TAG_NOT_PRESENT = "";
         public const MediaStreamStatusEnum DEFAULT_STREAM_STATUS = MediaStreamStatusEnum.SendRecv;
 
         // ICE attributes.
@@ -899,14 +900,14 @@ namespace SIPSorcery.Net
         /// </summary>
         /// <param name="mediaType">The media type to get the index for.</param>
         /// <returns></returns>
-        public int GetIndexForMediaType(SDPMediaTypesEnum mediaType)
+        public (int, string) GetIndexForMediaType(SDPMediaTypesEnum mediaType)
         {
             int index = 0;
             foreach (var ann in Media)
             {
                 if (ann.Media == mediaType)
                 {
-                    return index;
+                    return (index, ann.MediaID);
                 }
                 else
                 {
@@ -914,7 +915,7 @@ namespace SIPSorcery.Net
                 }
             }
 
-            return MEDIA_INDEX_NOT_PRESENT;
+            return (MEDIA_INDEX_NOT_PRESENT, MEDIA_INDEX_TAG_NOT_PRESENT);
         }
     }
 }

--- a/src/net/WebRTC/RTCPeerConnection.cs
+++ b/src/net/WebRTC/RTCPeerConnection.cs
@@ -1074,7 +1074,7 @@ namespace SIPSorcery.Net
             // Media announcements must be in the same order in the offer and answer.
             foreach (var track in tracks)
             {
-                int mindex = RemoteDescription == null || RequireRenegotiation ? mediaIndex++ : RemoteDescription.GetIndexForMediaType(track.Kind);
+                (int mindex, string midTag) = RemoteDescription == null || RequireRenegotiation ? (mediaIndex++, mediaIndex.ToString()) : RemoteDescription.GetIndexForMediaType(track.Kind);
 
                 if (mindex == SDP.MEDIA_INDEX_NOT_PRESENT)
                 {
@@ -1092,7 +1092,7 @@ namespace SIPSorcery.Net
                     announcement.AddExtra(RTCP_MUX_ATTRIBUTE);
                     announcement.AddExtra(RTCP_ATTRIBUTE);
                     announcement.MediaStreamStatus = track.StreamStatus;
-                    announcement.MediaID = mindex.ToString();
+                    announcement.MediaID = midTag;
                     announcement.MLineIndex = mindex;
 
                     announcement.IceUfrag = _rtpIceChannel.LocalIceUser;
@@ -1124,7 +1124,7 @@ namespace SIPSorcery.Net
 
             if (DataChannels.Count > 0 || (RemoteDescription?.Media.Any(x => x.Media == SDPMediaTypesEnum.application) ?? false))
             {
-                int mindex = RemoteDescription == null ? mediaIndex++ : RemoteDescription.GetIndexForMediaType(SDPMediaTypesEnum.application);
+                (int mindex, string midTag) = RemoteDescription == null ? (mediaIndex++, mediaIndex.ToString()) : RemoteDescription.GetIndexForMediaType(SDPMediaTypesEnum.application);
 
                 if (mindex == SDP.MEDIA_INDEX_NOT_PRESENT)
                 {
@@ -1142,7 +1142,7 @@ namespace SIPSorcery.Net
                     dataChannelAnnouncement.SctpPort = SCTP_DEFAULT_PORT;
                     dataChannelAnnouncement.MaxMessageSize = sctp.maxMessageSize;
                     dataChannelAnnouncement.MLineIndex = mindex;
-                    dataChannelAnnouncement.MediaID = mindex.ToString();
+                    dataChannelAnnouncement.MediaID = midTag;
                     dataChannelAnnouncement.IceUfrag = _rtpIceChannel.LocalIceUser;
                     dataChannelAnnouncement.IcePwd = _rtpIceChannel.LocalIcePassword;
                     dataChannelAnnouncement.IceOptions = ICE_OPTIONS;

--- a/src/net/WebRTC/RTCPeerConnection.cs
+++ b/src/net/WebRTC/RTCPeerConnection.cs
@@ -860,7 +860,9 @@ namespace SIPSorcery.Net
             foreach (var localTrack in localTracks)
             {
                 if (localTrack != null && localTrack.StreamStatus == MediaStreamStatusEnum.Inactive)
+                {
                     localTrack.StreamStatus = localTrack.DefaultStreamStatus;
+                }
             }
 
             var audioLocalTrack = localTracks.Find(a => a.Kind == SDPMediaTypesEnum.audio);
@@ -1325,7 +1327,9 @@ namespace SIPSorcery.Net
 
                 //Prevent continue with cancellation requested
                 if (token.IsCancellationRequested)
+                {
                     return;
+                }
                 else
                 {
                     if (_requireRenegotiation)
@@ -1347,7 +1351,10 @@ namespace SIPSorcery.Net
                 if (_cancellationSource != null)
                 {
                     if (!_cancellationSource.IsCancellationRequested)
+                    {
                         _cancellationSource.Cancel();
+                    }
+
                     _cancellationSource = null;
                 }
             }

--- a/src/net/WebRTC/RTCPeerConnection.cs
+++ b/src/net/WebRTC/RTCPeerConnection.cs
@@ -1163,7 +1163,7 @@ namespace SIPSorcery.Net
             if (offerSdp.Media?.Count > 0)
             {
                 offerSdp.Group = BUNDLE_ATTRIBUTE;
-                foreach (var ann in offerSdp.Media.OrderBy(x => x.MediaID))
+                foreach (var ann in offerSdp.Media.OrderBy(x => x.MLineIndex))
                 {
                     offerSdp.Group += $" {ann.MediaID}";
                 }

--- a/test/integration/core/SIPTransportIntegrationTest.cs
+++ b/test/integration/core/SIPTransportIntegrationTest.cs
@@ -29,7 +29,7 @@ using Microsoft.Extensions.Logging;
 using SIPSorcery.Sys;
 using Xunit;
 
-namespace SIPSorcery.SIP.IntegrationTest
+namespace SIPSorcery.SIP.IntegrationTests
 {
     [Trait("Category", "transport")]
     public class SIPTransportIntegrationTest

--- a/test/integration/net/WebRTC/RTCPeerConnectionUnitTest.cs
+++ b/test/integration/net/WebRTC/RTCPeerConnectionUnitTest.cs
@@ -216,7 +216,7 @@ a=rtpmap:100 VP8/90000";
             logger.LogDebug("--> " + System.Reflection.MethodBase.GetCurrentMethod().Name);
             logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
 
-            // In this SDP, the audio media identifier's tag is "foo" and the video media identifier's tag is "bar"
+            // In this SDP, the audio media identifier's tag is "bar" and the video media identifier's tag is "foo"
             string remoteSdp =
             @"v=0
 o=- 1064364449942365659 2 IN IP4 127.0.0.1
@@ -405,13 +405,14 @@ a=max-message-size:262144";
             logger.LogDebug("--> " + System.Reflection.MethodBase.GetCurrentMethod().Name);
             logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
 
-            // In this SDP, the audio media identifier's tag is "foo" and the video media identifier's tag is "bar"
+            // In this SDP, the audio media identifier's tag is "zzz" and the video media identifier's tag is "aaa".
+            // Such tag are meant to ensure that we do not sort sdp's media tracks by alphabetical order.
             string remoteSdp =
             @"v=0
 o=- 1064364449942365659 2 IN IP4 127.0.0.1
 s=-
 t=0 0
-a=group:BUNDLE zzz aaa
+a=group:BUNDLE zzz aaa 
 a=msid-semantic: WMS stream0
 m=audio 9 UDP/TLS/RTP/SAVPF 111 103 104 9 102 0 8 106 105 13 110 112 113 126
 c=IN IP4 0.0.0.0

--- a/test/integration/net/WebRTC/RTCPeerConnectionUnitTest.cs
+++ b/test/integration/net/WebRTC/RTCPeerConnectionUnitTest.cs
@@ -128,7 +128,6 @@ namespace SIPSorcery.Net.IntegrationTests
 
         /// <summary>
         /// Checks that the media formats are correctly negotiated when for a remote offer and the local
-        /// tracks.
         /// </summary>
         [Fact]
         public void CheckMediaFormatNegotiationUnitTest()
@@ -341,10 +340,9 @@ a=ssrc:4165955869 label:video0";
             pc.Close("normal");
         }
 
-
         /// <summary>
         /// Checks that the media identifier tags for datachannel (application data) are correctly reused in
-        /// the generated answer tracks.
+        /// the generated answer.
         /// </summary>
         [Fact]
         public void CheckDataChannelMediaIdentifierTagsAreReusedForAnswerUnitTest()
@@ -393,6 +391,140 @@ a=max-message-size:262144";
             Assert.Equal(SDPMediaTypesEnum.application, answer.Media[0].Media);
             Assert.Contains("a=group:BUNDLE application1", answerString);
             Assert.Contains("a=mid:application1", answerString);
+
+            pc.Close("normal");
+        }
+
+        /// <summary>
+        /// Checks that the media identifier tags in the generated answer are in the same order as in the 
+        /// received offer.
+        /// </summary>
+        [Fact]
+        public void CheckMediaIdentifierTagOrderRemainsForAnswerUnitTest()
+        {
+            logger.LogDebug("--> " + System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+
+            // In this SDP, the audio media identifier's tag is "foo" and the video media identifier's tag is "bar"
+            string remoteSdp =
+            @"v=0
+o=- 1064364449942365659 2 IN IP4 127.0.0.1
+s=-
+t=0 0
+a=group:BUNDLE zzz aaa
+a=msid-semantic: WMS stream0
+m=audio 9 UDP/TLS/RTP/SAVPF 111 103 104 9 102 0 8 106 105 13 110 112 113 126
+c=IN IP4 0.0.0.0
+a=rtcp:9 IN IP4 0.0.0.0
+a=ice-ufrag:G5P/
+a=ice-pwd:FICf2eBzvl5r/O/uf1ktSyuc
+a=ice-options:trickle renomination
+a=fingerprint:sha-256 5D:03:7C:22:69:2E:E7:10:17:5F:31:86:E6:47:2F:6F:1D:4C:A6:BF:5B:DE:0C:FB:8A:17:15:AA:22:63:0C:FD
+a=setup:actpass
+a=mid:zzz
+a=extmap:1 urn:ietf:params:rtp-hdrext:ssrc-audio-level
+a=extmap:2 http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time
+a=extmap:3 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01
+a=sendrecv
+a=rtcp-mux
+a=rtpmap:111 opus/48000/2
+a=rtcp-fb:111 transport-cc
+a=fmtp:111 minptime=10;useinbandfec=1
+a=rtpmap:103 ISAC/16000
+a=rtpmap:104 ISAC/32000
+a=rtpmap:9 G722/8000
+a=rtpmap:102 ILBC/8000
+a=rtpmap:0 PCMU/8000
+a=rtpmap:8 PCMA/8000
+a=rtpmap:106 CN/32000
+a=rtpmap:105 CN/16000
+a=rtpmap:13 CN/8000
+a=rtpmap:110 telephone-event/48000
+a=rtpmap:112 telephone-event/32000
+a=rtpmap:113 telephone-event/16000
+a=rtpmap:126 telephone-event/8000
+a=ssrc:3780525913 cname:FLLo3gHcblO+MbrR
+a=ssrc:3780525913 msid:stream0 audio0
+a=ssrc:3780525913 mslabel:stream0
+a=ssrc:3780525913 label:audio0
+m=video 9 UDP/TLS/RTP/SAVPF 96 97 98 99 100 101 127
+c=IN IP4 0.0.0.0
+a=rtcp:9 IN IP4 0.0.0.0
+a=ice-ufrag:G5P/
+a=ice-pwd:FICf2eBzvl5r/O/uf1ktSyuc
+a=ice-options:trickle renomination
+a=fingerprint:sha-256 5D:03:7C:22:69:2E:E7:10:17:5F:31:86:E6:47:2F:6F:1D:4C:A6:BF:5B:DE:0C:FB:8A:17:15:AA:22:63:0C:FD
+a=setup:actpass
+a=mid:aaa
+a=extmap:14 urn:ietf:params:rtp-hdrext:toffset
+a=extmap:2 http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time
+a=extmap:13 urn:3gpp:video-orientation
+a=extmap:3 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01
+a=extmap:5 http://www.webrtc.org/experiments/rtp-hdrext/playout-delay
+a=extmap:6 http://www.webrtc.org/experiments/rtp-hdrext/video-content-type
+a=extmap:7 http://www.webrtc.org/experiments/rtp-hdrext/video-timing
+a=extmap:8 http://www.webrtc.org/experiments/rtp-hdrext/color-space
+a=sendrecv
+a=rtcp-mux
+a=rtcp-rsize
+a=rtpmap:96 VP8/90000
+a=rtcp-fb:96 goog-remb
+a=rtcp-fb:96 transport-cc
+a=rtcp-fb:96 ccm fir
+a=rtcp-fb:96 nack
+a=rtcp-fb:96 nack pli
+a=rtpmap:97 rtx/90000
+a=fmtp:97 apt=96
+a=rtpmap:98 VP9/90000
+a=rtcp-fb:98 goog-remb
+a=rtcp-fb:98 transport-cc
+a=rtcp-fb:98 ccm fir
+a=rtcp-fb:98 nack
+a=rtcp-fb:98 nack pli
+a=rtpmap:99 rtx/90000
+a=fmtp:99 apt=98
+a=rtpmap:100 red/90000
+a=rtpmap:101 rtx/90000
+a=fmtp:101 apt=100
+a=rtpmap:127 ulpfec/90000
+a=ssrc-group:FID 3851740345 4165955869
+a=ssrc:3851740345 cname:FLLo3gHcblO+MbrR
+a=ssrc:3851740345 msid:stream0 video0
+a=ssrc:3851740345 mslabel:stream0
+a=ssrc:3851740345 label:video0
+a=ssrc:4165955869 cname:FLLo3gHcblO+MbrR
+a=ssrc:4165955869 msid:stream0 video0
+a=ssrc:4165955869 mslabel:stream0
+a=ssrc:4165955869 label:video0";
+
+            RTCPeerConnection pc = new RTCPeerConnection(null);
+            var audioTrack = new MediaStreamTrack(SDPMediaTypesEnum.audio, false, new List<SDPAudioVideoMediaFormat> { new SDPAudioVideoMediaFormat(SDPWellKnownMediaFormatsEnum.PCMU) });
+            pc.addTrack(audioTrack);
+            MediaStreamTrack localVideoTrack = new MediaStreamTrack(SDPMediaTypesEnum.video, false, new List<SDPAudioVideoMediaFormat> { new SDPAudioVideoMediaFormat(SDPMediaTypesEnum.video, 96, "VP8", 90000) });
+            pc.addTrack(localVideoTrack);
+
+            var offer = SDP.ParseSDPDescription(remoteSdp);
+
+            logger.LogDebug($"Remote offer: {offer}");
+
+            var result = pc.SetRemoteDescription(SIP.App.SdpType.offer, offer);
+
+            logger.LogDebug($"Set remote description on local session result {result}.");
+
+            Assert.Equal(SetDescriptionResultEnum.OK, result);
+
+            var answer = pc.CreateAnswer(null);
+            var answerString = answer.ToString();
+
+            logger.LogDebug($"Local answer: {answer}");
+
+            Assert.Equal("zzz", answer.Media[0].MediaID);
+            Assert.Equal(SDPMediaTypesEnum.audio, answer.Media[0].Media);
+            Assert.Equal("aaa", answer.Media[1].MediaID);
+            Assert.Equal(SDPMediaTypesEnum.video, answer.Media[1].Media);
+            Assert.Contains("a=group:BUNDLE zzz aaa", answerString);
+            Assert.Contains("a=mid:zzz", answerString);
+            Assert.Contains("a=mid:aaa", answerString);
 
             pc.Close("normal");
         }

--- a/test/integration/net/WebRTC/RTCPeerConnectionUnitTest.cs
+++ b/test/integration/net/WebRTC/RTCPeerConnectionUnitTest.cs
@@ -208,6 +208,140 @@ a=rtpmap:100 VP8/90000";
         }
 
         /// <summary>
+        /// Checks that the media identifier tag are correctly reused in the generated answer
+        /// tracks.
+        /// </summary>
+        [Fact]
+        public void CheckMediaIdentifierTagAreReusedForAnswerUnitTest()
+        {
+            logger.LogDebug("--> " + System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+
+            // In this SDP, the audio media identifier's tag is "foo" and the video media identifier's tag is "bar"
+            string remoteSdp =
+            @"=0
+o=- 1064364449942365659 2 IN IP4 127.0.0.1
+s=-
+t=0 0
+a=group:BUNDLE foo bar
+a=msid-semantic: WMS stream0
+m=audio 9 UDP/TLS/RTP/SAVPF 111 103 104 9 102 0 8 106 105 13 110 112 113 126
+c=IN IP4 0.0.0.0
+a=rtcp:9 IN IP4 0.0.0.0
+a=ice-ufrag:G5P/
+a=ice-pwd:FICf2eBzvl5r/O/uf1ktSyuc
+a=ice-options:trickle renomination
+a=fingerprint:sha-256 5D:03:7C:22:69:2E:E7:10:17:5F:31:86:E6:47:2F:6F:1D:4C:A6:BF:5B:DE:0C:FB:8A:17:15:AA:22:63:0C:FD
+a=setup:actpass
+a=mid:foo
+a=extmap:1 urn:ietf:params:rtp-hdrext:ssrc-audio-level
+a=extmap:2 http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time
+a=extmap:3 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01
+a=sendrecv
+a=rtcp-mux
+a=rtpmap:111 opus/48000/2
+a=rtcp-fb:111 transport-cc
+a=fmtp:111 minptime=10;useinbandfec=1
+a=rtpmap:103 ISAC/16000
+a=rtpmap:104 ISAC/32000
+a=rtpmap:9 G722/8000
+a=rtpmap:102 ILBC/8000
+a=rtpmap:0 PCMU/8000
+a=rtpmap:8 PCMA/8000
+a=rtpmap:106 CN/32000
+a=rtpmap:105 CN/16000
+a=rtpmap:13 CN/8000
+a=rtpmap:110 telephone-event/48000
+a=rtpmap:112 telephone-event/32000
+a=rtpmap:113 telephone-event/16000
+a=rtpmap:126 telephone-event/8000
+a=ssrc:3780525913 cname:FLLo3gHcblO+MbrR
+a=ssrc:3780525913 msid:stream0 audio0
+a=ssrc:3780525913 mslabel:stream0
+a=ssrc:3780525913 label:audio0
+m=video 9 UDP/TLS/RTP/SAVPF 96 97 98 99 100 101 127
+c=IN IP4 0.0.0.0
+a=rtcp:9 IN IP4 0.0.0.0
+a=ice-ufrag:G5P/
+a=ice-pwd:FICf2eBzvl5r/O/uf1ktSyuc
+a=ice-options:trickle renomination
+a=fingerprint:sha-256 5D:03:7C:22:69:2E:E7:10:17:5F:31:86:E6:47:2F:6F:1D:4C:A6:BF:5B:DE:0C:FB:8A:17:15:AA:22:63:0C:FD
+a=setup:actpass
+a=mid:bar
+a=extmap:14 urn:ietf:params:rtp-hdrext:toffset
+a=extmap:2 http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time
+a=extmap:13 urn:3gpp:video-orientation
+a=extmap:3 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01
+a=extmap:5 http://www.webrtc.org/experiments/rtp-hdrext/playout-delay
+a=extmap:6 http://www.webrtc.org/experiments/rtp-hdrext/video-content-type
+a=extmap:7 http://www.webrtc.org/experiments/rtp-hdrext/video-timing
+a=extmap:8 http://www.webrtc.org/experiments/rtp-hdrext/color-space
+a=sendrecv
+a=rtcp-mux
+a=rtcp-rsize
+a=rtpmap:96 VP8/90000
+a=rtcp-fb:96 goog-remb
+a=rtcp-fb:96 transport-cc
+a=rtcp-fb:96 ccm fir
+a=rtcp-fb:96 nack
+a=rtcp-fb:96 nack pli
+a=rtpmap:97 rtx/90000
+a=fmtp:97 apt=96
+a=rtpmap:98 VP9/90000
+a=rtcp-fb:98 goog-remb
+a=rtcp-fb:98 transport-cc
+a=rtcp-fb:98 ccm fir
+a=rtcp-fb:98 nack
+a=rtcp-fb:98 nack pli
+a=rtpmap:99 rtx/90000
+a=fmtp:99 apt=98
+a=rtpmap:100 red/90000
+a=rtpmap:101 rtx/90000
+a=fmtp:101 apt=100
+a=rtpmap:127 ulpfec/90000
+a=ssrc-group:FID 3851740345 4165955869
+a=ssrc:3851740345 cname:FLLo3gHcblO+MbrR
+a=ssrc:3851740345 msid:stream0 video0
+a=ssrc:3851740345 mslabel:stream0
+a=ssrc:3851740345 label:video0
+a=ssrc:4165955869 cname:FLLo3gHcblO+MbrR
+a=ssrc:4165955869 msid:stream0 video0
+a=ssrc:4165955869 mslabel:stream0
+a=ssrc:4165955869 label:video0";
+
+            RTCPeerConnection pc = new RTCPeerConnection(null);
+            var audioTrack = new MediaStreamTrack(SDPMediaTypesEnum.audio, false, new List<SDPAudioVideoMediaFormat> { new SDPAudioVideoMediaFormat(SDPWellKnownMediaFormatsEnum.PCMU) });
+            pc.addTrack(audioTrack);
+            MediaStreamTrack localVideoTrack = new MediaStreamTrack(SDPMediaTypesEnum.video, false, new List<SDPAudioVideoMediaFormat> { new SDPAudioVideoMediaFormat(SDPMediaTypesEnum.video, 96, "VP8", 90000) });
+            pc.addTrack(localVideoTrack);
+
+            var offer = SDP.ParseSDPDescription(remoteSdp);
+
+            logger.LogDebug($"Remote offer: {offer}");
+
+            var result = pc.SetRemoteDescription(SIP.App.SdpType.offer, offer);
+
+            logger.LogDebug($"Set remote description on local session result {result}.");
+
+            Assert.Equal(SetDescriptionResultEnum.OK, result);
+
+            var answer = pc.CreateAnswer(null);
+            var answerString = answer.ToString();
+
+            logger.LogDebug($"Local answer: {answer}");
+
+            Assert.Equal("foo", answer.Media[0].MediaID);
+            Assert.Equal(SDPMediaTypesEnum.audio, answer.Media[0].Media);
+            Assert.Equal("bar", answer.Media[1].MediaID);
+            Assert.Equal(SDPMediaTypesEnum.video, answer.Media[1].Media);
+            Assert.Contains("a=group:BUNDLE foo bar", answerString);
+            Assert.Contains("a=mid:foo", answerString);
+            Assert.Contains("a=mid:bar", answerString);
+
+            pc.Close("normal");
+        }
+
+        /// <summary>
         /// Checks that an inactive audio track gets added if the offer contains audio and video but
         /// the local peer connection only supports video.
         /// </summary>

--- a/test/integration/net/WebRTC/RTCPeerConnectionUnitTest.cs
+++ b/test/integration/net/WebRTC/RTCPeerConnectionUnitTest.cs
@@ -89,125 +89,6 @@ namespace SIPSorcery.Net.IntegrationTests
         }
 
         /// <summary>
-        /// Tests that attempting to send an RTCP feedback report for an audio stream works correctly.
-        /// </summary>
-        [Fact]
-        public void SendVideoRtcpFeedbackReportUnitTest()
-        {
-            logger.LogDebug("--> " + System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
-
-            RTCConfiguration pcConfiguration = new RTCConfiguration
-            {
-                X_UseRtpFeedbackProfile = true
-            };
-
-            RTCPeerConnection pcSrc = new RTCPeerConnection(pcConfiguration);
-            var videoTrackSrc = new MediaStreamTrack(SDPMediaTypesEnum.video, false, new List<SDPAudioVideoMediaFormat> { new SDPAudioVideoMediaFormat(SDPMediaTypesEnum.video, 96, "VP8", 90000) });
-            pcSrc.addTrack(videoTrackSrc);
-            var offer = pcSrc.createOffer(new RTCOfferOptions());
-
-            logger.LogDebug($"offer: {offer.sdp}");
-
-            RTCPeerConnection pcDst = new RTCPeerConnection(pcConfiguration);
-            var videoTrackDst = new MediaStreamTrack(SDPMediaTypesEnum.video, false, new List<SDPAudioVideoMediaFormat> { new SDPAudioVideoMediaFormat(SDPMediaTypesEnum.video, 96, "VP8", 90000) });
-            pcDst.addTrack(videoTrackDst);
-
-            var setOfferResult = pcDst.setRemoteDescription(offer);
-            Assert.Equal(SetDescriptionResultEnum.OK, setOfferResult);
-
-            var answer = pcDst.createAnswer(null);
-            var setAnswerResult = pcSrc.setRemoteDescription(answer);
-            Assert.Equal(SetDescriptionResultEnum.OK, setAnswerResult);
-
-            logger.LogDebug($"answer: {answer.sdp}");
-
-            RTCPFeedback pliReport = new RTCPFeedback(pcDst.VideoLocalTrack.Ssrc, pcDst.VideoRemoteTrack.Ssrc, PSFBFeedbackTypesEnum.PLI);
-            pcDst.SendRtcpFeedback(SDPMediaTypesEnum.video, pliReport);
-        }
-
-        /// <summary>
-        /// Checks that the media formats are correctly negotiated when for a remote offer and the local
-        /// tracks.
-        /// </summary>
-        [Fact]
-        public void CheckMediaFormatNegotiationUnitTest()
-        {
-            logger.LogDebug("--> " + System.Reflection.MethodBase.GetCurrentMethod().Name);
-            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
-
-            // By default offers made by us always put audio first. Create a remote SDP offer 
-            // with the video first.
-            string remoteSdp =
-            @"v=0
-o=- 62533 0 IN IP4 127.0.0.1
-s=-
-t=0 0
-a=group:BUNDLE 0 1
-a=msid-semantic: WMS
-m=audio 57148 UDP/TLS/RTP/SAVP 0 101
-c=IN IP6 2a02:8084:6981:7880::76
-a=rtcp:9 IN IP4 0.0.0.0
-a=candidate:2944 1 udp 659136 192.168.11.50 57148 typ host generation 0
-a=candidate:2488 1 udp 659136 192.168.0.50 57148 typ host generation 0
-a=candidate:2507 1 udp 659136 fe80::54a9:d238:b2ee:ceb%24 57148 typ host generation 0
-a=candidate:3159 1 udp 659136 2a02:8084:6981:7880::76 57148 typ host generation 0
-a=ice-ufrag:CUTK
-a=ice-pwd:QTCZWDIEBCIBGOYAGSIXRFIL
-a=ice-options:ice2,trickle
-a=fingerprint:sha-256 06:2F:61:85:1F:83:64:88:1B:93:93:8C:E5:FF:1C:D9:82:EA:60:97:1E:0D:DA:FA:28:11:00:FA:74:69:23:DB
-a=setup:actpass
-a=mid:0
-a=sendrecv
-a=rtcp-mux
-a=rtpmap:0 PCMU/8000
-a=rtpmap:101 telephone-event/8000
-a=fmtp:101 0-16
-m=video 9 UDP/TLS/RTP/SAVP 100
-c=IN IP4 0.0.0.0
-a=rtcp:9 IN IP4 0.0.0.0
-a=ice-ufrag:CUTK
-a=ice-pwd:QTCZWDIEBCIBGOYAGSIXRFIL
-a=ice-options:ice2,trickle
-a=fingerprint:sha-256 06:2F:61:85:1F:83:64:88:1B:93:93:8C:E5:FF:1C:D9:82:EA:60:97:1E:0D:DA:FA:28:11:00:FA:74:69:23:DB
-a=setup:actpass
-a=mid:1
-a=sendrecv
-a=rtcp-mux
-a=rtpmap:100 VP8/90000";
-
-            // Create a local session and add the video track first.
-            RTCPeerConnection pc = new RTCPeerConnection(null);
-            MediaStreamTrack localAudioTrack = new MediaStreamTrack(SDPMediaTypesEnum.audio, false, new List<SDPAudioVideoMediaFormat> {
-                new SDPAudioVideoMediaFormat(SDPWellKnownMediaFormatsEnum.PCMU),
-                new SDPAudioVideoMediaFormat(SDPMediaTypesEnum.audio, 110, "OPUS/48000/2")
-            });
-            pc.addTrack(localAudioTrack);
-            MediaStreamTrack localVideoTrack = new MediaStreamTrack(SDPMediaTypesEnum.video, false, new List<SDPAudioVideoMediaFormat> { new SDPAudioVideoMediaFormat(SDPMediaTypesEnum.video, 96, "VP8", 90000) });
-            pc.addTrack(localVideoTrack);
-
-            var offer = SDP.ParseSDPDescription(remoteSdp);
-
-            logger.LogDebug($"Remote offer: {offer}");
-
-            var result = pc.SetRemoteDescription(SIP.App.SdpType.offer, offer);
-
-            logger.LogDebug($"Set remote description on local session result {result}.");
-
-            Assert.Equal(SetDescriptionResultEnum.OK, result);
-
-            var answer = pc.CreateAnswer(null);
-
-            logger.LogDebug($"Local answer: {answer}");
-
-            Assert.Equal(2, pc.AudioLocalTrack.Capabilities.Count());
-            Assert.Equal(0, pc.AudioLocalTrack.Capabilities.Single(x => x.Name() == "PCMU").ID);
-            Assert.Equal(100, pc.VideoLocalTrack.Capabilities.Single(x => x.Name() == "VP8").ID);
-
-            pc.Close("normal");
-        }
-
-        /// <summary>
         /// Checks that the media identifier tags are correctly reused in the generated answer
         /// tracks.
         /// </summary>
@@ -527,6 +408,125 @@ a=ssrc:4165955869 label:video0";
             Assert.Contains("a=group:BUNDLE zzz aaa", answerString);
             Assert.Contains("a=mid:zzz", answerString);
             Assert.Contains("a=mid:aaa", answerString);
+
+            pc.Close("normal");
+        }
+
+        /// <summary>
+        /// Tests that attempting to send an RTCP feedback report for an audio stream works correctly.
+        /// </summary>
+        [Fact]
+        public void SendVideoRtcpFeedbackReportUnitTest()
+        {
+            logger.LogDebug("--> " + System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+
+            RTCConfiguration pcConfiguration = new RTCConfiguration
+            {
+                X_UseRtpFeedbackProfile = true
+            };
+
+            RTCPeerConnection pcSrc = new RTCPeerConnection(pcConfiguration);
+            var videoTrackSrc = new MediaStreamTrack(SDPMediaTypesEnum.video, false, new List<SDPAudioVideoMediaFormat> { new SDPAudioVideoMediaFormat(SDPMediaTypesEnum.video, 96, "VP8", 90000) });
+            pcSrc.addTrack(videoTrackSrc);
+            var offer = pcSrc.createOffer(new RTCOfferOptions());
+
+            logger.LogDebug($"offer: {offer.sdp}");
+
+            RTCPeerConnection pcDst = new RTCPeerConnection(pcConfiguration);
+            var videoTrackDst = new MediaStreamTrack(SDPMediaTypesEnum.video, false, new List<SDPAudioVideoMediaFormat> { new SDPAudioVideoMediaFormat(SDPMediaTypesEnum.video, 96, "VP8", 90000) });
+            pcDst.addTrack(videoTrackDst);
+
+            var setOfferResult = pcDst.setRemoteDescription(offer);
+            Assert.Equal(SetDescriptionResultEnum.OK, setOfferResult);
+
+            var answer = pcDst.createAnswer(null);
+            var setAnswerResult = pcSrc.setRemoteDescription(answer);
+            Assert.Equal(SetDescriptionResultEnum.OK, setAnswerResult);
+
+            logger.LogDebug($"answer: {answer.sdp}");
+
+            RTCPFeedback pliReport = new RTCPFeedback(pcDst.VideoLocalTrack.Ssrc, pcDst.VideoRemoteTrack.Ssrc, PSFBFeedbackTypesEnum.PLI);
+            pcDst.SendRtcpFeedback(SDPMediaTypesEnum.video, pliReport);
+        }
+
+        /// <summary>
+        /// Checks that the media formats are correctly negotiated when for a remote offer and the local
+        /// tracks.
+        /// </summary>
+        [Fact]
+        public void CheckMediaFormatNegotiationUnitTest()
+        {
+            logger.LogDebug("--> " + System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+
+            // By default offers made by us always put audio first. Create a remote SDP offer 
+            // with the video first.
+            string remoteSdp =
+            @"v=0
+o=- 62533 0 IN IP4 127.0.0.1
+s=-
+t=0 0
+a=group:BUNDLE 0 1
+a=msid-semantic: WMS
+m=audio 57148 UDP/TLS/RTP/SAVP 0 101
+c=IN IP6 2a02:8084:6981:7880::76
+a=rtcp:9 IN IP4 0.0.0.0
+a=candidate:2944 1 udp 659136 192.168.11.50 57148 typ host generation 0
+a=candidate:2488 1 udp 659136 192.168.0.50 57148 typ host generation 0
+a=candidate:2507 1 udp 659136 fe80::54a9:d238:b2ee:ceb%24 57148 typ host generation 0
+a=candidate:3159 1 udp 659136 2a02:8084:6981:7880::76 57148 typ host generation 0
+a=ice-ufrag:CUTK
+a=ice-pwd:QTCZWDIEBCIBGOYAGSIXRFIL
+a=ice-options:ice2,trickle
+a=fingerprint:sha-256 06:2F:61:85:1F:83:64:88:1B:93:93:8C:E5:FF:1C:D9:82:EA:60:97:1E:0D:DA:FA:28:11:00:FA:74:69:23:DB
+a=setup:actpass
+a=mid:0
+a=sendrecv
+a=rtcp-mux
+a=rtpmap:0 PCMU/8000
+a=rtpmap:101 telephone-event/8000
+a=fmtp:101 0-16
+m=video 9 UDP/TLS/RTP/SAVP 100
+c=IN IP4 0.0.0.0
+a=rtcp:9 IN IP4 0.0.0.0
+a=ice-ufrag:CUTK
+a=ice-pwd:QTCZWDIEBCIBGOYAGSIXRFIL
+a=ice-options:ice2,trickle
+a=fingerprint:sha-256 06:2F:61:85:1F:83:64:88:1B:93:93:8C:E5:FF:1C:D9:82:EA:60:97:1E:0D:DA:FA:28:11:00:FA:74:69:23:DB
+a=setup:actpass
+a=mid:1
+a=sendrecv
+a=rtcp-mux
+a=rtpmap:100 VP8/90000";
+
+            // Create a local session and add the video track first.
+            RTCPeerConnection pc = new RTCPeerConnection(null);
+            MediaStreamTrack localAudioTrack = new MediaStreamTrack(SDPMediaTypesEnum.audio, false, new List<SDPAudioVideoMediaFormat> {
+                new SDPAudioVideoMediaFormat(SDPWellKnownMediaFormatsEnum.PCMU),
+                new SDPAudioVideoMediaFormat(SDPMediaTypesEnum.audio, 110, "OPUS/48000/2")
+            });
+            pc.addTrack(localAudioTrack);
+            MediaStreamTrack localVideoTrack = new MediaStreamTrack(SDPMediaTypesEnum.video, false, new List<SDPAudioVideoMediaFormat> { new SDPAudioVideoMediaFormat(SDPMediaTypesEnum.video, 96, "VP8", 90000) });
+            pc.addTrack(localVideoTrack);
+
+            var offer = SDP.ParseSDPDescription(remoteSdp);
+
+            logger.LogDebug($"Remote offer: {offer}");
+
+            var result = pc.SetRemoteDescription(SIP.App.SdpType.offer, offer);
+
+            logger.LogDebug($"Set remote description on local session result {result}.");
+
+            Assert.Equal(SetDescriptionResultEnum.OK, result);
+
+            var answer = pc.CreateAnswer(null);
+
+            logger.LogDebug($"Local answer: {answer}");
+
+            Assert.Equal(2, pc.AudioLocalTrack.Capabilities.Count());
+            Assert.Equal(0, pc.AudioLocalTrack.Capabilities.Single(x => x.Name() == "PCMU").ID);
+            Assert.Equal(100, pc.VideoLocalTrack.Capabilities.Single(x => x.Name() == "VP8").ID);
 
             pc.Close("normal");
         }

--- a/test/integration/net/WebRTC/RTCPeerConnectionUnitTest.cs
+++ b/test/integration/net/WebRTC/RTCPeerConnectionUnitTest.cs
@@ -223,7 +223,7 @@ a=rtpmap:100 VP8/90000";
 o=- 1064364449942365659 2 IN IP4 127.0.0.1
 s=-
 t=0 0
-a=group:BUNDLE foo bar
+a=group:BUNDLE bar foo
 a=msid-semantic: WMS stream0
 m=audio 9 UDP/TLS/RTP/SAVPF 111 103 104 9 102 0 8 106 105 13 110 112 113 126
 c=IN IP4 0.0.0.0
@@ -233,7 +233,7 @@ a=ice-pwd:FICf2eBzvl5r/O/uf1ktSyuc
 a=ice-options:trickle renomination
 a=fingerprint:sha-256 5D:03:7C:22:69:2E:E7:10:17:5F:31:86:E6:47:2F:6F:1D:4C:A6:BF:5B:DE:0C:FB:8A:17:15:AA:22:63:0C:FD
 a=setup:actpass
-a=mid:foo
+a=mid:bar
 a=extmap:1 urn:ietf:params:rtp-hdrext:ssrc-audio-level
 a=extmap:2 http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time
 a=extmap:3 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01
@@ -267,7 +267,7 @@ a=ice-pwd:FICf2eBzvl5r/O/uf1ktSyuc
 a=ice-options:trickle renomination
 a=fingerprint:sha-256 5D:03:7C:22:69:2E:E7:10:17:5F:31:86:E6:47:2F:6F:1D:4C:A6:BF:5B:DE:0C:FB:8A:17:15:AA:22:63:0C:FD
 a=setup:actpass
-a=mid:bar
+a=mid:foo
 a=extmap:14 urn:ietf:params:rtp-hdrext:toffset
 a=extmap:2 http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time
 a=extmap:13 urn:3gpp:video-orientation
@@ -330,13 +330,13 @@ a=ssrc:4165955869 label:video0";
 
             logger.LogDebug($"Local answer: {answer}");
 
-            Assert.Equal("foo", answer.Media[0].MediaID);
+            Assert.Equal("bar", answer.Media[0].MediaID);
             Assert.Equal(SDPMediaTypesEnum.audio, answer.Media[0].Media);
-            Assert.Equal("bar", answer.Media[1].MediaID);
+            Assert.Equal("foo", answer.Media[1].MediaID);
             Assert.Equal(SDPMediaTypesEnum.video, answer.Media[1].Media);
-            Assert.Contains("a=group:BUNDLE foo bar", answerString);
-            Assert.Contains("a=mid:foo", answerString);
+            Assert.Contains("a=group:BUNDLE bar foo", answerString);
             Assert.Contains("a=mid:bar", answerString);
+            Assert.Contains("a=mid:foo", answerString);
 
             pc.Close("normal");
         }


### PR DESCRIPTION
Related to issue #609 

This will keep the same media identifier tag specified from the offer into the generated answer.
Previous behavior implied an index based only identification. This caused issues when offer had none indexed tags such as "a=group:BUNDLE audioTag videoTag applicationTag0 applicationTag1" for which sipsorcery would show those tracks in a response similar to "a=group:BUNDLE 0 1 2 3".

