### PR TITLE
Use SIPSorceryMedia.Abstractions v1.1.0.2

### DIFF
--- a/src/SIPSorcery.csproj
+++ b/src/SIPSorcery.csproj
@@ -20,12 +20,13 @@
     <PackageReference Include="Portable.BouncyCastle" Version="1.8.10" />
     <PackageReference Include="DnsClient" Version="1.5.0" />
     <PackageReference Include="SIPSorcery.WebSocketSharp" Version="0.0.1" />
-    <PackageReference Include="SIPSorceryMedia.Abstractions" Version="1.1.0" />
+    <PackageReference Include="SIPSorceryMedia.Abstractions" Version="1.1.0.2" />
     <PackageReference Include="System.Net.WebSockets.Client" Version="4.3.2" />
   </ItemGroup>
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net461;net5.0;net6.0</TargetFrameworks>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Authors>Aaron Clauson &amp; Contributors</Authors>
     <Copyright>Copyright © 2010-2022 Aaron Clauson</Copyright>
     <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>

--- a/src/app/Media/VoIPMediaSession.cs
+++ b/src/app/Media/VoIPMediaSession.cs
@@ -266,9 +266,9 @@ namespace SIPSorcery.Media
             }
         }
 
-        private void VideoSinkSampleReady(byte[] buffer, uint width, uint height, int stride, VideoPixelFormatsEnum pixelFormat)
+        private void VideoSinkSampleReady(RawImage rawImage)
         {
-            OnVideoSinkSample?.Invoke(buffer, width, height, stride, pixelFormat);
+            OnVideoSinkSample?.Invoke(rawImage);
         }
 
         protected void RtpMediaPacketReceived(IPEndPoint remoteEndPoint, SDPMediaTypesEnum mediaType, RTPPacket rtpPacket)


### PR DESCRIPTION
### PR:
**SIPSorceryMedia.Abstractions** v1.1.0.2 use **RawImage** class.  Update this project in consequence

Since **VideoTestPatternSource** needs some encoding we have to use "**AllowUnsafeBlocks**" in the project.It should be better to create a package specific for this purpose