### PR TITLE
Proposal fix for SRTP not working with multiple media types in the RTP Session

### DIFF
--- a/src/net/DtlsSrtp/RtpSecureContextCollection.cs
+++ b/src/net/DtlsSrtp/RtpSecureContextCollection.cs
@@ -1,0 +1,71 @@
+﻿//-----------------------------------------------------------------------------
+// Filename: RtpSecureContextCollection.cs
+//
+// Description: Represents a secure context for Rtp Sessions
+//
+// Author(s):
+// Jean-Philippe Fournier
+//
+// History:
+// 5 January 2022 : Jean-Philippe Fournier, created Montréal, QC, Canada
+//
+// License:
+// BSD 3-Clause "New" or "Revised" License, see included LICENSE.md file.
+//-----------------------------------------------------------------------------
+
+using SIPSorcery.Sys;
+using System.Collections.Concurrent;
+using Microsoft.Extensions.Logging;
+
+namespace SIPSorcery.Net
+{
+    public class SecureContext
+    {
+        public ProtectRtpPacket ProtectRtpPacket { get; private set; }
+        public ProtectRtpPacket ProtectRtcpPacket { get; private set; }
+
+        public ProtectRtpPacket UnprotectRtpPacket { get; private set; }
+        public ProtectRtpPacket UnprotectRtcpPacket { get; private set;}
+
+        public SecureContext(ProtectRtpPacket protectRtpPacket, ProtectRtpPacket unprotectRtpPacket, ProtectRtpPacket protectRtcpPacket, ProtectRtpPacket unprotectRtcpPacket)
+        {
+            ProtectRtpPacket = protectRtpPacket;
+            ProtectRtcpPacket = protectRtcpPacket;
+            UnprotectRtpPacket = unprotectRtpPacket;
+            UnprotectRtcpPacket = unprotectRtcpPacket;
+        }
+    }
+
+    public class RtpSecureContextCollection
+    {
+        private readonly ILogger _logger = Log.Logger;
+
+        private readonly ConcurrentDictionary<SDPMediaTypesEnum, SecureContext> m_handlerCollection;
+
+        public RtpSecureContextCollection()
+        {
+            m_handlerCollection = new ConcurrentDictionary<SDPMediaTypesEnum, SecureContext>();
+        }
+
+        public void SetSecureContextForMediaType(SDPMediaTypesEnum mediaType, SecureContext srtpHandler)
+        {
+            var result = m_handlerCollection.TryAdd(mediaType, srtpHandler);
+            if (!result)
+            {
+                _logger.LogTrace($"Tried adding new SecureContext for media type {mediaType}, but one already existed");
+            }
+        }
+
+        public SecureContext GetSecureContext(SDPMediaTypesEnum mediaType)
+        {
+            m_handlerCollection.TryGetValue(mediaType, out var secureContext);
+            return secureContext;
+        }
+
+        public bool IsSecureContextReady(SDPMediaTypesEnum mediaType)
+        {
+            m_handlerCollection.TryGetValue(mediaType, out var secureContext);
+            return secureContext != null;
+        }
+    }
+}

--- a/src/net/DtlsSrtp/SecureContextCollection.cs
+++ b/src/net/DtlsSrtp/SecureContextCollection.cs
@@ -36,13 +36,13 @@ namespace SIPSorcery.Net
         }
     }
 
