### PR TITLE
fix crash due to NullReferenceException

### DIFF
--- a/src/net/ICE/RtpIceChannel.cs
+++ b/src/net/ICE/RtpIceChannel.cs
@@ -729,7 +729,7 @@ namespace SIPSorcery.Net
             }
             if (_activeIceServer._uri.Scheme != STUNSchemesEnum.turn || NominatedEntry.LocalCandidate.IceServer is null)
             {
-                _refreshTurnTimer.Dispose();
+                _refreshTurnTimer?.Dispose();
                 return;
             }
             if (_activeIceServer.TurnTimeToExpiry.Subtract(DateTime.Now) <= TimeSpan.FromMinutes(1))


### PR DESCRIPTION
It will crash frequently in Linux(.Net6) caused by NullReferenceException, but never in windows(.Net6). So I guess the root cause is .Net6 runtime in Linux. I just do a minor change to fix it.

More details below:
Unhandled exception. System.NullReferenceException: Object reference not set to an instance of an object.
   at SIPSorcery.Net.RtpIceChannel.RefreshTurn(Object state)
   at System.Threading.TimerQueueTimer.<>c.<.cctor>b__27_0(Object state)
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
--- End of stack trace from previous location ---
   at System.Threading.TimerQueueTimer.CallCallback(Boolean isThreadPool)
   at System.Threading.TimerQueueTimer.Fire(Boolean isThreadPool)
   at System.Threading.TimerQueue.FireNextTimers()
Aborted (core dumped)
 