### PR TITLE
added ability to specify the value for the UserAgent and Server SIP Header

### DIFF
--- a/src/app/SIPUserAgents/SIPClientUserAgent.cs
+++ b/src/app/SIPUserAgents/SIPClientUserAgent.cs
@@ -33,8 +33,6 @@ namespace SIPSorcery.SIP.App
 
         private static ILogger logger = Log.Logger;
 
-        private static string m_userAgent = SIPConstants.SIP_USERAGENT_STRING;
-
         private SIPTransport m_sipTransport;
 
         private SIPCallDescriptor m_sipCallDescriptor;              // Describes the server leg of the call from the sipswitch.
@@ -508,7 +506,7 @@ namespace SIPSorcery.SIP.App
             inviteHeader.Contact = new List<SIPContactHeader>() { SIPContactHeader.GetDefaultSIPContactHeader(inviteRequest.URI.Scheme) };
             inviteHeader.Contact[0].ContactURI.User = sipCallDescriptor.Username;
             inviteHeader.CSeqMethod = SIPMethodsEnum.INVITE;
-            inviteHeader.UserAgent = m_userAgent;
+            inviteHeader.UserAgent = SIPConstants.SipUserAgentVersionString;
             inviteHeader.Routes = routeSet;
             inviteHeader.Supported = SIPExtensionHeaders.REPLACES + ", " + SIPExtensionHeaders.NO_REFER_SUB
                 + ((PrackSupported == true) ? ", " + SIPExtensionHeaders.PRACK : "");

