### PR TITLE
Fix SIP/TLS RINGING not sent after TRYING (#889)

### DIFF
--- a/src/core/SIP/Channels/SIPStreamConnection.cs
+++ b/src/core/SIP/Channels/SIPStreamConnection.cs
@@ -50,7 +50,7 @@ namespace SIPSorcery.SIP
         /// For secure streams the TCP connection will be upgraded to an SSL stream and the SslStreamBuffer will
         /// be used for receives.
         /// </summary>
-        public SslStream SslStream;
+        public SIPStreamWrapper SslStream;
 
         /// <summary>
         /// The receive buffer to use for SSL streams.

--- a/src/core/SIP/Channels/SIPStreamWrapper.cs
+++ b/src/core/SIP/Channels/SIPStreamWrapper.cs
@@ -1,0 +1,114 @@
+//-----------------------------------------------------------------------------
+// Filename: SIPStreamWrapper.cs
+//
+// Description: Helper class for Stream with a thread-safe function WriteAsync.
+//
+// Author(s):
+// Steffen Liersch (https://www.steffen-liersch.de/)
+//
+// History:
+// 20 Feb 2023	Steffen Liersch           Created
+//
+// License: 
+// BSD 3-Clause "New" or "Revised" License, see included LICENSE.md file.
+//-----------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace SIPSorcery.SIP
+{
+    public sealed class SIPStreamWrapper : IDisposable
+    {
+        private readonly object m_syncRoot = new object();
+        private readonly Queue<Request> m_pendingRequests = new Queue<Request>();
+        private readonly Stream m_stream;
+        private bool m_isInProgress;
+
+        public SIPStreamWrapper(Stream stream) => m_stream = stream ?? throw new ArgumentNullException(nameof(stream));
+
+        public void Dispose() => m_stream.Dispose();
+
+        public IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback callback, object state)
+          => m_stream.BeginRead(buffer, offset, count, callback, state);
+
+        public int EndRead(IAsyncResult asyncResult) => m_stream.EndRead(asyncResult);
+
+        public Task WriteAsync(byte[] buffer, int offset, int count)
+        {
+            lock (m_syncRoot)
+            {
+                if (m_isInProgress)
+                {
+                    var req = new Request(buffer, offset, count);
+                    m_pendingRequests.Enqueue(req);
+                    return req.Task;
+                }
+
+                m_isInProgress = true;
+            }
+
+            var task = m_stream.WriteAsync(buffer, offset, count);
+            task.ContinueWith(x => TrySendNextFromQueue(), TaskContinuationOptions.RunContinuationsAsynchronously);
+            return task;
+        }
+
+        private void TrySendNextFromQueue()
+        {
+            Request request;
+            lock (m_syncRoot)
+            {
+                if (m_pendingRequests.Count <= 0)
+                {
+                    m_isInProgress = false;
+                    return;
+                }
+
+                request = m_pendingRequests.Dequeue();
+            }
+
+            Task task = m_stream.WriteAsync(request.Buffer, request.Offset, request.Count);
+            task.ContinueWith(x => HandleEndOfQueuedRequest(request, task));
+            // TaskContinuationOptions.RunContinuationsAsynchronously is not necessary here!
+        }
+
+        private void HandleEndOfQueuedRequest(Request request, Task task)
+        {
+            request.SetStatus(task);
+            TrySendNextFromQueue();
+        }
+
+        private class Request
+        {
+            public readonly byte[] Buffer;
+            public readonly int Offset;
+            public readonly int Count;
+
+            public Task Task => m_tcs.Task;
+            private readonly TaskCompletionSource<bool> m_tcs;
+
+            public Request(byte[] buffer, int offset, int count)
+            {
+                Buffer = buffer ?? throw new ArgumentNullException(nameof(buffer));
+                Offset = offset;
+                Count = count;
+                m_tcs = new TaskCompletionSource<bool>();
+            }
+
+            public void SetStatus(Task task)
+            {
+                AggregateException e = task.Exception;
+                if (e != null)
+                {
+                    m_tcs.SetException(e);
+                }
+                else
+                {
+                    m_tcs.SetResult(true);
+                }
+            }
+        }
+    }
+}

