### PR TITLE
Respect RTCDataChannelInit negotiated setting when opening data channel

### DIFF
--- a/src/net/WebRTC/RTCDataChannel.cs
+++ b/src/net/WebRTC/RTCDataChannel.cs
@@ -89,7 +89,17 @@ namespace SIPSorcery.Net
         {
             _transport = transport;
 
-            // TODO: Apply init settings.
+            if (init == null) {
+                return;
+            }
+            // TODO: Utilize ordered, maxPacketLifeTime, maxRetransmits, andprotocol;
+            ordered = init.ordered;
+            maxPacketLifeTime = init.maxPacketLifeTime;
+            maxRetransmits = init.maxRetransmits;
+            protocol = init.protocol;
+            
+            negotiated = init.negotiated;
+            id = init.id;
         }
 
         internal void GotAck()

--- a/src/net/WebRTC/RTCPeerConnection.cs
+++ b/src/net/WebRTC/RTCPeerConnection.cs
@@ -1637,7 +1637,11 @@ namespace SIPSorcery.Net
         /// <param name="dataChannel">The data channel to open.</param>
         private void OpenDataChannel(RTCDataChannel dataChannel)
         {
-            if (dataChannel.id.HasValue)
+            if (dataChannel.negotiated) {
+                logger.LogDebug($"WebRTC data channel negotiated out of band with label {dataChannel.label} and stream ID {dataChannel.id}; invoking open event");
+                dataChannel.GotAck();
+            }
+            else if (dataChannel.id.HasValue)
             {
                 logger.LogDebug($"WebRTC attempting to open data channel with label {dataChannel.label} and stream ID {dataChannel.id}.");
                 dataChannel.SendDcepOpen();


### PR DESCRIPTION
This now allows for creating a data channel that is negotiated out of band. Prior to this, the DCEP messages were being sent which the other side will not expect and will most likely fail.