### PR TITLE
Fix the bodyStartPos in the ParseSIPMessage Method. Fix the SIPUserAgent.OnCallHungup Event was not triggered when hanging up

### DIFF
--- a/src/app/SIPUserAgents/SIPUserAgent.cs
+++ b/src/app/SIPUserAgents/SIPUserAgent.cs
@@ -1565,6 +1565,7 @@ namespace SIPSorcery.SIP.App
             _ringTimeout?.Dispose();
 
             ClientCallFailed?.Invoke(uac, errorMessage, sipResponse);
+            CallEnded(uac.CallDescriptor?.CallId); 
         }
 
         /// <summary>

--- a/src/core/SIP/Channels/SIPUDPChannel.cs
+++ b/src/core/SIP/Channels/SIPUDPChannel.cs
@@ -69,7 +69,7 @@ namespace SIPSorcery.SIP
             IPEndPoint endPoint,
             Encoding sipEncoding,
             Encoding sipBodyEncoding,
-            bool useDualMode=false) : base(sipEncoding, sipBodyEncoding)
+            bool useDualMode = false) : base(sipEncoding, sipBodyEncoding)
         {
             if (endPoint == null)
             {
@@ -113,7 +113,13 @@ namespace SIPSorcery.SIP
                 m_udpSocket.BeginReceiveFrom(m_recvBuffer, 0, m_recvBuffer.Length, SocketFlags.None, ref recvEndPoint, EndReceiveFrom, null);
             }
             catch (ObjectDisposedException) { } // Thrown when socket is closed. Can be safely ignored.
-            catch (Exception excp)
+            catch (SocketException socketException)
+            {
+                //ignored.
+                logger.LogError(socketException, $"SocketException Receive. {socketException.Message}");
+                EndReceiveFrom(null);
+            }
+            catch (Exception excp) when (excp is ArgumentException || excp is ArgumentNullException || excp is ArgumentOutOfRangeException || excp is InvalidOperationException)
             {
                 // From https://github.com/dotnet/corefx/blob/e99ec129cfd594d53f4390bf97d1d736cff6f860/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs#L3056
                 // the BeginReceiveMessageFrom will only throw if there is an problem with the arguments or the socket has been disposed of. In that

--- a/src/core/SIP/SIPMessageBuffer.cs
+++ b/src/core/SIP/SIPMessageBuffer.cs
@@ -86,10 +86,10 @@ namespace SIPSorcery.SIP
         /// <param name="sipEncoding">SIP protocol encoding, according to RFC should be UTF-8 </param>
         /// <returns>If successful a SIP message or null if not.</returns>
         public static SIPMessageBuffer ParseSIPMessage(
-            byte[] buffer, 
+            byte[] buffer,
             Encoding sipEncoding,
             Encoding sipBodyEncoding,
-            SIPEndPoint localSIPEndPoint, 
+            SIPEndPoint localSIPEndPoint,
             SIPEndPoint remoteSIPEndPoint)
         {
 
@@ -109,7 +109,7 @@ namespace SIPSorcery.SIP
             }
             else
             {
-                var sipMessage = new SIPMessageBuffer(sipEncoding,sipBodyEncoding);
+                var sipMessage = new SIPMessageBuffer(sipEncoding, sipBodyEncoding);
 
                 sipMessage.RawBuffer = buffer;
                 sipMessage.LocalSIPEndPoint = localSIPEndPoint;
@@ -137,6 +137,7 @@ namespace SIPSorcery.SIP
                         sipMessage.SIPMessageType = SIPMessageTypesEnum.Request;
                     }
 
+                    //index of \r\n\r\n in the string,is not exactly the position in bytes buffer
                     int endHeaderPosn = message.IndexOf(m_CRLF + m_CRLF);
                     if (endHeaderPosn == -1)
                     {
@@ -151,8 +152,9 @@ namespace SIPSorcery.SIP
 
                         if (message.Length > endHeaderPosn + 4)
                         {
-                            sipMessage.Body = new byte[buffer.Length - (endHeaderPosn + 4)];
-                            Buffer.BlockCopy(buffer, endHeaderPosn + 4, sipMessage.Body, 0, buffer.Length - (endHeaderPosn + 4));
+                            var bodyStartPos = sipEncoding.GetByteCount(headerString) + sipEncoding.GetByteCount(sipMessage.FirstLine) + 2 + 4;
+                            sipMessage.Body = new byte[buffer.Length - bodyStartPos];
+                            Buffer.BlockCopy(buffer, bodyStartPos, sipMessage.Body, 0, sipMessage.Body.Length);
                         }
                     }
 
@@ -186,10 +188,10 @@ namespace SIPSorcery.SIP
             string message,
             Encoding sipEncoding,
             Encoding sipBodyEncoding,
-            SIPEndPoint localSIPEndPoint, 
+            SIPEndPoint localSIPEndPoint,
             SIPEndPoint remoteSIPEndPoint)
         {
-            return ParseSIPMessage(sipEncoding.GetBytes(message), sipEncoding,sipBodyEncoding, localSIPEndPoint, remoteSIPEndPoint);
+            return ParseSIPMessage(sipEncoding.GetBytes(message), sipEncoding, sipBodyEncoding, localSIPEndPoint, remoteSIPEndPoint);
         }
 
         //rj2: check if message could be "well"known Ping message
@@ -246,8 +248,8 @@ namespace SIPSorcery.SIP
         /// <returns>A byte array holding a full SIP message or if no full SIP messages are available null.</returns>
         public static byte[] ParseSIPMessageFromStream(
             byte[] receiveBuffer,
-            int start, 
-            int length, 
+            int start,
+            int length,
             Encoding sipEncoding,
             out int bytesSkipped)
         {
@@ -299,7 +301,7 @@ namespace SIPSorcery.SIP
         /// <param name="end">The position in the buffer to stop the search at.</param>
         /// <param name="sipEncoding"></param>
         /// <returns>If the Content-Length header is found the value if contains otherwise 0.</returns>
-        public static int GetContentLength(byte[] buffer, int start, int end,Encoding sipEncoding)
+        public static int GetContentLength(byte[] buffer, int start, int end, Encoding sipEncoding)
         {
             if (buffer == null || start > end || buffer.Length < end)
             {

--- a/src/sys/Net/NetServices.cs
+++ b/src/sys/Net/NetServices.cs
@@ -113,7 +113,8 @@ namespace SIPSorcery.Sys
                 // TODO: Reset if the local network interfaces change.
                 if (_localIPAddresses == null)
                 {
-                    _localIPAddresses = NetServices.GetAllLocalIPAddresses();
+                    //_localIPAddresses = NetServices.GetAllLocalIPAddresses();
+                    _localIPAddresses = Dns.GetHostAddresses(string.Empty).ToList(); //SCT 解决安卓系统获取不到本地IP地址的问题
                 }
 
                 return _localIPAddresses;


### PR DESCRIPTION
Fix the bodyStartPos in the ParseSIPMessage Method when the FromName or ToName is Chinese