### PR TITLE
GetMediaStream(uint) works with multiple streams

### DIFF
--- a/src/net/RTP/RTPSession.cs
+++ b/src/net/RTP/RTPSession.cs
@@ -2207,21 +2207,6 @@ namespace SIPSorcery.Net
 
         private MediaStream GetMediaStream(uint ssrc)
         {
-            if (HasAudio)
-            {
-                if (!HasVideo)
-                {
-                    return AudioStream;
-                }
-            }
-            else
-            {
-                if (HasVideo)
-                {
-                    return VideoStream;
-                }
-            }
-
             foreach (var audioStream in AudioStreamList)
             {
                 if (audioStream?.RemoteTrack?.IsSsrcMatch(ssrc) == true)

--- a/src/net/RTP/RTPSession.cs
+++ b/src/net/RTP/RTPSession.cs
@@ -2231,7 +2231,28 @@ namespace SIPSorcery.Net
                 }
             }
 
-            return GetMediaStreamRemoteSDPSsrcAttributes(ssrc);
+            var stream = GetMediaStreamRemoteSDPSsrcAttributes(ssrc);
+            if (stream != null)
+            {
+                return stream;
+            }
+
+            if (HasAudio)
+            {
+                if (!HasVideo)
+                {
+                    return AudioStream;
+                }
+            }
+            else
+            {
+                if (HasVideo)
+                {
+                    return VideoStream;
+                }
+            }
+
+            return null;
         }
 
         private MediaStream GetMediaStreamRemoteSDPSsrcAttributes(uint ssrc)


### PR DESCRIPTION
Fix: Previously, when multiple tracks of one type(audio/video) were active and none of the other.
GetMediaStream(uint) would return wrong mediastreams.

https://github.com/sipsorcery-org/sipsorcery/issues/898