--- a/src/app/SIPUserAgents/SIPNonInviteClientUserAgent.cs
+++ b/src/app/SIPUserAgents/SIPNonInviteClientUserAgent.cs
@@ -28,8 +28,6 @@ namespace SIPSorcery.SIP.App
     {
         private static ILogger logger = Log.Logger;
 
-        private static readonly string m_userAgent = SIPConstants.SIP_USERAGENT_STRING;
-
         private SIPTransport m_sipTransport;
         private SIPEndPoint m_outboundProxy;
         private SIPCallDescriptor m_callDescriptor;
@@ -147,7 +145,7 @@ namespace SIPSorcery.SIP.App
 
                 SIPHeader header = new SIPHeader(fromHeader, toHeader, cseq, CallProperties.CreateNewCallId());
                 header.CSeqMethod = method;
-                header.UserAgent = m_userAgent;
+                header.UserAgent = SIPConstants.SipUserAgentVersionString;
                 request.Header = header;
 
                 header.Vias.PushViaHeader(SIPViaHeader.GetDefaultSIPViaHeader());

--- a/src/app/SIPUserAgents/SIPRegistrationUserAgent.cs
+++ b/src/app/SIPUserAgents/SIPRegistrationUserAgent.cs
@@ -39,8 +39,6 @@ namespace SIPSorcery.SIP.App
 
         private static ILogger logger = Log.Logger;
 
-        private static readonly string m_userAgent = SIPConstants.SIP_USERAGENT_STRING;
-
         private SIPTransport m_sipTransport;
         private SIPEndPoint m_outboundProxy;
         private SIPURI m_sipAccountAOR;
@@ -653,7 +651,7 @@ namespace SIPSorcery.SIP.App
             registerRequest.Header.Contact = new List<SIPContactHeader> { new SIPContactHeader(this.UserDisplayName, m_contactURI) };
             registerRequest.Header.CSeq = ++m_cseq;
             registerRequest.Header.CallId = m_callID;
-            registerRequest.Header.UserAgent = (!UserAgent.IsNullOrBlank()) ? UserAgent : m_userAgent;
+            registerRequest.Header.UserAgent = (!UserAgent.IsNullOrBlank()) ? UserAgent : SIPConstants.SipUserAgentVersionString;
             registerRequest.Header.Expires = m_expiry;
 
             if (m_customHeaders != null && m_customHeaders.Length > 0)

--- a/src/app/SIPUserAgents/SIPUserAgent.cs
+++ b/src/app/SIPUserAgents/SIPUserAgent.cs
@@ -48,7 +48,6 @@ namespace SIPSorcery.SIP.App
     {
         private static readonly string m_sdpContentType = SDP.SDP_MIME_CONTENTTYPE;
         private static readonly string m_sipReferContentType = SIPMIMETypes.REFER_CONTENT_TYPE;
-        private static string m_userAgent = SIPConstants.SIP_USERAGENT_STRING;
         private static int WAIT_ONHOLD_TIMEOUT = SIPTimings.T1;
         private static int WAIT_DIALOG_TIMEOUT = SIPTimings.T2;
 
@@ -1210,7 +1209,7 @@ namespace SIPSorcery.SIP.App
                 m_sipDialogue.SDP = sdp.ToString();
 
                 var reinviteRequest = m_sipDialogue.GetInDialogRequest(SIPMethodsEnum.INVITE);
-                reinviteRequest.Header.UserAgent = m_userAgent;
+                reinviteRequest.Header.UserAgent = SIPConstants.SipUserAgentVersionString;
                 reinviteRequest.Header.ContentType = m_sdpContentType;
                 reinviteRequest.Body = sdp.ToString();
                 reinviteRequest.Header.Supported = SIPExtensionHeaders.REPLACES + ", " + SIPExtensionHeaders.NO_REFER_SUB + ", " + SIPExtensionHeaders.PRACK;

--- a/src/core/SIP/SIPConstants.cs
+++ b/src/core/SIP/SIPConstants.cs
@@ -64,7 +64,7 @@ namespace SIPSorcery.SIP
         public const string ALLOWED_SIP_METHODS = "ACK, BYE, CANCEL, INFO, INVITE, NOTIFY, OPTIONS, PRACK, REFER, REGISTER, SUBSCRIBE";
 
         private static string _userAgentVersion;
-        public static string SIP_USERAGENT_STRING
+        public static string SipUserAgentVersionString
         {
             get
             {
@@ -74,6 +74,10 @@ namespace SIPSorcery.SIP
                 }
 
                 return _userAgentVersion;
+            }
+            set
+            {
+                _userAgentVersion = value;
             }
         }
 

--- a/src/core/SIPTransactions/UASInviteTransaction.cs
+++ b/src/core/SIPTransactions/UASInviteTransaction.cs
@@ -27,8 +27,6 @@ namespace SIPSorcery.SIP
     /// </summary>
     public class UASInviteTransaction : SIPTransaction
     {
-        private static string m_sipServerAgent = SIPConstants.SIP_USERAGENT_STRING;
-
         /// <summary>
         /// The local tag is set on the To SIP header and forms part of the information used to identify a SIP dialog.
         /// </summary>
@@ -154,7 +152,7 @@ namespace SIPSorcery.SIP
             okResponse.Header.To.ToTag = m_localTag;
             okResponse.Header.CSeqMethod = requestHeader.CSeqMethod;
             okResponse.Header.Vias = requestHeader.Vias;
-            okResponse.Header.Server = m_sipServerAgent;
+            okResponse.Header.Server = SIPConstants.SipUserAgentVersionString;
             okResponse.Header.MaxForwards = Int32.MinValue;
             okResponse.Header.RecordRoutes = requestHeader.RecordRoutes;
             okResponse.Header.Supported = SIPExtensionHeaders.REPLACES + ", " + SIPExtensionHeaders.NO_REFER_SUB


### PR DESCRIPTION
I want to be able to see in network traces the version of the application that is using sipsorcery. This is important because there might be a new version of the application using sipsorcery which changes some behavior but the underlying sipsorcery version stays the same.

I added a setter to SIPConstants.SIP_USERAGENT_STRING and replaced all static readonly field usages with direct references to SIPConstants.SIP_USERAGENT_STRING.

Beacause this is now not really a constant, I renamed the property to SIPConstants.SipUserAgentVersionString.