### PR TITLE
Thread-safe RTCDataChannel collection

### DIFF
--- a/src/net/WebRTC/RTCDataChannel.cs
+++ b/src/net/WebRTC/RTCDataChannel.cs
@@ -113,7 +113,8 @@ namespace SIPSorcery.Net
         {
             IsOpened = false;
             readyState = RTCDataChannelState.closed;
-            // TODO. What actions are required?
+            logger.LogDebug($"Data channel with id {id} has been closed");
+            onclose?.Invoke();
         }
 
         /// <summary>
@@ -219,13 +220,6 @@ namespace SIPSorcery.Net
                        (uint)DataChannelPayloadProtocols.WebRTC_DCEP,
                        new byte[] { (byte)DataChannelMessageTypes.ACK });
             }
-        }
-
-        public void close(uint streamID)
-        {
-            IsOpened = false;
-            logger.LogDebug($"Data channel stream closed id {streamID}.");
-            onclose?.Invoke();
         }
 
         /// <summary>

--- a/src/net/WebRTC/RTCDataChannelCollection.cs
+++ b/src/net/WebRTC/RTCDataChannelCollection.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Collections;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace SIPSorcery.Net
+{
+    class RTCDataChannelCollection : IReadOnlyCollection<RTCDataChannel>
+    {
+        readonly ConcurrentBag<RTCDataChannel> pendingChannels = new ConcurrentBag<RTCDataChannel>();
+        readonly ConcurrentDictionary<ushort, RTCDataChannel> activeChannels = new ConcurrentDictionary<ushort, RTCDataChannel>();
+        readonly Func<bool> useEvenIds;
+        
+        readonly object idSyncObj = new object();
+        ushort lastChannelId = ushort.MaxValue - 1;
+
+        public int Count => pendingChannels.Count + activeChannels.Count;
+
+        public RTCDataChannelCollection(Func<bool> useEvenIds)
+            => this.useEvenIds = useEvenIds;
+
+        public void AddPendingChannel(RTCDataChannel channel)
+            => pendingChannels.Add(channel);
+
+        public IEnumerable<RTCDataChannel> ActivatePendingChannels()
+        {
+            while (pendingChannels.TryTake(out var channel))
+            {
+                AddActiveChannel(channel);
+                yield return channel;
+            }
+        }
+        
+        public bool TryGetChannel(ushort dataChannelID, out RTCDataChannel result)
+            => activeChannels.TryGetValue(dataChannelID, out result);
+        
+        public bool AddActiveChannel(RTCDataChannel channel)
+        {
+            if (channel.id.HasValue)
+            {
+                if (!activeChannels.TryAdd(channel.id.Value, channel))
+                    return false;
+            }
+            else
+            {
+                while (true)
+                {
+                    var id = GetNextChannelID();
+                    if (activeChannels.TryAdd(id, channel))
+                    {
+                        channel.id = id;
+                        break;
+                    }
+                }
+            }
+
+            channel.onclose += OnClose;
+            channel.onerror += OnError;
+            return true;
+            
+            void OnClose()
+            {
+                channel.onclose -= OnClose;
+                channel.onerror -= OnError;
+                activeChannels.TryRemove(channel.id.Value, out _);
+            }
+            void OnError(string error) => OnClose();
+        }
+        
+        ushort GetNextChannelID()
+        {
+            lock (idSyncObj)
+            {
+                unchecked
+                {
+                    //  The SCTP stream identifier 65535 is reserved due to SCTP INIT and
+                    // INIT - ACK chunks only allowing a maximum of 65535 streams to be
+                    // negotiated(0 - 65534) - https://tools.ietf.org/html/rfc8832
+                    if (lastChannelId == ushort.MaxValue - 3)
+                        lastChannelId += 4;
+                    else
+                        lastChannelId += 2;
+                }
+                return useEvenIds() ? lastChannelId : (ushort) (lastChannelId + 1);
+            }
+        }
+
+        public IEnumerator<RTCDataChannel> GetEnumerator()
+            => pendingChannels.Concat(activeChannels.Select(e => e.Value)).GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+}


### PR DESCRIPTION
When a new SCTP data frame is received by the `RTCPeerConnection` at the same time as a new data channel is being opened, an exception occurs, because collection of type `List<RTCDataChannel>` is not thread-safe and cannot be changed and enumerated simultaneously.

Additionally, the following things have been improved:
- Data channels are removed from the collection when closed
- New data channel ID generation is also thread-safe now
- Minimized the chance of running out of available data channel IDs
- `RTCDataChannel.onclose` event was not fired from its `close()` method

Worth to mention, that this pull request introduces two breaking changes to the public API:
- The old `RTCPeerConnection.DataChannels` property was of type `List<RTCDataChannel>` and now is of type `IReadOnlyCollection<RTCDataChannel>`. The code in "examples" folder is only enumerating the collection and using its `Count` property, which is still possible with the new type. However, it might influence other library users. On the other hand, the `DataChannels` property is not a part of the official standard.
- I have removed the redundant `RTCDataChannel.close(uint streamID)` method.

Technically, I can adjust both breaking changes to make them still binary backward compatible, but should I?