### PR TITLE
SCTP fix duplicate TSNs being resent

### DIFF
--- a/src/net/SCTP/SctpDataSender.cs
+++ b/src/net/SCTP/SctpDataSender.cs
@@ -256,6 +256,19 @@ namespace SIPSorcery.Net
                         }
                     }
 
+                    if (sack.DuplicateTSN.Count > 0)
+                    {
+                        // The remote is reporting that we have sent a duplicate TSN. 
+                        // This is probably because a SACK chunk was dropped. 
+                        // Ensure that we stop sending the duplicate.
+                        foreach (uint duplicateTSN in sack.DuplicateTSN)
+                        {
+                            _unconfirmedChunks.TryRemove(duplicateTSN, out _);
+                            _missingChunks.TryRemove(duplicateTSN, out _);
+                        }
+                    }
+
+
                     // Check gap reports. Only process them if the cumulative ACK TSN was acceptable.
                     if (processGapReports && sack.GapAckBlocks.Count > 0)
                     {


### PR DESCRIPTION
In real-world high-throughput scenarios and testing with [clumsy](https://jagt.github.io/clumsy) we've been running into an issue where the SCTP sender would get stuck repeatedly sending duplicate TSNs. 

Due to the trouble in isolating the exact cause I suspect this is due to a concurrency issue in the sender class where `_unconfirmedChunks` and/or `_missingChunks` are not correctly removed following a `SACK`. It is easy to repeat by increasing the lossy scenarios with clumsy, but difficult to repeat with low throughput or stable network conditions.

Rather than affecting performance with the addition of thread locks, this simple solution responds to the already included `SctpSackChunk.DuplicateTSN` reports to clean out the chunk dictionaries and resolves this issue.

