### PR TITLE
Add support for abs capture time and reorder buffer

### DIFF
--- a/src/net/RTP/MediaStreamTrack.cs
+++ b/src/net/RTP/MediaStreamTrack.cs
@@ -20,6 +20,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using Microsoft.Extensions.Logging;
+using SIPSorcery.net.RTP;
 using SIPSorcery.Sys;
 using SIPSorceryMedia.Abstractions;
 
@@ -53,6 +54,11 @@ namespace SIPSorcery.Net
         public ushort SeqNum { get { return (ushort)m_seqNum; } internal set { m_seqNum = value; } }
 
         /// <summary>
+        /// The last abs-capture-time received from the remote peer for this stream.
+        /// </summary>
+        public TimestampPair LastAbsoluteCaptureTimestamp{ get; internal set; }
+
+        /// <summary>
         /// The value used in the RTP Timestamp header field for media packets
         /// sent using this media stream.
         /// </summary>
@@ -73,6 +79,11 @@ namespace SIPSorcery.Net
         /// The media capabilities supported by this track.
         /// </summary>
         public List<SDPAudioVideoMediaFormat> Capabilities { get; internal set; }
+
+        // <summary>
+        ///  a=extmap - Mapping for RTP header extensions
+        /// </summary>
+        public Dictionary<int, RTPHeaderExtension> HeaderExtensions { get; }
 
         /// <summary>
         /// Represents the original and default stream status for the track. This is set
@@ -151,14 +162,14 @@ namespace SIPSorcery.Net
             bool isRemote,
             List<SDPAudioVideoMediaFormat> capabilities,
             MediaStreamStatusEnum streamStatus = MediaStreamStatusEnum.SendRecv,
