### PR TITLE
SIPResponse.Copy copies body

### DIFF
--- a/src/core/SIP/SIPResponse.cs
+++ b/src/core/SIP/SIPResponse.cs
@@ -213,7 +213,7 @@ namespace SIPSorcery.SIP
             if (_body != null && _body.Length > 0)
             {
                 copy._body = new byte[_body.Length];
-                Buffer.BlockCopy(copy._body, 0, copy._body, 0, copy._body.Length);
+                Buffer.BlockCopy(_body, 0, copy._body, 0, copy._body.Length);
             }
 
             copy.Created = Created;

--- a/test/unit/core/SIP/SIPResponseUnitTest.cs
+++ b/test/unit/core/SIP/SIPResponseUnitTest.cs
@@ -463,6 +463,33 @@ namespace SIPSorcery.SIP.UnitTests
             Assert.Equal(0, resp.Header.CSeq);
             Assert.True(Regex.Match(resp.ToString(), "CSeq: 0 OPTIONS", RegexOptions.Multiline).Success);
         }
+
+        [Fact]
+        public void SipResponseCopy()
+        {
+            SIPURI uri = new SIPURI("dummy", "dummy", null, SIPSchemesEnum.sip, SIPProtocolsEnum.udp);
+            SIPRequest req = SIPRequest.GetRequest(SIPMethodsEnum.INVITE, uri);
+
+            var resp = SIPResponse.GetResponse(req, SIPResponseStatusCodesEnum.Ok, null);
+
+            resp.Body = "test";
+
+            var copy = resp.Copy();
+
+            Assert.Equal(resp.SIPVersion, copy.SIPVersion);
+            Assert.Equal(resp.Status, copy.Status);
+            Assert.Equal(resp.StatusCode, copy.StatusCode);
+            Assert.Equal(resp.ReasonPhrase, copy.ReasonPhrase);
+            Assert.Equal(resp.Header?.ToString(), copy.Header?.ToString());
+            Assert.Equal(resp.SIPEncoding, copy.SIPEncoding);
+            Assert.Equal(resp.SIPBodyEncoding, copy.SIPBodyEncoding);
+            Assert.Equal(resp.BodyBuffer, copy.BodyBuffer);
+            Assert.Equal(resp.Created, copy.Created);
+            Assert.Equal(resp.LocalSIPEndPoint, copy.LocalSIPEndPoint);
+            Assert.Equal(resp.RemoteSIPEndPoint, copy.RemoteSIPEndPoint);
+            Assert.Equal(resp.SendFromHintChannelID, copy.SendFromHintChannelID);
+            Assert.Equal(resp.SendFromHintConnectionID, copy.SendFromHintConnectionID);
+        }
     }
 
 #pragma warning restore SYSLIB0021


### PR DESCRIPTION
Fix a bug where SipResponse.Copy did not copy the message body