### PR TITLE
Fix errors in sipcmdline to make appveyor pass

### DIFF
--- a/examples/sipcmdline/Program.cs
+++ b/examples/sipcmdline/Program.cs
@@ -519,20 +519,23 @@ namespace SIPSorcery
                 bool result = false;
                 ManualResetEvent mre = new ManualResetEvent(false);
 
-                ua.RegistrationFailed += (uri, err) =>
+                ua.RegistrationFailed += (uri, err, msg) =>
                 {
                     result = false;
                     mre.Set();
+                    logger.LogDebug(msg);
                 };
                 ua.RegistrationTemporaryFailure += (uri, err) =>
                 {
                     result = false;
                     mre.Set();
+                    logger.LogDebug(msg);
                 };
                 ua.RegistrationSuccessful += (uri) =>
                 {
                     result = true;
                     mre.Set();
+                    logger.LogDebug(msg);
                 };
 
                 ua.Start();


### PR DESCRIPTION
AppVeyor pipeline is complaining about this issue. If I am not mistaken this blocks this library from being published to nuget repository. 