### PR TITLE
Prevent NullReferenceException on SIPRegistrationUserAgent.Stop

### DIFF
--- a/src/app/SIPUserAgents/SIPRegistrationUserAgent.cs
+++ b/src/app/SIPUserAgents/SIPRegistrationUserAgent.cs
@@ -153,6 +153,7 @@ namespace SIPSorcery.SIP.App
             m_registerFailureRetryInterval = registerFailureRetryInterval;
             m_maxRegisterAttempts = maxRegisterAttempts;
             m_exitOnUnequivocalFailure = exitOnUnequivocalFailure;
+            m_exit = true;
 
             // Setting the contact to "0.0.0.0" tells the transport layer to populate it at send time.
             m_contactURI = new SIPURI(m_sipAccountAOR.Scheme, IPAddress.Any, 0);
@@ -190,6 +191,7 @@ namespace SIPSorcery.SIP.App
             m_registerFailureRetryInterval = registerFailureRetryInterval;
             m_maxRegisterAttempts = maxRegisterAttempts;
             m_exitOnUnequivocalFailure = exitOnUnequivocalFailure;
+            m_exit = true;
         }
 
         public void Start()


### PR DESCRIPTION
Hello, I've noticed some bug, here is a fix:

There will be NullReferenceException if we call `Stop` on `SIPRegistrationUserAgent` without calling `Start`:

```
[sipsorcery:Error][T43] Exception SIPRegistrationUserAgent Stop. System.NullReferenceException: Object reference not set to an instance of an object.
   at SIPSorcery.SIP.App.SIPRegistrationUserAgent.Stop(Boolean sendZeroExpiryRegister) in /_/src/app/SIPUserAgents/SIPRegistrationUserAgent.cs:line 310 
```

There is a check for `m_exit` flag, but default value is `false`. So this method will try to stop registration agent even it was not started

Probably related to https://github.com/sipsorcery-org/sipsorcery/issues/737