-    public class RtpSecureContextCollection
+    public class SecureContextCollection
     {
         private readonly ILogger _logger = Log.Logger;
 
         private readonly ConcurrentDictionary<SDPMediaTypesEnum, SecureContext> m_handlerCollection;
 
-        public RtpSecureContextCollection()
+        public SecureContextCollection()
         {
             m_handlerCollection = new ConcurrentDictionary<SDPMediaTypesEnum, SecureContext>();
         }

--- a/src/net/DtlsSrtp/SrtpHandlerCollection.cs
+++ b/src/net/DtlsSrtp/SrtpHandlerCollection.cs
@@ -1,5 +1,5 @@
 ﻿//-----------------------------------------------------------------------------
-// Filename: SrtpHandler.cs
+// Filename: SrtpHandlerCollection.cs
 //
 // Description: This class represents a collection of SRTP handlers for SIP calls
 //

--- a/src/net/DtlsSrtp/SrtpHandlerCollection.cs
+++ b/src/net/DtlsSrtp/SrtpHandlerCollection.cs
@@ -1,0 +1,40 @@
+﻿//-----------------------------------------------------------------------------
+// Filename: SrtpHandler.cs
+//
+// Description: This class represents a collection of SRTP handlers for SIP calls
+//
+// Author(s):
+// Jean-Philippe Fournier
+//
+// History:
+// 5 January 2022 : Jean-Philippe Fournier, created Montréal, QC, Canada
+//
+// License:
+// BSD 3-Clause "New" or "Revised" License, see included LICENSE.md file.
+//-----------------------------------------------------------------------------
+
+using System.Collections.Concurrent;
+
+namespace SIPSorcery.Net
+{
+    public class SrtpHandlerCollection
+    {
+        private readonly ConcurrentDictionary<SDPMediaTypesEnum, SrtpHandler> m_handlerCollection;
+
+        public SrtpHandlerCollection()
+        {
+            m_handlerCollection = new ConcurrentDictionary<SDPMediaTypesEnum, SrtpHandler>();
+        }
+
+        public SrtpHandler GetOrCreateSrtpHandler(SDPMediaTypesEnum mediaType)
+        {
+            var found = m_handlerCollection.TryGetValue(mediaType, out var current);
+            if (!found)
+            {
+                current = new SrtpHandler();
+                m_handlerCollection[mediaType] = current;
+            }
+            return current;
+        }
+    }
+}

--- a/src/net/RTP/RTPSession.cs
+++ b/src/net/RTP/RTPSession.cs
@@ -189,7 +189,7 @@ namespace SIPSorcery.Net
 
         private SrtpHandlerCollection m_secureHandlerCollection = new SrtpHandlerCollection();
 
-        private RtpSecureContextCollection m_secureContextCollection = new RtpSecureContextCollection();
+        private SecureContextCollection m_secureContextCollection = new SecureContextCollection();
 
         /// <summary>
         /// Track if current remote description is invalid (used in Renegotiation logic)
@@ -2170,7 +2170,6 @@ namespace SIPSorcery.Net
                             logger.LogWarning("Could not find appropriate remote track for SSRC for RTCP packet");
                         }
                     }
-
 
                     var rtcpPkt = new RTCPCompoundPacket(buffer);
 

--- a/src/net/SDP/SDPTypes.cs
+++ b/src/net/SDP/SDPTypes.cs
@@ -23,6 +23,7 @@ namespace SIPSorcery.Net
 {
     public enum SDPMediaTypesEnum
     {
+        invalid = 0,
         audio = 1,
         video = 2,
         application = 3,

--- a/src/net/WebRTC/RTCPeerConnection.cs
+++ b/src/net/WebRTC/RTCPeerConnection.cs
@@ -204,10 +204,7 @@ namespace SIPSorcery.Net
         /// </summary>
         public RTCDtlsFingerprint RemotePeerDtlsFingerprint { get; private set; }
 
-        public bool IsDtlsNegotiationComplete
-        {
-            get { return base.IsSecureContextReady; }
-        }
+        public bool IsDtlsNegotiationComplete { get; private set; } = false;
 
         public RTCSessionDescription localDescription { get; private set; }
 
@@ -1678,6 +1675,8 @@ namespace SIPSorcery.Net
                         dtlsHandle.UnprotectRTP,
                         dtlsHandle.ProtectRTCP,
                         dtlsHandle.UnprotectRTCP);
+                        
+                    IsDtlsNegotiationComplete = true;
 
                     return true;
                 }

--- a/src/net/WebRTC/RTCPeerConnection.cs
+++ b/src/net/WebRTC/RTCPeerConnection.cs
@@ -1673,6 +1673,7 @@ namespace SIPSorcery.Net
                     logger.LogDebug($"RTCPeerConnection remote certificate fingerprint matched expected value of {remoteFingerprint.value} for {remoteFingerprint.algorithm}.");
 
                     base.SetSecurityContext(
+                        new List<SDPMediaTypesEnum> { SDPMediaTypesEnum.audio, SDPMediaTypesEnum.video, SDPMediaTypesEnum.application },
                         dtlsHandle.ProtectRTP,
                         dtlsHandle.UnprotectRTP,
                         dtlsHandle.ProtectRTCP,


### PR DESCRIPTION
When using SRTP with audio and video, the last media announcement will be the only one to work. 
This for example will cause video to work but not audio, although the negotiation was done for both types individually

The issue arises because of the SRTP handler being agnostic of the media type, and being reconfigured by both media types

This fixes that by replacing the singular srtp handler by a collection that maps a handler by media type.

These are then used to create secure contexts which are used upon receiving or sending rtp packets