--- a/src/core/SIP/Channels/SIPTLSChannel.cs
+++ b/src/core/SIP/Channels/SIPTLSChannel.cs
@@ -108,7 +108,7 @@ namespace SIPSorcery.SIP
             //sslStream.ReadTimeout = 5000;
             //sslStream.WriteTimeout = 5000;
 
-            streamConnection.SslStream = sslStream;
+            streamConnection.SslStream = new SIPStreamWrapper(sslStream);
             streamConnection.SslStreamBuffer = new byte[2 * SIPStreamConnection.MaxSIPTCPMessageSize];
 
             sslStream.BeginRead(streamConnection.SslStreamBuffer, 0, SIPStreamConnection.MaxSIPTCPMessageSize, new AsyncCallback(OnReadCallback), streamConnection);
@@ -139,7 +139,7 @@ namespace SIPSorcery.SIP
                 }
                 else
                 {
-                    streamConnection.SslStream = sslStream;
+                    streamConnection.SslStream = new SIPStreamWrapper(sslStream);
                     streamConnection.SslStreamBuffer = new byte[2 * SIPStreamConnection.MaxSIPTCPMessageSize];
 
                     logger.LogDebug($"SIP TLS Channel successfully upgraded client connection to SSL stream for {ListeningSIPEndPoint}->{streamConnection.RemoteSIPEndPoint}.");
@@ -217,12 +217,7 @@ namespace SIPSorcery.SIP
         {
             try
             {
-                lock (sipStreamConn.SslStream)
-                {
-                    var t = sipStreamConn.SslStream.WriteAsync(buffer, 0, buffer.Length);
-                    t.Wait();
-                    return t;
-                }
+                return sipStreamConn.SslStream.WriteAsync(buffer, 0, buffer.Length);
             }
             catch (SocketException sockExcp)
             {

--- a/src/core/SIP/Channels/SIPTLSChannel.cs
+++ b/src/core/SIP/Channels/SIPTLSChannel.cs
@@ -217,7 +217,12 @@ namespace SIPSorcery.SIP
         {
             try
             {
-                return sipStreamConn.SslStream.WriteAsync(buffer, 0, buffer.Length);
+                lock (sipStreamConn.SslStream)
+                {
+                    var t = sipStreamConn.SslStream.WriteAsync(buffer, 0, buffer.Length);
+                    t.Wait();
+                    return t;
+                }
             }
             catch (SocketException sockExcp)
             {


### PR DESCRIPTION
The workaround has been proven to work in production.

When using SIP/TLS on an incoming call, RINGING after TRYING may not be sent over the network. Instead, the following exception occurs:

```
System.NotSupportedException: The BeginWrite method cannot be called when another write operation is pending.
   at System.Net.Security._SslStream.ProcessWrite(Byte[] buffer, Int32 offset, Int32 count, AsyncProtocolRequest asyncRequest)
   at System.Net.Security._SslStream.BeginWrite(Byte[] buffer, Int32 offset, Int32 count, AsyncCallback asyncCallback, Object asyncState)
   at System.IO.Stream.<>c.<BeginEndWriteAsync>b__53_0(Stream stream, ReadWriteParameters args, AsyncCallback callback, Object state)
   at System.Threading.Tasks.TaskFactory`1.FromAsyncTrim[TInstance,TArgs](TInstance thisRef, TArgs args, Func`5 beginMethod, Func`3 endMethod)
   at System.IO.Stream.BeginEndWriteAsync(Byte[] buffer, Int32 offset, Int32 count)
   at System.IO.Stream.WriteAsync(Byte[] buffer, Int32 offset, Int32 count, CancellationToken cancellationToken)
   at System.IO.Stream.WriteAsync(Byte[] buffer, Int32 offset, Int32 count)
   at SIPSorcery.SIP.SIPTLSChannel.SendOnConnected(SIPStreamConnection sipStreamConn, Byte[] buffer)
   at SIPSorcery.SIP.SIPTCPChannel.SendSecureAsync(SIPEndPoint dstSIPEndPoint, Byte[] buffer, String serverCertificateName, Boolean
```