-            List<SDPSsrcAttribute> ssrcAttributes = null)
+            List<SDPSsrcAttribute> ssrcAttributes = null, Dictionary<int, RTPHeaderExtension> headerExtensions = null)
         {
             Kind = kind;
             IsRemote = isRemote;
             Capabilities = capabilities;
             StreamStatus = streamStatus;
             DefaultStreamStatus = streamStatus;
-
+            HeaderExtensions = headerExtensions ?? new Dictionary<int, RTPHeaderExtension>();
             if (!isRemote)
             {
                 Ssrc = Convert.ToUInt32(Crypto.GetRandomInt(0, Int32.MaxValue));

--- a/src/net/RTP/Ntp64Timestamp.cs
+++ b/src/net/RTP/Ntp64Timestamp.cs
@@ -1,0 +1,58 @@
+﻿using System;
+
+namespace SIPSorcery.Net
+{
+    public class TimestampPair
+    {
+        public uint RtpTimestamp { get; set; }
+        public ulong NtpTimestamp { get; set; }
+    }
+
+    public class Ntp64Timestamp
+    {
+        public static ulong AddFraction(ulong timestamp, double fraction) {
+            var fractionalPart = GetFraction(timestamp);
+            fractionalPart += ((uint) (fraction * uint.MaxValue)) & 0x00000000FFFFFFFF; 
+            return (timestamp & 0xFFFFFFFF00000000) | fractionalPart;
+        }
+
+        public static ulong AddSeconds(ulong timestamp, uint seconds) {
+            var sec = (ulong) GetSeconds(timestamp) + seconds;
+            return (sec << 32) | (timestamp & 0x00000000FFFFFFFF);
+        }
+
+        public static uint GetSeconds(ulong timestamp) {
+            return (uint)((timestamp & 0xFFFFFFFF00000000) >> 32);
+        }
+
+        public static uint GetFraction(ulong timestamp)
+        {
+            return (uint)(timestamp & 0x00000000FFFFFFFF);
+        }
+
+        public static DateTime GetDatetime(ulong timestamp) {
+            var epochStart = new DateTime(1900, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
+            var millis = ((double)GetFraction(timestamp) * 1000 / (double)uint.MaxValue);
+            var time = epochStart + TimeSpan.FromSeconds(GetSeconds(timestamp)) + TimeSpan.FromMilliseconds(millis);
+            return time;
+        }
+
+        public static ulong InterpolateNtpTime(TimestampPair lastTimestampPair, uint currentRtpTimestamp, int clockrate)
+        {
+            var diff = currentRtpTimestamp - lastTimestampPair.RtpTimestamp;
+            var diffTime = diff / (double)clockrate;
+            var seconds = Math.Truncate(diffTime);
+            var fractionalPart = (diffTime - seconds);
+           
+           
+            
+            var withSeconds = AddSeconds(lastTimestampPair.NtpTimestamp, (uint)seconds);
+            return AddFraction(withSeconds, fractionalPart);
+        }
+
+        public static DateTime InterpolateDatetime(TimestampPair lastTimestampPair, uint currentRtpTimestamp, int clockrate) {
+            var time = InterpolateNtpTime(lastTimestampPair, currentRtpTimestamp, clockrate);
+            return GetDatetime(time);
+        }
+    }
+}

--- a/src/net/RTP/RTPHeader.cs
+++ b/src/net/RTP/RTPHeader.cs
@@ -15,6 +15,10 @@
 //-----------------------------------------------------------------------------
 
 using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using SIPSorcery.net.RTP;
 using SIPSorcery.Sys;
 
 namespace SIPSorcery.Net
@@ -176,6 +180,73 @@ namespace SIPSorcery.Net
             }
 
             return header;
+        }
+
+        private RTPHeaderExtensionData GetExtensionAtPosition(ref int position, int id, int len, RTPHeaderExtensionType type, out bool invalid) {
+            RTPHeaderExtensionData ext = null;
+            if (id != 0)
+            {
+                if (position + len > ExtensionPayload.Length)
+                {
+                    // invalid extension
+                    invalid = true;
+                    return null;
+                }
+                ext = new RTPHeaderExtensionData(id, ExtensionPayload.Skip(position).Take(len).ToArray(), type);
+                position += len;
+            }
+            else
+            {
+                position++;
+            }
+            while ((position < ExtensionPayload.Length) && (ExtensionPayload[position] == 0))
+            {
+                position++;
+            }
+
+            invalid = false;
+            return ext;
+        }
+
+        public List<RTPHeaderExtensionData> GetHeaderExtensions() {
+            var extensions = new List<RTPHeaderExtensionData>();
+            RTPHeaderExtensionData extension = null;
+            var i = 0;
+            bool invalid = false;
+            while (i + 1 < ExtensionPayload.Length)
+            {
+                if (HasOneByteExtension()) {
+                    var id = (ExtensionPayload[i] & 0xF0) >> 4;
+                    var len = (ExtensionPayload[i] & 0x0F) + 1;
+                    i++;
+                    extension = GetExtensionAtPosition(ref i, id, len, RTPHeaderExtensionType.OneByte, out invalid);
+
+                }
+                else if(HasTwoByteExtension()) {
+                    var id = ExtensionPayload[i++];
+                    var len = ExtensionPayload[i++] + 1;
+                    extension = GetExtensionAtPosition(ref i, id, len, RTPHeaderExtensionType.TwoByte, out invalid);
+                }
+
+                if (invalid) {
+                    break;
+                }
+
+                if (extension != null) {
+                    extensions.Add(extension);
+                }
+            }
+
+            return extensions;
+        }
+
+        private bool HasOneByteExtension() {
+            return ExtensionProfile == 0xBEDE;
+        }
+
+        private bool HasTwoByteExtension()
+        {
+            return (ExtensionProfile & 0b1111111111110000) == 0b0001000000000000;
         }
     }
 }

--- a/src/net/RTP/RTPHeader.cs
+++ b/src/net/RTP/RTPHeader.cs
@@ -45,7 +45,7 @@ namespace SIPSorcery.Net
 
         public int PayloadSize;
         public byte PaddingCount;
