### PR TITLE
When SIP.Authorization is not the value specified in the RFC, the original value is stored to provide the ability for the application to handle it by itself.

### DIFF
--- a/src/core/SIP/SIPAuthorisationDigest.cs
+++ b/src/core/SIP/SIPAuthorisationDigest.cs
@@ -40,6 +40,7 @@ namespace SIPSorcery.SIP
 
     public class SIPAuthorisationDigest
     {
+        public const string METHOD = "Digest";
         public const string QOP_AUTHENTICATION_VALUE = "auth";
         private const int NONCE_DEFAULT_COUNT = 1;
         private const string SHA256_ALGORITHM_ID = "SHA-256";
@@ -48,7 +49,7 @@ namespace SIPSorcery.SIP
 
         private static char[] m_headerFieldRemoveChars = new char[] { ' ', '"', '\'' };
 
-        public SIPAuthorisationHeadersEnum AuthorisationType { get; private set; }              // This is the type of authorisation request received.
+        public SIPAuthorisationHeadersEnum AuthorisationType { get; private set; } // This is the type of authorisation request received.
         public SIPAuthorisationHeadersEnum AuthorisationResponseType { get; private set; }      // If this is set it's the type of authorisation response to use otherwise use the same as the request (God knows why you need a different response header?!?)
 
         public string Realm;
@@ -84,7 +85,7 @@ namespace SIPSorcery.SIP
         {
             SIPAuthorisationDigest authRequest = new SIPAuthorisationDigest(authorisationType);
 
-            string noDigestHeader = Regex.Replace(authorisationRequest, @"^\s*Digest\s*", "", RegexOptions.IgnoreCase);
+            string noDigestHeader = Regex.Replace(authorisationRequest, $@"^\s*{METHOD}\s*", "", RegexOptions.IgnoreCase);
             string[] headerFields = noDigestHeader.Split(',');
 
             if (headerFields != null && headerFields.Length > 0)

--- a/src/core/SIP/SIPHeader.cs
+++ b/src/core/SIP/SIPHeader.cs
@@ -822,30 +822,44 @@ namespace SIPSorcery.SIP
     public class SIPAuthenticationHeader
     {
         public SIPAuthorisationDigest SIPDigest;
-
-        private SIPAuthenticationHeader()
+        public string Value;
+        
+        private SIPAuthenticationHeader():this(new SIPAuthorisationDigest())
         {
-            SIPDigest = new SIPAuthorisationDigest();
         }
 
         public SIPAuthenticationHeader(SIPAuthorisationDigest sipDigest)
         {
             SIPDigest = sipDigest;
+            Value = string.Empty;
         }
 
         public SIPAuthenticationHeader(SIPAuthorisationHeadersEnum authorisationType, string realm, string nonce)
         {
-            SIPDigest = new SIPAuthorisationDigest(authorisationType);
-            SIPDigest.Realm = realm;
-            SIPDigest.Nonce = nonce;
+            SIPDigest = new SIPAuthorisationDigest(authorisationType)
+            {
+                Realm = realm,
+                Nonce = nonce
+            };
+            Value = string.Empty;
         }
 
         public static SIPAuthenticationHeader ParseSIPAuthenticationHeader(SIPAuthorisationHeadersEnum authorizationType, string headerValue)
         {
             try
             {
-                SIPAuthenticationHeader authHeader = new SIPAuthenticationHeader();
-                authHeader.SIPDigest = SIPAuthorisationDigest.ParseAuthorisationDigest(authorizationType, headerValue);
+                var authHeader = new SIPAuthenticationHeader
+                {
+                    Value = headerValue
+                };
+                if (headerValue.StartsWith(SIPAuthorisationDigest.METHOD))
+                {
+                    authHeader.SIPDigest = SIPAuthorisationDigest.ParseAuthorisationDigest(authorizationType, headerValue);
+                }
+                else
+                {
+                    authHeader.SIPDigest = new SIPAuthorisationDigest(SIPAuthorisationHeadersEnum.Unknown);
+                }
                 return authHeader;
             }
             catch


### PR DESCRIPTION
Solve the scene:
An extended private protocol based on the SIP protocol, adding a custom field to the Authorization field.