### PR TITLE
Change for #639: Changing SIPHeader fields Expire and Min-Expire

### DIFF
--- a/src/app/SIPUserAgents/SIPNotifierClient.cs
+++ b/src/app/SIPUserAgents/SIPNotifierClient.cs
@@ -196,9 +196,18 @@ namespace SIPSorcery.SIP.App
                         if (m_subscribed)
                         {
                             // Schedule the subscription based on its expiry.
-                            logger.LogDebug($"Rescheduling next attempt for a successful subscription to {m_resourceURI} in {m_expiry - RESCHEDULE_SUBSCRIBE_MARGIN}s.");
-                            int expiry = (m_expiry > UInt32.MaxValue) ? Int32.MaxValue : (int)m_expiry;
-                            m_waitForNextSubscribe.WaitOne((expiry - RESCHEDULE_SUBSCRIBE_MARGIN) * 1000);
+                            logger.LogDebug(
+                                $"Rescheduling next attempt for a successful subscription to {m_resourceURI} in {m_expiry - RESCHEDULE_SUBSCRIBE_MARGIN}s.");
+                            int expiry = (m_expiry >= UInt32.MaxValue) ? -1 : (int)m_expiry; // In case m_expiry is set to
+
+                            if (expiry == Int32.MaxValue)
+                            {
+                                m_waitForNextSubscribe.WaitOne(Int32.MaxValue);
+                            }
+                            else
+                            {
+                                m_waitForNextSubscribe.WaitOne((expiry - RESCHEDULE_SUBSCRIBE_MARGIN) * 1000);
+                            }
                         }
                         else
                         {

--- a/src/app/SIPUserAgents/SIPNotifierClient.cs
+++ b/src/app/SIPUserAgents/SIPNotifierClient.cs
@@ -51,7 +51,7 @@ namespace SIPSorcery.SIP.App
         private string m_authDomain;
         private string m_authPassword;
         private string m_filter;
-        private int m_expiry;
+        private long m_expiry;
         private int m_localCSeq;
         private int m_remoteCSeq;
         private string m_subscribeCallID;
@@ -197,7 +197,8 @@ namespace SIPSorcery.SIP.App
                         {
                             // Schedule the subscription based on its expiry.
                             logger.LogDebug($"Rescheduling next attempt for a successful subscription to {m_resourceURI} in {m_expiry - RESCHEDULE_SUBSCRIBE_MARGIN}s.");
-                            m_waitForNextSubscribe.WaitOne((m_expiry - RESCHEDULE_SUBSCRIBE_MARGIN) * 1000);
+                            int expiry = (m_expiry > UInt32.MaxValue) ? Int32.MaxValue : (int)m_expiry;
+                            m_waitForNextSubscribe.WaitOne((expiry - RESCHEDULE_SUBSCRIBE_MARGIN) * 1000);
                         }
                         else
                         {
@@ -220,7 +221,7 @@ namespace SIPSorcery.SIP.App
         /// Initiates a SUBSCRIBE request to a notification server.
         /// </summary>
         /// <param name="subscribeURI">The SIP user that dialog notifications are being subscribed to.</param>
-        public void Subscribe(SIPURI subscribeURI, int expiry, SIPEventPackagesEnum sipEventPackage, string subscribeCallID, SIPURI contactURI)
+        public void Subscribe(SIPURI subscribeURI, long expiry, SIPEventPackagesEnum sipEventPackage, string subscribeCallID, SIPURI contactURI)
         {
             try
             {

--- a/src/app/SIPUserAgents/SIPNotifierClient.cs
+++ b/src/app/SIPUserAgents/SIPNotifierClient.cs
@@ -200,7 +200,7 @@ namespace SIPSorcery.SIP.App
                                 $"Rescheduling next attempt for a successful subscription to {m_resourceURI} in {m_expiry - RESCHEDULE_SUBSCRIBE_MARGIN}s.");
                             int expiry = (m_expiry >= UInt32.MaxValue) ? -1 : (int)m_expiry; // In case m_expiry is set to
 
-                            if (expiry == Int32.MaxValue)
+                            if (expiry == -1)
                             {
                                 m_waitForNextSubscribe.WaitOne(Int32.MaxValue);
                             }

--- a/src/core/SIP/SIPHeader.cs
+++ b/src/core/SIP/SIPHeader.cs
@@ -634,16 +634,20 @@ namespace SIPSorcery.SIP
         }
 
         // A value of -1 indicates the header did not contain an expires parameter setting.
-        public int Expires
+        public long Expires
         {
             get
             {
-                int expires = -1;
+                long expires = -1;
 
                 if (ContactParameters.Has(EXPIRES_PARAMETER_KEY))
                 {
                     string expiresStr = ContactParameters.Get(EXPIRES_PARAMETER_KEY);
-                    Int32.TryParse(expiresStr, out expires);
+                    Int64.TryParse(expiresStr, out expires);
+                    if (expires > UInt32.MaxValue)
+                    {
+                        expires = UInt32.MaxValue;
+                    }
                 }
 
                 return expires;
@@ -1321,10 +1325,10 @@ namespace SIPSorcery.SIP
         public string ErrorInfo;
         public string ETag;                                 // added by Tilmann: look RFC3903
         public string Event;                                // RFC3265 SIP Events.
-        public int Expires = -1;
+        public long Expires = -1;
         public SIPFromHeader From;
         public string InReplyTo;
-        public int MinExpires = -1;
+        public long MinExpires = -1;
         public int MaxForwards = SIPConstants.DEFAULT_MAX_FORWARDS;
         public string MIMEVersion;
         public string Organization;
@@ -1553,7 +1557,7 @@ namespace SIPSorcery.SIP
                         {
                             //sipHeader.RawExpires += headerValue;
 
-                            if (!Int32.TryParse(headerValue, out sipHeader.Expires))
+                            if (!Int64.TryParse(headerValue, out sipHeader.Expires))
                             {
                                 logger.LogWarning("The Expires value was not a valid integer, " + headerLine + ".");
                             }
@@ -1562,7 +1566,7 @@ namespace SIPSorcery.SIP
                         #region Min-Expires
                         else if (headerNameLower == SIPHeaders.SIP_HEADER_MINEXPIRES.ToLower())
                         {
-                            if (!Int32.TryParse(headerValue, out sipHeader.MinExpires))
+                            if (!Int64.TryParse(headerValue, out sipHeader.MinExpires))
                             {
                                 logger.LogWarning("The Min-Expires value was not a valid integer, " + headerLine + ".");
                             }


### PR DESCRIPTION
Changes attached.

Two notes: I have actually found a spot where 2^31 -1 is demanded as value for the Expires field, I have attached the reference in the commit message.

The change in SIPNotifierClient.StartSubscription:
It is quite clumsy and actually not correct in terms of total waiting time.
I thought it wouldn't be worth the effort to make things more complicated than necessary.