-
+        public DateTime ReceivedTime;
         public int Length
         {
             get { return MIN_HEADER_LEN + (CSRCCount * 4) + ((HeaderExtensionFlag == 0) ? 0 : 4 + (ExtensionLength * 4)); }

--- a/src/net/RTP/RTPHeaderExtension.cs
+++ b/src/net/RTP/RTPHeaderExtension.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using SIPSorcery.Net;
+using SIPSorcery.Sys;
+
+namespace SIPSorcery.net.RTP
+{
+    public class RTPHeaderExtension
+    {
+        public RTPHeaderExtension(int id, string uri)
+        {
+            Id = id;
+            Uri = uri;
+        }
+        public int Id { get; }
+        public string Uri { get; }
+
+        public RTPHeaderExtensionUri.Type? Type => RTPHeaderExtensionUri.GetType(Uri);
+    }
+
+    public class RTPHeaderExtensionUri
+    {
+        public enum Type{
+            Unknown,
+            AbsCaptureTime
+        }
+
+        private static Dictionary<string, Type> Types { get; } = new Dictionary<string, Type>() {{"http://www.webrtc.org/experiments/rtp-hdrext/abs-capture-time", Type.AbsCaptureTime}};
+
+        public static Type? GetType(string uri) {
+            if (!Types.ContainsKey(uri)) {
+                return Type.Unknown;
+            }
+
+            return Types[uri];
+        }
+    }
+    
+    public enum RTPHeaderExtensionType
+    {
+        OneByte,
+        TwoByte
+    }
+
+    public class RTPHeaderExtensionData
+    {
+        public RTPHeaderExtensionData(int id, byte[] data, RTPHeaderExtensionType type)
+        {
+            Id = id;
+            Data = data;
+            Type = type;
+        }
+        public int Id { get; }
+        public byte[] Data { get; }
+        public RTPHeaderExtensionType Type { get; }
+
+        public RTPHeaderExtensionUri.Type? GetUriType(Dictionary<int, RTPHeaderExtension> map) {
+            return !map.ContainsKey(Id) ? null : map[Id].Type;
+        }
+
+
+        public ulong? GetNtpTimestamp(Dictionary<int, RTPHeaderExtension> extensions){
+            var extensionType = GetUriType(extensions);
+            if (extensionType != RTPHeaderExtensionUri.Type.AbsCaptureTime) {
+                return null;
+            }
+
+            return GetUlong(0);
+        }
+
+        public ulong? GetUlong(int offset) {
+            if (offset + sizeof(ulong) - 1 >= Data.Length) {
+                return null;
+            }
+
+            return BitConverter.IsLittleEndian ? 
+                NetConvert.DoReverseEndian(BitConverter.ToUInt64(Data, offset)) : 
+                BitConverter.ToUInt64(Data, offset);
+        }
+    }
+}

--- a/src/net/RTP/RTPReorderBuffer.cs
+++ b/src/net/RTP/RTPReorderBuffer.cs
@@ -1,0 +1,122 @@
+﻿using System;
+using Microsoft.Extensions.Logging;
+using SIPSorcery.Net;
+using SIPSorcery.Sys;
+
+namespace SIPSorcery.net.RTP
+{
+    public class RTPReorderBuffer
+    {
+        private readonly TimeSpan _maxDropOutTime;
+        private readonly IDateTime _datetimeProvider;
+        private readonly System.Collections.Generic.LinkedList<RTPPacket> _data = new System.Collections.Generic.LinkedList<RTPPacket>();
+        private ushort? _currentSeqNumber;
+
+        private static ILogger logger = Log.Logger;
+
+        public RTPReorderBuffer(TimeSpan maxDropOutTime, IDateTime datetimeProvider = null)
+        {
+            _maxDropOutTime = maxDropOutTime;
+            _datetimeProvider = datetimeProvider ?? new DefaultTimeProvider();
+        }
+
+        private RTPPacket First => _data.First?.Value;
+        private RTPPacket Last => _data.Last?.Value;
+
+        private bool IsBeforeWrapAround(RTPPacket packet) {
+            return IsBeforeWrapAround(packet.Header.SequenceNumber);
+        }
+        private bool IsBeforeWrapAround(ushort seq)
+        {
+            return seq > ushort.MaxValue / 2 + ushort.MaxValue / 4;
+        }
+        private bool IsAfterWrapAround(RTPPacket packet)
+        {
+            return packet.Header.SequenceNumber < ushort.MaxValue / 4;
+        }
+
+        public bool Get(out RTPPacket packet)
+        {
+            packet = null;
+            if (Last == null)
+            {
+                return false;
+            }
+
+            if (_currentSeqNumber.HasValue && _currentSeqNumber != Last.Header.SequenceNumber)
+            {
+
+                if (_datetimeProvider.Time - Last.Header.ReceivedTime < _maxDropOutTime)
+                {
+                    return false;
+                }
+            }
+            packet = Last;
+            _data.RemoveLast();
+            _currentSeqNumber = (ushort)checked(packet.Header.SequenceNumber + 1);
+            return true;
+        }
+
+        public void Add(RTPPacket current)
+        {
+            if (_data.Count == 0)
+            {
+                _data.AddFirst(current);
+                return;
+            }
+
+            // if seq number is greater or equal than we are waiting for then append to last position
+            if (_currentSeqNumber.HasValue && _currentSeqNumber >= current.Header.SequenceNumber) {
+                if (Last.Header.SequenceNumber > _currentSeqNumber || IsAfterWrapAround(Last) && IsBeforeWrapAround(_currentSeqNumber.Value)) {
+                    _data.AddLast(current);
+                    return;
+                }
+            }
+            
+            if (IsBeforeWrapAround(Last) && !IsAfterWrapAround(First) && IsAfterWrapAround(current)) // first incoming packet after wraparound
+            {
+                _data.AddFirst(current);
+                return;
+            }
+
+            var node = _data.First;
+            do
+            {
+                // if it is packet before wrap around skip all packets after wrap around and then insert the packet
+                if (IsBeforeWrapAround(current) && IsBeforeWrapAround(Last) && IsAfterWrapAround(node.Value))
+                {
+                    node = node.Next;
+                    continue;
+                }
+                if (IsBeforeWrapAround(node.Value) && IsAfterWrapAround(current))
+                {
+                    _data.AddBefore(node, current);
+                    break;
+                }
+                if (current.Header.SequenceNumber > node.Value.Header.SequenceNumber)
+                {
+                    _data.AddBefore(node, current);
+                    break;
+                }
+                if (current.Header.SequenceNumber == node.Value.Header.SequenceNumber)
+                {
+                    logger.LogInformation("Duplicate seq number: " + current.Header.SequenceNumber);
+                    break;
+                }
+
+                node = node.Next;
+            }
+            while (node != null);
+        }
+    }
+
+    public interface IDateTime
+    {
+        DateTime Time { get; }
+    }
+
+    public class DefaultTimeProvider : IDateTime
+    {
+        public DateTime Time => DateTime.Now;
+    }
+}

--- a/src/net/SDP/SDPMediaAnnouncement.cs
+++ b/src/net/SDP/SDPMediaAnnouncement.cs
@@ -32,6 +32,7 @@ using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using Microsoft.Extensions.Logging;
+using SIPSorcery.net.RTP;
 using SIPSorceryMedia.Abstractions;
 
 namespace SIPSorcery.Net
@@ -68,6 +69,7 @@ namespace SIPSorcery.Net
 
     public class SDPMediaAnnouncement
     {
+        public const string MEDIA_EXTENSION_MAP_ATTRIBUE_PREFIX = "a=extmap:";
         public const string MEDIA_FORMAT_ATTRIBUE_PREFIX = "a=rtpmap:";
         public const string MEDIA_FORMAT_PARAMETERS_ATTRIBUE_PREFIX = "a=fmtp:";
         public const string MEDIA_FORMAT_SSRC_ATTRIBUE_PREFIX = "a=ssrc:";
@@ -149,6 +151,11 @@ namespace SIPSorcery.Net
         ///  For AVP these will normally be a media payload type as defined in the RTP Audio/Video Profile.
         /// </summary>
         public Dictionary<int, SDPAudioVideoMediaFormat> MediaFormats = new Dictionary<int, SDPAudioVideoMediaFormat>();
+
+        /// <summary>
+        ///  a=extmap - Mapping for RTP header extensions
+        /// </summary>
+        public Dictionary<int, RTPHeaderExtension> HeaderExtensions = new Dictionary<int, RTPHeaderExtension>();
 
         /// <summary>
         ///  For AVP these will normally be a media payload type as defined in the RTP Audio/Video Profile.
@@ -311,6 +318,7 @@ namespace SIPSorcery.Net
 
             announcement += GetFormatListAttributesToString();
 
+            announcement += string.Join("", HeaderExtensions.Select(x => $"{MEDIA_EXTENSION_MAP_ATTRIBUE_PREFIX}{x.Value.Id} {x.Value.Uri}{m_CRLF}"));
             foreach (string extra in ExtraMediaAttributes)
             {
                 announcement += string.IsNullOrWhiteSpace(extra) ? null : extra + m_CRLF;

--- a/test/unit/net/RTP/Ntp64TimestampUnitTest.cs
+++ b/test/unit/net/RTP/Ntp64TimestampUnitTest.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using Microsoft.Extensions.Logging;
+using SIPSorcery.Net;
+using Xunit;
+
+namespace SIPSorcery.UnitTests.net.RTP
+{
+    [Trait("Category", "unit")]
+    public class Ntp64TimestampUnitTest
+    {
+        private Microsoft.Extensions.Logging.ILogger logger = null;
+
+        public Ntp64TimestampUnitTest(Xunit.Abstractions.ITestOutputHelper output)
+        {
+            logger = SIPSorcery.UnitTests.TestLogHelper.InitTestLogger(output);
+        }
+
+        [Fact]
+        public void InterpolatesNtpTimestampFromRtpTimestamp() {
+            logger.LogDebug("--> " + System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+
+            var lastNtpTimestamp = 0x00000001_00000000ul;
+            var lastRtpTimestamp = 1100u;
+            var timestampPair = new TimestampPair() {RtpTimestamp = lastRtpTimestamp, NtpTimestamp = lastNtpTimestamp};
+            int clockrate = 1000;
+            var currentRtpTimestamp = 2101u;
+            var diff = currentRtpTimestamp - lastRtpTimestamp;
+            var timeUnits = (double)diff / clockrate;
+            var interpolatedNtpTimestamp = Ntp64Timestamp.InterpolateNtpTime(timestampPair, currentRtpTimestamp, clockrate);
+
+            var secs = Ntp64Timestamp.GetSeconds(interpolatedNtpTimestamp);
+            var fraction = Ntp64Timestamp.GetFraction(interpolatedNtpTimestamp);
+
+            Assert.Equal(2u, secs);
+            Assert.Equal(Math.Round(fraction/(double)uint.MaxValue, 3), Math.Round(timeUnits - Math.Truncate(timeUnits), 3));
+        }
+        
+    }
+}

--- a/test/unit/net/RTP/RTPHeaderExtensionUnitTest.cs
+++ b/test/unit/net/RTP/RTPHeaderExtensionUnitTest.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Extensions.Logging;
+using SIPSorcery.Net;
+using SIPSorcery.net.RTP;
+using SIPSorceryMedia.Abstractions;
+using Xunit;
+
+namespace SIPSorcery.UnitTests.net.RTP
+{
+    [Trait("Category", "unit")]
+    public class RTPHeaderExtensionUnitTest
+    {
+        private Microsoft.Extensions.Logging.ILogger logger = null;
+
+        public RTPHeaderExtensionUnitTest(Xunit.Abstractions.ITestOutputHelper output)
+        {
+            logger = SIPSorcery.UnitTests.TestLogHelper.InitTestLogger(output);
+        }
+
+        [Fact]
+        public void ExtensionShouldReturnRightUlongValue() {
+            logger.LogDebug("--> " + System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+
+            var absCaptureTime = new byte[] {0xb3, 0x85, 0xb0, 0x8f, 0xc, 0x13, 0x9d, 0xe5, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
+            var extension = new RTPHeaderExtensionData(13, absCaptureTime, RTPHeaderExtensionType.OneByte);
+
+            var val = extension.GetUlong(0);
+            Assert.NotNull(val);
+            Assert.Equal(0xb385b08f0c139de5, val.Value);
+
+            val = extension.GetUlong(8);
+            Assert.NotNull(val);
+            Assert.Equal(0ul, val.Value);
+
+            val = extension.GetUlong(9);
+            Assert.Null(val);
+        }
+
+        [Fact]
+        public void ShouldReturnCorrectTimestamps() {
+            logger.LogDebug("--> " + System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+
+            var absCaptureTime = new byte[] { 0xb3, 0x85, 0xb0, 0x8f, 0xc, 0x13, 0x9d, 0xe5, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0 };
+            var extension = new RTPHeaderExtensionData(13, absCaptureTime, RTPHeaderExtensionType.OneByte);
+            var extensions = new Dictionary<int, RTPHeaderExtension>() {{13, new RTPHeaderExtension(13, "http://www.webrtc.org/experiments/rtp-hdrext/abs-capture-time") }};
+            var ntpTimestamp = extension.GetNtpTimestamp(extensions);
+
+            Assert.NotNull(ntpTimestamp);
+            Assert.Equal(extension.GetUlong(0), ntpTimestamp.Value);
+        }
+
+        [Fact]
+        public void ReturnsNullTimestamps()
+        {
+            logger.LogDebug("--> " + System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+
+            var absCaptureTime = new byte[] { 0xb3, 0x85, 0xb0, 0x8f, 0xc, 0x13, 0x9d, 0xe5, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0 };
+            var extension = new RTPHeaderExtensionData(13, absCaptureTime, RTPHeaderExtensionType.OneByte);
+            const uint timestamp = 0x123456u;
+            var extensions = new Dictionary<int, RTPHeaderExtension>();
+            var timestamps = extension.GetNtpTimestamp(extensions);
+
+            Assert.Null(timestamps);
+        }
+    }
+}

--- a/test/unit/net/RTP/RTPHeaderUnitTest.cs
+++ b/test/unit/net/RTP/RTPHeaderUnitTest.cs
@@ -9,7 +9,9 @@
 // BSD 3-Clause "New" or "Revised" License, see included LICENSE.md file.
 //-----------------------------------------------------------------------------
 
+using System.Linq;
 using Microsoft.Extensions.Logging;
+using SIPSorcery.net.RTP;
 using SIPSorcery.Sys;
 using SIPSorceryMedia.Abstractions;
 using Xunit;
@@ -190,6 +192,29 @@ namespace SIPSorcery.Net.UnitTests
             logger.LogDebug($"RTP length: {rtp.Header.Length}");
 
             Assert.NotNull(rtp);
+        }
+
+        [Fact]
+        public void ParseHeaderExtensions()
+        {
+            logger.LogDebug("--> " + System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+
+            var rtpHeaderBytes = new byte[] {
+                0x90, 0x60, 0x0c, 0xd5, 0x83, 0x0a, 0xcd, 0x97, 0x2e, 0xba, 0x23, 0x57, 0xbe, 0xde, 0x00, 0x05,
+                0xdf, 0xb3, 0x85, 0xb0, 0x8f, 0x0c, 0x13, 0x9d, 0xe5, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                0x00, 0x00, 0x00, 0x00
+            };
+
+            var header = new RTPHeader(rtpHeaderBytes);
+            var extensions = header.GetHeaderExtensions();
+            Assert.Single(extensions);
+            var extension = extensions.Single();
+            Assert.Equal(13, extension.Id);
+            Assert.Equal(RTPHeaderExtensionType.OneByte, extension.Type);
+
+            var expectedValue = new byte[] {0xb3, 0x85, 0xb0, 0x8f, 0xc, 0x13, 0x9d, 0xe5, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
+            Assert.Equal(expectedValue, extension.Data);
         }
     }
 }

--- a/test/unit/net/RTP/ReorderBufferUnitTest.cs
+++ b/test/unit/net/RTP/ReorderBufferUnitTest.cs
@@ -1,0 +1,198 @@
+﻿using System;
+using Microsoft.Extensions.Logging;
+using SIPSorcery.Net;
+using SIPSorcery.net.RTP;
+using Xunit;
+
+namespace SIPSorcery.UnitTests.net.RTP
+{
+    internal class DatetimeProvider : IDateTime
+    {
+        public DateTime Time { get; set; }
+    }
+
+    [Trait("Category", "unit")]
+    public class ReorderBufferUnitTest
+    {
+        private ILogger logger = null;
+
+        public ReorderBufferUnitTest(Xunit.Abstractions.ITestOutputHelper output)
+        {
+            logger = TestLogHelper.InitTestLogger(output);
+        }
+
+        [Fact]
+        public void ShouldReorder()
+        {
+            logger.LogDebug("--> " + System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            var buffer = new RTPReorderBuffer(TimeSpan.FromMilliseconds(300));
+            var packets = new[] { CreatePacket(1), CreatePacket(3), CreatePacket(4), CreatePacket(2) };
+
+            foreach (var rtpPacket in packets)
+            {
+                buffer.Add(rtpPacket);
+            }
+
+            for (ushort i = 1; i <= 4; i++)
+            {
+                AssertSequenceNumber(buffer, i);
+            }
+        }
+
+        [Fact]
+        public void ShouldReorder2()
+        {
+            logger.LogDebug("--> " + System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            var buffer = new RTPReorderBuffer(TimeSpan.FromMilliseconds(300));
+            var packets = new[] { CreatePacket(1), CreatePacket(3), CreatePacket(2), CreatePacket(0) };
+
+            foreach (var rtpPacket in packets)
+            {
+                buffer.Add(rtpPacket);
+            }
+
+            for (ushort i = 1; i <= 3; i++)
+            {
+                AssertSequenceNumber(buffer, i);
+            }
+        }
+
+        [Fact]
+        public void ShouldReorderWithWrapAround()
+        {
+            logger.LogDebug("--> " + System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            var buffer = new RTPReorderBuffer(TimeSpan.FromMilliseconds(300));
+            var packets = new[] { CreatePacket(65534), CreatePacket(3), CreatePacket(2), CreatePacket(0), CreatePacket(65535) };
+
+            foreach (var rtpPacket in packets)
+            {
+                buffer.Add(rtpPacket);
+            }
+            AssertSequenceNumber(buffer, 65534);
+            AssertSequenceNumber(buffer, 65535);
+            AssertSequenceNumber(buffer, 0);
+            AssertSequenceNumber(buffer, 2);
+            AssertSequenceNumber(buffer, 3);
+        }
+
+        [Fact]
+        public void ShouldReturnPacketsInOrder()
+        {
+            logger.LogDebug("--> " + System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            var provider = new DatetimeProvider();
+            var baseTime = DateTime.Now;
+            var buffer = new RTPReorderBuffer(TimeSpan.FromMilliseconds(300), provider);
+
+            provider.Time = baseTime;
+            buffer.Add(CreatePacket(1));
+            buffer.Add(CreatePacket(3));
+            buffer.Add(CreatePacket(2));
+
+            AssertSequenceNumber(buffer, 1);
+            AssertSequenceNumber(buffer, 2);
+            AssertSequenceNumber(buffer, 3);
+
+            buffer.Add(CreatePacket(4));
+
+            AssertSequenceNumber(buffer, 4);
+        }
+
+        [Fact]
+        public void ShouldRemoveDuplicate()
+        {
+            logger.LogDebug("--> " + System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            var provider = new DatetimeProvider();
+            var baseTime = DateTime.Now;
+            var buffer = new RTPReorderBuffer(TimeSpan.FromMilliseconds(300), provider);
+
+            provider.Time = baseTime;
+            buffer.Add(CreatePacket(1));
+            buffer.Add(CreatePacket(2));
+            buffer.Add(CreatePacket(2));
+
+            AssertSequenceNumber(buffer, 1);
+            AssertSequenceNumber(buffer, 2);
+
+            Assert.False(buffer.Get(out _));
+        }
+
+        [Fact]
+        public void ShouldWaitForMissingPacket()
+        {
+            logger.LogDebug("--> " + System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            var provider = new DatetimeProvider();
+            var baseTime = DateTime.Now;
+            var buffer = new RTPReorderBuffer(TimeSpan.FromMilliseconds(300), provider);
+   
+            provider.Time = baseTime;
+            buffer.Add(CreatePacket(1, baseTime));
+            buffer.Add(CreatePacket(3, baseTime + TimeSpan.FromMilliseconds(100)));
+
+            AssertSequenceNumber(buffer, 1);
+            Assert.False(buffer.Get(out _));
+
+            buffer.Add(CreatePacket(2, baseTime + TimeSpan.FromMilliseconds(200)));
+
+            AssertSequenceNumber(buffer, 2);
+            AssertSequenceNumber(buffer, 3);
+        }
+
+        [Fact]
+        public void ShouldSkipPacketAfterSpecifiedTimeout()
+        {
+            logger.LogDebug("--> " + System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            var provider = new DatetimeProvider();
+            var baseTime = DateTime.Now;
+            var buffer = new RTPReorderBuffer(TimeSpan.FromMilliseconds(300), provider);
+
+            provider.Time = baseTime;
+            buffer.Add(CreatePacket(1, baseTime));
+            buffer.Add(CreatePacket(3, baseTime + TimeSpan.FromMilliseconds(100)));
+
+            AssertSequenceNumber(buffer, 1);
+            Assert.False(buffer.Get(out var p1));
+
+            provider.Time = baseTime + TimeSpan.FromMilliseconds(400);
+            
+            AssertSequenceNumber(buffer, 3);
+        }
+
+        [Fact]
+        public void ShouldSkipPacketAfterSpecifiedTimeoutWithWrapAround()
+        {
+            logger.LogDebug("--> " + System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+            var provider = new DatetimeProvider();
+            var baseTime = DateTime.Now;
+            var buffer = new RTPReorderBuffer(TimeSpan.FromMilliseconds(300), provider);
+
+            provider.Time = baseTime;
+            buffer.Add(CreatePacket(65534, baseTime));
+            buffer.Add(CreatePacket(0, baseTime + TimeSpan.FromMilliseconds(100)));
+
+            AssertSequenceNumber(buffer, 65534);
+            Assert.False(buffer.Get(out var p1));
+
+            buffer.Add(CreatePacket(65535, baseTime + TimeSpan.FromMilliseconds(200)));
+
+            AssertSequenceNumber(buffer, 65535);
+            AssertSequenceNumber(buffer, 0);
+        }
+
+        private void AssertSequenceNumber(RTPReorderBuffer buffer, ushort expected) {
+            Assert.True(buffer.Get(out var p1));
+            Assert.Equal(expected, p1.Header.SequenceNumber);
+        }
+
+        private RTPPacket CreatePacket(ushort seq, DateTime datetime = default) {
+            return new RTPPacket() { Header = new RTPHeader() { SequenceNumber = seq, ReceivedTime = datetime } };
+        }
+    }
+}


### PR DESCRIPTION
I added support for abs-capture-time RTP header extension. It enables us to know when exactly was media captured. Based on
https://webrtc.googlesource.com/src/+/refs/heads/main/docs/native-code/rtp-hdrext/abs-capture-time

Then I added reorder buffer into RTPSession. When reorder happened to RTP packet with Mark set in RTP header, then during decoding some artifacts shows. Now there is reorder buffer which wait specified time for packet with right sequential number.

I also added small refactor of OnReceive method inside RTPSession method. Because there were a lot of duplicate code and the refactor made easier for me to add reorder buffer feature. 

There are unit tests for all added functionality. Also tested with real connection with another peer.

I hope it make sense also to you to implement these features into sipsorcery