### PR TITLE
Allow RTP port range to be specified when creating VoIPMediaSession

### DIFF
--- a/src/app/Media/VoIPMediaSession.cs
+++ b/src/app/Media/VoIPMediaSession.cs
@@ -112,7 +112,8 @@ namespace SIPSorcery.Media
                 IsRtcpMultiplexed = false,
                 RtpSecureMediaOption = config.RtpSecureMediaOption,
                 BindAddress = config.BindAddress,
-                BindPort = config.BindPort
+                BindPort = config.BindPort,
+                RtpPortRange = config.RtpPortRange
             })
         {
             if (config.MediaEndPoint == null)

--- a/src/app/Media/VoIPMediaSessionConfig.cs
+++ b/src/app/Media/VoIPMediaSessionConfig.cs
@@ -15,6 +15,7 @@
 
 using System.Net;
 using SIPSorcery.Net;
+using SIPSorcery.Sys;
 using SIPSorceryMedia.Abstractions;
 
 namespace SIPSorcery.Media
@@ -30,5 +31,7 @@ namespace SIPSorcery.Media
         public RtpSecureMediaOptionEnum RtpSecureMediaOption { get; set; }
 
         public VideoTestPatternSource TestPatternSource { get; set; }
+
+        public PortRange RtpPortRange { get; set; }
     }
 }


### PR DESCRIPTION
Hello! I've noticed, there was added an option to specify RTP port range in this PR: https://github.com/sipsorcery-org/sipsorcery/pull/630

But there is no way to set port range when working with VoIPMediaSession, so this PR adds PortRange property to VoIPMediaSessionConfig

Sincerely,
Aleksei