### PR TITLE
Enable parsing SIP packets using RFC5031 URI starting with urn: 

### DIFF
--- a/src/core/SIP/SIPConstants.cs
+++ b/src/core/SIP/SIPConstants.cs
@@ -147,6 +147,7 @@ namespace SIPSorcery.SIP
         sip = 1,
         sips = 2,
         tel = 3,
+        urn = 4,
     }
 
     public static class SIPSchemesType


### PR DESCRIPTION
Such as described in https://datatracker.ietf.org/doc/html/rfc5031 URI can start with urn: which acts exactly like other URIs but with known words.