### PR TITLE
Stop TURN refresh when host ICE candidate was nominated

### DIFF
--- a/src/net/ICE/RtpIceChannel.cs
+++ b/src/net/ICE/RtpIceChannel.cs
@@ -727,7 +727,7 @@ namespace SIPSorcery.Net
             {
                 return;
             }
-            if (_activeIceServer._uri.Scheme != STUNSchemesEnum.turn)
+            if (_activeIceServer._uri.Scheme != STUNSchemesEnum.turn || NominatedEntry.LocalCandidate.IceServer is null)
             {
                 _refreshTurnTimer.Dispose();
                 return;


### PR DESCRIPTION
When the nominated local ICE candidate is of 'host' type but the active ICE server is a TURN server, a `NullReferenceException` is thrown when accessing the properties of `NominatedEntry.LocalCandidate.IceServer`.

I assume that the correct behavior would be to just stop the timer, since TURN is not used in this case.