### PR TITLE
Controlled/controlling is set based on ICE implementation

### DIFF
--- a/src/net/ICE/IRTCIceCandidate.cs
+++ b/src/net/ICE/IRTCIceCandidate.cs
@@ -19,6 +19,16 @@ namespace SIPSorcery.Net
     /// The ICE set up roles that a peer can be in. The role determines how the DTLS
     /// handshake is performed, i.e. which peer is the client and which is the server.
     /// </summary>
+    public enum IceImplementationEnum
+    {
+        full,
+        lite
+    }
+
+    /// <summary>
+    /// The ICE set up roles that a peer can be in. The role determines how the DTLS
+    /// handshake is performed, i.e. which peer is the client and which is the server.
+    /// </summary>
     public enum IceRolesEnum
     {
         actpass = 0,

--- a/src/net/SDP/SDP.cs
+++ b/src/net/SDP/SDP.cs
@@ -132,6 +132,7 @@ namespace SIPSorcery.Net
         public const MediaStreamStatusEnum DEFAULT_STREAM_STATUS = MediaStreamStatusEnum.SendRecv;
 
         // ICE attributes.
+        public const string ICE_LITE_IMPLEMENTATION_ATTRIBUTE_PREFIX = "ice-lite";
         public const string ICE_UFRAG_ATTRIBUTE_PREFIX = "ice-ufrag";
         public const string ICE_PWD_ATTRIBUTE_PREFIX = "ice-pwd";
         public const string END_ICE_CANDIDATES_ATTRIBUTE = "end-of-candidates";
@@ -164,6 +165,7 @@ namespace SIPSorcery.Net
         public string URI;                          // URI for additional information about the session.
         public string[] OriginatorEmailAddresses;   // Email addresses for the person responsible for the session.
         public string[] OriginatorPhoneNumbers;     // Phone numbers for the person responsible for the session.
+        public IceImplementationEnum IceImplementation = IceImplementationEnum.full;
         public string IceUfrag;                     // If ICE is being used the username for the STUN requests.
         public string IcePwd;                       // If ICE is being used the password for the STUN requests.
         public IceRolesEnum? IceRole = null;
@@ -328,7 +330,9 @@ namespace SIPSorcery.Net
                             case var x when x.StartsWith($"a={GROUP_ATRIBUTE_PREFIX}"):
                                 sdp.Group = sdpLineTrimmed.Substring(sdpLineTrimmed.IndexOf(':') + 1);
                                 break;
-
+                            case var x when x.StartsWith($"a={ICE_LITE_IMPLEMENTATION_ATTRIBUTE_PREFIX}"):
+                                sdp.IceImplementation = IceImplementationEnum.lite;
+                                break;
                             case var x when x.StartsWith($"a={ICE_UFRAG_ATTRIBUTE_PREFIX}"):
                                 if (activeAnnouncement != null)
                                 {

--- a/src/net/WebRTC/RTCPeerConnection.cs
+++ b/src/net/WebRTC/RTCPeerConnection.cs
@@ -731,6 +731,9 @@ namespace SIPSorcery.Net
 
                 SdpSessionID = remoteSdp.SessionId;
 
+                if (remoteSdp.IceImplementation == IceImplementationEnum.lite) {
+                    _rtpIceChannel.IsController = true;
+                }
                 if (init.type == RTCSdpType.answer)
                 {
                     _rtpIceChannel.IsController = true;


### PR DESCRIPTION
If there are two agents one with full ICE implementation and one with lite ICE implementation, then the full implementation agent should be always controlling peer

Based on https://datatracker.ietf.org/doc/html/rfc8445#section-6.1.1 and https://datatracker.ietf.org/doc/html/rfc8839#section-4.2.1.4