### PR TITLE
Fix crash when using SipSorcery in Android devices.

### DIFF
--- a/src/SIPSorcery.csproj
+++ b/src/SIPSorcery.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.1;net461;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.1;net461;net5.0;net6.0;net6.0-android</TargetFrameworks>
     <Authors>Aaron Clauson, Christophe Irles, Rafael Soares &amp; Contributors</Authors>
     <Copyright>Copyright © 2010-2022 Aaron Clauson</Copyright>
     <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>


### PR DESCRIPTION
Workaround for .NET 6 issue 75809: https://github.com/dotnet/runtime/issues/75809

This produces a crash when using SipSorcery on Android devices, as the retrieval of all network interfaces creates an internal crash.