### PR TITLE
Allow disabling of extended master password when RTCPeerConnection creates a DTLS client and is set by config. (#650)

### DIFF
--- a/src/net/WebRTC/RTCPeerConnection.cs
+++ b/src/net/WebRTC/RTCPeerConnection.cs
@@ -531,7 +531,8 @@ namespace SIPSorcery.Net
                     bool disableDtlsExtendedMasterSecret = _configuration != null && _configuration.X_DisableExtendedMasterSecretKey;
                     _dtlsHandle = new DtlsSrtpTransport(
                                 IceRole == IceRolesEnum.active ?
-                                new DtlsSrtpClient(_dtlsCertificate, _dtlsPrivateKey) :
+                                new DtlsSrtpClient(_dtlsCertificate, _dtlsPrivateKey)
+                                { ForceUseExtendedMasterSecret = !disableDtlsExtendedMasterSecret } :
                                 (IDtlsSrtpPeer)new DtlsSrtpServer(_dtlsCertificate, _dtlsPrivateKey)
                                 { ForceUseExtendedMasterSecret = !disableDtlsExtendedMasterSecret }
                                 );


### PR DESCRIPTION
Hi,

As per #650, I've modified RTCPeerConnection IceConnectionStateChange() to set ForceUseExtendedMasterSecret based on the config param when the dtlsHandle creates a DtlsSrtpClient (i.e. when ICE role is active). 

I've just kept the existing short hand ? : notation even though it's quite long a statement now. Let me know if you'd prefer an if statement for readability.

Found this to cause issues when connecting to [Sipwise/RTPEngine](https://github.com/sipwise/rtpengine), it doesn't look to support extended master passwords and was throwing a TLSFatalAlert from the bouncy castle code. Have tested this change which fixes it.

Cheers,

Ali.