### PR TITLE
Allow RTP port range to be specified when creating an RTPSession

### DIFF
--- a/src/net/RTP/RTPChannel.cs
+++ b/src/net/RTP/RTPChannel.cs
@@ -300,9 +300,9 @@ namespace SIPSorcery.Net
         /// the RTP and control sockets to. If left empty then the IPv6 any address will be used if IPv6 is supported
         /// and fallback to the IPv4 any address.</param>
         /// <param name="bindPort">Optional. The specific port to attempt to bind the RTP port on.</param>
-        public RTPChannel(bool createControlSocket, IPAddress bindAddress, int bindPort = 0)
+        public RTPChannel(bool createControlSocket, IPAddress bindAddress, int bindPort = 0, PortRange rtpPortRange = null)
         {
-            NetServices.CreateRtpSocket(createControlSocket, bindAddress, bindPort, out var rtpSocket, out m_controlSocket);
+            NetServices.CreateRtpSocket(createControlSocket, bindAddress, bindPort, rtpPortRange, out var rtpSocket, out m_controlSocket);
 
             if (rtpSocket == null)
             {

--- a/src/net/RTP/RTPSession.cs
+++ b/src/net/RTP/RTPSession.cs
@@ -177,6 +177,7 @@ namespace SIPSorcery.Net
         private bool m_isRtcpMultiplexed = false;       // Indicates whether the RTP channel is multiplexing RTP and RTCP packets on the same port.
         private IPAddress m_bindAddress = null;       // If set the address to use for binding the RTP and control sockets.
         protected int m_bindPort = 0;                     // If non-zero specifies the port number to attempt to bind the first RTP socket on.
+        protected PortRange m_rtpPortRange = null;        // If non-null, overwritws m_bindPort and calls to PortRange.GetNextPort() when trying to bind an RTP socket
         private bool m_rtpEventInProgress;              // Gets set to true when an RTP event is being sent and the normal stream is interrupted.
         private uint m_lastRtpTimestamp;                // The last timestamp used in an RTP packet.    
         private RtpVideoFramer _rtpVideoFramer;
@@ -478,6 +479,7 @@ namespace SIPSorcery.Net
             UseSdpCryptoNegotiation = config.RtpSecureMediaOption == RtpSecureMediaOptionEnum.SdpCryptoNegotiation;
             m_bindAddress = config.BindAddress;
             m_bindPort = config.BindPort;
+            m_rtpPortRange = config.RtpPortRange;
 
             m_sdpSessionID = Crypto.GetRandomInt(SDP_SESSIONID_LENGTH).ToString();
 
@@ -1370,7 +1372,7 @@ namespace SIPSorcery.Net
         {
             // If RTCP is multiplexed we don't need a control socket.
             int bindPort = (m_bindPort == 0) ? 0 : m_bindPort + m_rtpChannels.Count() * 2;
-            var rtpChannel = new RTPChannel(!m_isRtcpMultiplexed, m_bindAddress, bindPort);
+            var rtpChannel = new RTPChannel(!m_isRtcpMultiplexed, m_bindAddress, bindPort, m_rtpPortRange);
             m_rtpChannels.Add(mediaType, rtpChannel);
 
             rtpChannel.OnRTPDataReceived += OnReceive;

--- a/src/net/RTP/RTPSessionConfig.cs
+++ b/src/net/RTP/RTPSessionConfig.cs
@@ -15,6 +15,7 @@
 //-----------------------------------------------------------------------------
 
 using System.Net;
+using SIPSorcery.Sys;
 
 namespace SIPSorcery.Net
 {
@@ -70,5 +71,11 @@ namespace SIPSorcery.Net
         /// System select the port number.
         /// </summary>
         public int BindPort { get; set; }
+
+        /// <summary>
+        /// Optional. If specified, overwrites BindPort and calls the PortRange whenever an RTP-Port
+        /// should be created.
+        /// </summary>
+        public PortRange RtpPortRange { get; set; }
     }
 }

--- a/src/net/SCTP/SctpUdpTransport.cs
+++ b/src/net/SCTP/SctpUdpTransport.cs
@@ -48,9 +48,10 @@ namespace SIPSorcery.Net
         /// Creates a new UDP transport capable of encapsulating SCTP packets.
         /// </summary>
         /// <param name="udpEncapPort">The port to bind to for the UDP encapsulation socket.</param>
-        public SctpUdpTransport(int udpEncapPort = 0)
+        /// <param name="portRange">Optional. The portRange which should be used to get a listening port.</param>
+        public SctpUdpTransport(int udpEncapPort = 0, PortRange portRange = null)
         {
-            NetServices.CreateRtpSocket(false, IPAddress.IPv6Any, udpEncapPort, out _udpEncapSocket, out _);
+            NetServices.CreateRtpSocket(false, IPAddress.IPv6Any, udpEncapPort, portRange, out _udpEncapSocket, out _);
             UdpReceiver udpReceiver = new UdpReceiver(_udpEncapSocket);
             udpReceiver.OnPacketReceived += OnEncapsulationSocketPacketReceived;
             udpReceiver.OnClosed += OnEncapsulationSocketClosed;

--- a/src/sys/Net/NetServices.cs
+++ b/src/sys/Net/NetServices.cs
@@ -374,9 +374,11 @@ namespace SIPSorcery.Sys
         /// will be made to bind the RTP and optionally control listeners on it.</param>
         /// <param name="bindPort">Optional. If 0 the choice of port will be left up to the Operating System. If specified
         /// a single attempt will be made to bind on the port.</param>
+        /// <param name="portRange">Optional. If non-null the choice of port will be left up to the PortRange. Multiple ports will be
+        /// tried before giving up. The parameter bindPort is ignored.</param>
         /// <param name="rtpSocket">An output parameter that will contain the allocated RTP socket.</param>
         /// <param name="controlSocket">An output parameter that will contain the allocated control (RTCP) socket.</param>
-        public static void CreateRtpSocket(bool createControlSocket, IPAddress bindAddress, int bindPort, out Socket rtpSocket, out Socket controlSocket)
+        public static void CreateRtpSocket(bool createControlSocket, IPAddress bindAddress, int bindPort, PortRange portRange, out Socket rtpSocket, out Socket controlSocket)
         {
             if (bindAddress == null)
             {
@@ -396,6 +398,10 @@ namespace SIPSorcery.Sys
             {
                 try
                 {
+                    if(portRange != null)
+                    {
+                        bindPort = portRange.GetNextPort();
+                    }
                     rtpSocket = CreateBoundUdpSocket(bindPort, bindAddress, createControlSocket);
                     rtpSocket.ReceiveBufferSize = RTP_RECEIVE_BUFFER_SIZE;
                     rtpSocket.SendBufferSize = RTP_SEND_BUFFER_SIZE;
@@ -420,7 +426,7 @@ namespace SIPSorcery.Sys
                 }
                 catch (ApplicationException) { }
 
-                if ((rtpSocket != null && (!createControlSocket || controlSocket != null)) || bindPort != 0)
+                if ((rtpSocket != null && (!createControlSocket || controlSocket != null)) || (bindPort != 0 && portRange == null))
                 {
                     // If a specific bind port was specified only a single attempt to create the socket is made.
                     break;

--- a/src/sys/Net/PortRange.cs
+++ b/src/sys/Net/PortRange.cs
@@ -1,0 +1,118 @@
+﻿// ============================================================================
+// FileName: PortRange.cs
+//
+// Description:
+// Contains a helper class to manage sequential or random allocation of
+// UDP-Port pairs for RTP-Streams.
+//
+// Author(s):
+// Tobias Stähli
+//
+// History:
+// 6 Dec 2021	Tobias Stähli	Created, Frauenfeld, Switzerland.
+//
+// License: 
+// BSD 3-Clause "New" or "Revised" License, see included LICENSE.md file.
+// ============================================================================
+
+using System;
+using System.Net;
+
+namespace SIPSorcery.Sys
+{
+    /// <summary>
+    /// Class to manage port allocation for Rtp Ports. Ports are always even, because
+    /// due Rtp data and control ports are always with data on even port and 
+    /// control (if any) on data_port + 1
+    /// 
+    /// There are two operation modes:
+    ///  - The sequential mode which hands out all ports within the assigned range and 
+    /// wraps around if the last port was assigned
+    ///  - The shuffled mode: Ports are handed out evenly distributed within the assigned
+    ///  port range.
+    /// </summary>
+    public class PortRange
+    {
+        private readonly Random m_random;
+        private readonly bool m_shuffle;
+        private readonly int m_startPort;
+        private readonly int m_endPort;
+        private int m_nextPort;
+
+        /// <summary>
+        /// Initializes a new PortRange.
+        /// </summary>
+        /// <param name="startPort">Inclusive, lowest port within this portrange. must be an even number</param>
+        /// <param name="endPort">Inclusive, highest port within this portrange.</param>
+        /// <param name="shuffle">optional, if set, the ports are assigned in a pseudorandom order.</param>
+        /// <param name="randomSeed">optional, the seed for the pseudorandom order.</param>
+        /// <exception cref="ArgumentException"></exception>
+        public PortRange(int startPort, int endPort, bool shuffle = false, int? randomSeed = null)
+        {
+            if (startPort <= 0 || startPort > IPEndPoint.MaxPort)
+            {
+                throw new ArgumentException($"startPort must be greater than 0 and less than or euqal {IPEndPoint.MaxPort}");
+            }
+            if (endPort <= 0 || endPort > IPEndPoint.MaxPort)
+            {
+                throw new ArgumentException($"endPort must be greater than 0 and less than or euqal {IPEndPoint.MaxPort}");
+            }
+            if (endPort - startPort < 2)
+            {
+                throw new ArgumentException($"endPort({endPort}) - startPort({startPort}) must be at least 2, but is {endPort - startPort}");
+            }
+            if (startPort % 2 == 1)
+            {
+                throw new ArgumentException("startPort must be even");
+            }
+            if (endPort % 2 == 0)
+            {
+                endPort -= 1;// correct end-port to odd if even -> RtpPort are always handed out in pairs
+            }
+            m_startPort = startPort;
+            m_endPort = endPort;
+            m_shuffle = shuffle;
+            if (shuffle)
+            {
+                m_random = randomSeed.HasValue ? new Random(randomSeed.Value) : new Random();
+                m_nextPort = m_random.Next(m_startPort, m_endPort + 1) // The + 1 is needed to get an even distribution because Random.Next(start, end) is inclusive start but exclusive the end
+                    & 0x0000_FFFE; // AND with IPEndPoint.MaxPort but last bit is set to zero to always have an even port
+            }
+            else
+            {
+                m_nextPort = startPort;
+            }
+        }
+
+        /// <summary>
+        /// Calculates the next port which should be tried.
+        /// No guarantee is made, that the returned port can also be bound to; actual check is still needed.
+        /// Caller of this method should try to bind to the socket and if not successful, try again for x times
+        /// before giving up.
+        /// 
+        /// This method is thread-safe
+        /// </summary>
+        /// <returns>port from the portrange</returns>
+        public virtual int GetNextPort()
+        {
+            lock (this)
+            {
+                var res = m_nextPort;
+                if (m_shuffle)
+                {
+                    m_nextPort = m_random.Next(m_startPort, m_endPort + 1) // The + 1 is needed to get an even distribution because Random.Next(start, end) is inclusive start but exclusive the end
+                        & 0x0000_FFFE; // AND with IPEndPoint.MaxPort but last bit is set to zero to always have an even port
+                }
+                else
+                {
+                    m_nextPort = m_nextPort + 2;
+                    if (m_nextPort > m_endPort)
+                    {
+                        m_nextPort = m_startPort;
+                    }
+                }
+                return res;
+            }
+        }
+    }
+}

--- a/test/integration/net/ICE/MockTurnServer.cs
+++ b/test/integration/net/ICE/MockTurnServer.cs
@@ -48,7 +48,7 @@ namespace SIPSorcery.Net.IntegrationTests
             _listenAddress = listenAddress;
             _listenPort = port;
 
-            NetServices.CreateRtpSocket(false, _listenAddress, 0, out _clientSocket, out _);
+            NetServices.CreateRtpSocket(false, _listenAddress, 0, null, out _clientSocket, out _);
 
             ListeningEndPoint = _clientSocket.LocalEndPoint as IPEndPoint;
 
@@ -75,7 +75,7 @@ namespace SIPSorcery.Net.IntegrationTests
                         _clientEndPoint = remoteEndPoint;
 
                         // Create a new relay socket.
-                        NetServices.CreateRtpSocket(false, _listenAddress, 0, out _relaySocket, out _);
+                        NetServices.CreateRtpSocket(false, _listenAddress, 0, null, out _relaySocket, out _);
 
                         _relayEndPoint = _relaySocket.LocalEndPoint as IPEndPoint;
 

--- a/test/unit/sys/net/NetServicesUnitTest.cs
+++ b/test/unit/sys/net/NetServicesUnitTest.cs
@@ -212,7 +212,7 @@ namespace SIPSorcery.Sys.UnitTests
             Socket rtpSocket = null;
             Socket controlSocket = null;
 
-            NetServices.CreateRtpSocket(true, null, 0, out rtpSocket, out controlSocket);
+            NetServices.CreateRtpSocket(true, null, 0, null, out rtpSocket, out controlSocket);
 
             Assert.NotNull(rtpSocket);
             Assert.NotNull(controlSocket);
@@ -234,7 +234,7 @@ namespace SIPSorcery.Sys.UnitTests
             Socket rtpSocket = null;
             Socket controlSocket = null;
 
-            NetServices.CreateRtpSocket(true, IPAddress.Any, 0, out rtpSocket, out controlSocket);
+            NetServices.CreateRtpSocket(true, IPAddress.Any, 0, null, out rtpSocket, out controlSocket);
 
             Assert.NotNull(rtpSocket);
             Assert.NotNull(controlSocket);
@@ -258,7 +258,7 @@ namespace SIPSorcery.Sys.UnitTests
                 Socket rtpSocket = null;
                 Socket controlSocket = null;
 
-                NetServices.CreateRtpSocket(true, IPAddress.IPv6Any, 0, out rtpSocket, out controlSocket);
+                NetServices.CreateRtpSocket(true, IPAddress.IPv6Any, 0, null, out rtpSocket, out controlSocket);
 
                 Assert.NotNull(rtpSocket);
                 Assert.NotNull(controlSocket);
@@ -285,7 +285,7 @@ namespace SIPSorcery.Sys.UnitTests
                 Socket rtpSocket = null;
                 Socket controlSocket = null;
 
-                NetServices.CreateRtpSocket(true, null, 0, out rtpSocket, out controlSocket);
+                NetServices.CreateRtpSocket(true, null, 0, null, out rtpSocket, out controlSocket);
 
                 Assert.NotNull(rtpSocket);
                 Assert.NotNull(controlSocket);
@@ -402,7 +402,7 @@ namespace SIPSorcery.Sys.UnitTests
                 Socket rtpSocket = null;
                 Socket controlSocket = null;
 
-                NetServices.CreateRtpSocket(true, IPAddress.Any, 0, out rtpSocket, out controlSocket);
+                NetServices.CreateRtpSocket(true, IPAddress.Any, 0, null, out rtpSocket, out controlSocket);
 
                 Assert.NotNull(rtpSocket);
                 Assert.NotNull(controlSocket);
@@ -437,7 +437,7 @@ namespace SIPSorcery.Sys.UnitTests
                 Socket rtpSocket = null;
                 Socket controlSocket = null;
 
-                NetServices.CreateRtpSocket(true, IPAddress.IPv6Any, 0, out rtpSocket, out controlSocket);
+                NetServices.CreateRtpSocket(true, IPAddress.IPv6Any, 0, null, out rtpSocket, out controlSocket);
 
                 Assert.NotNull(rtpSocket);
                 Assert.NotNull(controlSocket);

--- a/test/unit/sys/net/PortRangeUnitTest.cs
+++ b/test/unit/sys/net/PortRangeUnitTest.cs
@@ -1,0 +1,94 @@
+﻿//-----------------------------------------------------------------------------
+// Filename: PortRangeUnitTest.cs
+//
+// Description: Unit tests for the PortRange class.
+//
+// Author(s):
+// Tobias Stähli
+// 
+// History:
+// 6 Dec 2021  Tobias Stähli   Created.
+//
+// License: 
+// BSD 3-Clause "New" or "Revised" License, see included LICENSE.md file.
+//-----------------------------------------------------------------------------
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.NetworkInformation;
+using System.Net.Sockets;
+using System.Runtime.InteropServices;
+using Microsoft.Extensions.Logging;
+using SIPSorcery.Sys;
+using Xunit;
+
+namespace SIPSorcery.UnitTests.sys.net
+{
+    [Trait("Category", "unit")]
+    public class PortRangeUnitTest
+    {
+        private Microsoft.Extensions.Logging.ILogger logger = null;
+
+        public PortRangeUnitTest(Xunit.Abstractions.ITestOutputHelper output)
+        {
+            logger = SIPSorcery.UnitTests.TestLogHelper.InitTestLogger(output);
+        }
+
+        /// <summary>
+        /// Tests simple sequential port allocation
+        /// </summary>
+        [Fact]
+        public void GetSequentialPortUnitTest()
+        {
+            logger.LogDebug("--> " + System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+
+            var portRange = new PortRange(6000, 6005);
+            Assert.Equal(6000, portRange.GetNextPort());
+            Assert.Equal(6002, portRange.GetNextPort());
+            Assert.Equal(6004, portRange.GetNextPort());
+            Assert.Equal(6000, portRange.GetNextPort());
+            Assert.Equal(6002, portRange.GetNextPort());
+        }
+
+        /// <summary>
+        /// Tests statistical distribution of shuffled port allocation
+        /// </summary>
+        [Fact]
+        public void GetShuffledPortsEvenlyDistributedUnitTest()
+        {
+            logger.LogDebug("--> " + System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+
+            var portRange = new PortRange(6000, 6011, shuffle: true);
+            var portCount = new Dictionary<int, int>();
+            const int N = 50_000;
+            const int startPort = 6000;
+            const int endPort = 6011;
+            const float atLeastXPercentPerPort = 0.9f;
+            for (int i = 0; i < N; i++) { 
+                var p = portRange.GetNextPort();
+                if (!portCount.ContainsKey(p))
+                {
+                    portCount[p] = 1;
+                }
+                else
+                {
+                    portCount[p]++;
+                }
+            }
+            var portAssignedCount = ((endPort + 1) - startPort) / 2;
+            Assert.Equal(portCount.Count, portAssignedCount);
+            for(int i = startPort; i<endPort; i += 2)
+            {
+                logger.LogTrace($"shuffled PortRange Port {i}: Actual Count:{portCount[i]} Expected Count: {(N / portAssignedCount)} Acceptable Range: [{(N / portAssignedCount) * atLeastXPercentPerPort}, {(N / portAssignedCount) * ((1.0 - atLeastXPercentPerPort) + 1)}])");
+                Assert.True(portCount.ContainsKey(i), $"Expected port {i} to be allocated at least once");
+                Assert.True(portCount[i] > (N / portAssignedCount) * atLeastXPercentPerPort);
+                Assert.True(portCount[i] < (N / portAssignedCount) * ((1.0 - atLeastXPercentPerPort) + 1));
+            }            
+        }
+    }
+}


### PR DESCRIPTION
implements #461 

I was not sure, where the state of the already allocated ports/the next port should live. I chose RTPSession, because my usecase has different connected SIP-Enpoints each with their own RTP-Port range. 
For example ports 6000-7999 should be used with PBX 1 and Ports 8000-10000 should be used with a different PBX. RTPSession seemd to be a good place.
I can move it, if there is a better suited place.

I could not test SctpUdpTransport.cs, because I do not have the infrastructure for that. Should Icreate a second CreateRtpSocket overload instead of reusing the existing methods to avoid having to change SctpUdpTransport?

Regards,
Tobias