### PR TITLE
Join transaction polling thread: fix ObjectDisposedException

### DIFF
--- a/src/core/SIPTransactions/SIPTransactionEngine.cs
+++ b/src/core/SIPTransactions/SIPTransactionEngine.cs
@@ -83,7 +83,7 @@ namespace SIPSorcery.SIP
 
         public void AddTransaction(SIPTransaction sipTransaction)
         {
-            if (m_disposed)
+            if (m_disposed || m_isClosed)
             {
                 return;
             }
@@ -263,8 +263,11 @@ namespace SIPSorcery.SIP
 
         public void Shutdown()
         {
-            m_isClosed = true;
-            m_newPendingTransactionEvent.Set();
+            if (!m_isClosed)
+            {
+                m_isClosed = true;
+                m_newPendingTransactionEvent.Set();
+            }
         }
 
         /// <summary>
@@ -748,8 +751,7 @@ namespace SIPSorcery.SIP
 
                 if (disposing)
                 {
-                    // Actually m_newPendingTransactionEvent.Set() is called on Shutdown(). Call it again just to be safe and make thread join faster
-                    m_newPendingTransactionEvent.Set();
+                    Shutdown();
                     m_transactionPollingThread.Join();
                     m_newPendingTransactionEvent.Dispose();
                 }


### PR DESCRIPTION
Hello, in PR https://github.com/sipsorcery-org/sipsorcery/pull/794 I've introduced ObjectDisposedException, as @DavidMartynWood noticed. So there is a draft that can improve the situation.
Is it ok, if we replace Thread created by ThreadPool (Task.Factory.StartNew) with native thread, that can be joined synchronously?
@sipsorcery, of course if you don't mind waiting a bit for transaction polling thread to complete.

In my scenario application creates many instances of SIPTransport and can free any of them at any time. That's why I care about memory leaks and proper dispose of SIPTransport

If it conflicts with vision of SIPSorcery library, then ok, I can maintain a fork with this kind of behaviour. But part which checks if TransactionEngine was disposed at AddTransaction can be handy anyways