### PR TITLE
Fix typo in SendRtcpFeedback

### DIFF
--- a/src/net/RTP/RTPSession.cs
+++ b/src/net/RTP/RTPSession.cs
@@ -1981,7 +1981,7 @@ namespace SIPSorcery.Net
             {
                 AudioStream.SendRtcpFeedback(feedback);
             }
-            else if (mediaType == SDPMediaTypesEnum.audio)
+            else if (mediaType == SDPMediaTypesEnum.video)
             {
                 VideoStream.SendRtcpFeedback(feedback);
             }


### PR DESCRIPTION
Hello!

Pretty sure it is a typo error. There was double `mediaType == SDPMediaTypesEnum.audio` check in `SendRtcpFeedback`