### PR TITLE
Implement round trip measurement for SCTP

### DIFF
--- a/test/unit/net/SCTP/SctpDataSendRecvUnitTest.cs
+++ b/test/unit/net/SCTP/SctpDataSendRecvUnitTest.cs
@@ -91,6 +91,8 @@ namespace SIPSorcery.Net.UnitTests
 
             SctpDataReceiver receiver = new SctpDataReceiver(arwnd, mtu, initialTSN);
             SctpDataSender sender = new SctpDataSender("dummy", null, mtu, initialTSN, arwnd);
+            sender._rtoInitialMilliseconds = 300;
+            sender._rtoMinimumMilliseconds = 300;
             sender.StartSending();
 
             // This local function replicates a data chunk being sent from a data

--- a/test/unit/net/SCTP/SctpDataSenderUnitTest.cs
+++ b/test/unit/net/SCTP/SctpDataSenderUnitTest.cs
@@ -103,12 +103,13 @@ namespace SIPSorcery.Net.UnitTests
             SctpDataReceiver receiver = new SctpDataReceiver(arwnd, mtu, initialTSN);
             SctpDataSender sender = new SctpDataSender("dummy", null, mtu, initialTSN, arwnd);
             sender._burstPeriodMilliseconds = 1;
-            sender._rtoInitialMilliseconds = 1;
-            sender._rtoMinimumMilliseconds = 1;
+            sender._rtoInitialMilliseconds = 20;
+            sender._rtoMinimumMilliseconds = 20;
+            sender._rtoMaximumMilliseconds = 100;
 
             Action<SctpDataChunk> reluctantSender = (chunk) =>
             {
-                if (chunk.TSN % 10 == 0)
+                if (chunk.TSN % 5 == 0)
                 {
                     receiver.OnDataChunk(chunk);
                     sender.GotSack(receiver.GetSackChunk());
@@ -127,7 +128,7 @@ namespace SIPSorcery.Net.UnitTests
                 sender.SendData(0, 0, buffer);
             }
 
-            await Task.Delay(500);
+            await Task.Delay(200);
 
             Assert.Equal(SctpDataSender.CONGESTION_WINDOW_FACTOR + mtu, sender._congestionWindow);
         }


### PR DESCRIPTION
Finishing off the TODO in the code. 
Helps avoid resending the same unconfirmed chunk(s) repeatedly when latency is present. 