### PR TITLE
ClientCertificates: X509Certificate2Collection for TLS connections

### DIFF
--- a/src/core/SIP/Channels/SIPTLSChannel.cs
+++ b/src/core/SIP/Channels/SIPTLSChannel.cs
@@ -31,6 +31,7 @@ namespace SIPSorcery.SIP
         private const int TLS_ATTEMPT_CONNECT_TIMEOUT = 5000;
 
         private X509Certificate2 m_serverCertificate;
+        private X509Certificate2Collection m_clientCertificates;
 
         override protected string ProtDescr { get; } = "TLS";
 
@@ -47,7 +48,7 @@ namespace SIPSorcery.SIP
             IsSecure = true;
         }
 
-        public SIPTLSChannel(X509Certificate2 serverCertificate, IPEndPoint endPoint, bool useDualMode = false)
+        public SIPTLSChannel(X509Certificate2 serverCertificate, IPEndPoint endPoint, bool useDualMode = false, X509Certificate2Collection clientCertificates = null)
             : base(endPoint, SIPProtocolsEnum.tls, serverCertificate != null, useDualMode)
         {
             if (endPoint == null)
@@ -57,6 +58,7 @@ namespace SIPSorcery.SIP
 
             IsSecure = true;
             m_serverCertificate = serverCertificate;
+            m_clientCertificates = clientCertificates;
 
             if (m_serverCertificate != null)
             {
@@ -114,7 +116,7 @@ namespace SIPSorcery.SIP
             //DisplayCertificateInformation(sslStream);
 
             var timeoutTask = Task.Delay(TLS_ATTEMPT_CONNECT_TIMEOUT);
-            var sslStreamTask = sslStream.AuthenticateAsClientAsync(serverCertificateName);
+            var sslStreamTask = m_clientCertificates != null ? sslStream.AuthenticateAsClientAsync(serverCertificateName, m_clientCertificates, System.Security.Authentication.SslProtocols.None, false) : sslStream.AuthenticateAsClientAsync(serverCertificateName);
             await Task.WhenAny(sslStreamTask, timeoutTask).ConfigureAwait(false);
 
             if(sslStreamTask.IsCompleted)


### PR DESCRIPTION
While testing with TLS and SRTP against a innovaphone PBX, I found the need to be able to provide a client certificate.
otherwise the PBX will not continue with the TLS connection.

Even though in most scenarios, the server and client certificate in use will probably be the same, I left that to the caller of the SIPTLSChannel. There might be some corner cases, where different and/or multiple client certificates are preferrable.