### PR TITLE
SonarQube alert fix

### DIFF
--- a/src/net/WebRTC/RTCDataChannel.cs
+++ b/src/net/WebRTC/RTCDataChannel.cs
@@ -123,7 +123,7 @@ namespace SIPSorcery.Net
         /// <param name="message">The string message to send.</param>
         public void send(string message)
         {
-            if (message != null & Encoding.UTF8.GetByteCount(message) > _transport.maxMessageSize)
+            if (message != null && Encoding.UTF8.GetByteCount(message) > _transport.maxMessageSize)
             {
                 throw new ApplicationException($"Data channel {label} was requested to send data of length {Encoding.UTF8.GetByteCount(message)} " +
                     $" that exceeded the maximum allowed message size of {_transport.maxMessageSize}.");


### PR DESCRIPTION
The use of non-short-circuit logic in a boolean context is likely a mistake - one that could cause serious program errors as conditions are evaluated under the wrong circumstances.