### PR TITLE
Fix datachannel initialization

### DIFF
--- a/src/net/WebRTC/IRTCDataChannel.cs
+++ b/src/net/WebRTC/IRTCDataChannel.cs
@@ -166,11 +166,11 @@ namespace SIPSorcery.Net
 
     public class RTCDataChannelInit
     {
-        public bool ordered { get; set; }
-        public ushort maxPacketLifeTime { get; set; }
-        public ushort maxRetransmits { get; set; }
+        public bool? ordered { get; set; }
+        public ushort? maxPacketLifeTime { get; set; }
+        public ushort? maxRetransmits { get; set; }
         public string protocol { get; set; }
-        public bool negotiated { get; set; }
-        public ushort id { get; set; }
+        public bool? negotiated { get; set; }
+        public ushort? id { get; set; }
     };
 }

--- a/src/net/WebRTC/RTCDataChannel.cs
+++ b/src/net/WebRTC/RTCDataChannel.cs
@@ -92,13 +92,12 @@ namespace SIPSorcery.Net
             if (init == null) {
                 return;
             }
-            // TODO: Utilize ordered, maxPacketLifeTime, maxRetransmits, andprotocol;
-            ordered = init.ordered;
+            // TODO: Utilize ordered, maxPacketLifeTime, maxRetransmits, and protocol;
+            ordered = init.ordered ?? true;
             maxPacketLifeTime = init.maxPacketLifeTime;
             maxRetransmits = init.maxRetransmits;
-            protocol = init.protocol;
-            
-            negotiated = init.negotiated;
+            protocol = init.protocol ?? "";
+            negotiated = init.negotiated ?? false;
             id = init.id;
         }
 

--- a/test/unit/net/SCTP/SctpDataSendRecvUnitTest.cs
+++ b/test/unit/net/SCTP/SctpDataSendRecvUnitTest.cs
@@ -91,8 +91,9 @@ namespace SIPSorcery.Net.UnitTests
 
             SctpDataReceiver receiver = new SctpDataReceiver(arwnd, mtu, initialTSN);
             SctpDataSender sender = new SctpDataSender("dummy", null, mtu, initialTSN, arwnd);
-            sender._rtoInitialMilliseconds = 300;
-            sender._rtoMinimumMilliseconds = 300;
+            sender._rtoInitialMilliseconds = 250;
+            sender._rtoMinimumMilliseconds = 250;
+            sender._rtoMaximumMilliseconds = 250;
             sender.StartSending();
 
             // This local function replicates a data chunk being sent from a data
@@ -113,7 +114,7 @@ namespace SIPSorcery.Net.UnitTests
 
             sender.SendData(0, 0, new byte[] { 0x55 });
             Assert.Equal(initialTSN + 1, sender.TSN);
-            await Task.Delay(250);
+            await Task.Delay(100);
             Assert.Null(receiver.CumulativeAckTSN);
 
             await Task.Delay(500);
@@ -127,7 +128,7 @@ namespace SIPSorcery.Net.UnitTests
 
             sender.SendData(0, 0, new byte[] { 0x55 });
             Assert.Equal(initialTSN + 3, sender.TSN);
-            await Task.Delay(250);
+            await Task.Delay(100);
             Assert.Equal(initialTSN + 2, receiver.CumulativeAckTSN);
         }
 


### PR DESCRIPTION
This PR fixes a breaking bug from https://github.com/sipsorcery-org/sipsorcery/pull/783 where datachannels were initialized with Id "0" when unspecified instead of "null".

It also applies the correct default values for[ `RTCDataChannelInit`](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/createDataChannel)