### PR TITLE
Fix dead code in SendRequestAsync and SendResponseAsync

### DIFF
--- a/src/SIPSorcery.csproj
+++ b/src/SIPSorcery.csproj
@@ -18,7 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="Portable.BouncyCastle" Version="1.9.0" />
-    <PackageReference Include="DnsClient" Version="1.6.1" />
+    <PackageReference Include="DnsClient" Version="1.7.0" />
     <PackageReference Include="SIPSorcery.WebSocketSharp" Version="0.0.1" />
     <PackageReference Include="SIPSorceryMedia.Abstractions" Version="1.2.0" />
     <PackageReference Include="System.Net.WebSockets.Client" Version="4.3.2" />

--- a/src/core/SIP/SIPEndPoint.cs
+++ b/src/core/SIP/SIPEndPoint.cs
@@ -235,7 +235,11 @@ namespace SIPSorcery.SIP
 
         public override bool Equals(object obj)
         {
-            return AreEqual(this, (SIPEndPoint)obj);
+            if (obj is SIPEndPoint sipEndPoint)
+            {
+                return AreEqual(this, sipEndPoint);
+            }
+            return false;
         }
 
         public static bool operator ==(SIPEndPoint endPoint1, SIPEndPoint endPoint2)

--- a/src/core/SIP/SIPTransport.cs
+++ b/src/core/SIP/SIPTransport.cs
@@ -29,6 +29,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using SIPSorcery.Sys;
+// ReSharper disable InconsistentNaming
+// ReSharper disable TemplateIsNotCompileTimeConstantProblem
 
 namespace SIPSorcery.SIP
 {
@@ -499,11 +501,7 @@ namespace SIPSorcery.SIP
 
             var cacheResult = ResolveSIPUriFromCacheCallback(lookupURI, PreferIPv6NameResolution);
 
-            if (cacheResult == null || cacheResult == SIPEndPoint.Empty)
-            {
-                return SocketError.HostNotFound;
-            }
-            else if(cacheResult != null)
+            if (cacheResult != null && cacheResult != SIPEndPoint.Empty)
             {
                 return await SendRequestAsync(cacheResult, sipRequest).ConfigureAwait(false);
             }
@@ -516,22 +514,23 @@ namespace SIPSorcery.SIP
                     // DNS lookups can take a relatively LONG time, possibly >=20s with a poor DNS server.
                     // In ideal circumstances DON'T wait for DNS and instead use the SIP retransmit mechanism
                     // with its regular retry attempts to wait for DNS resolution.
-                    SIPEndPoint lookupResult = ResolveSIPUriFromCacheCallback(lookupURI, PreferIPv6NameResolution);
+                    cacheResult = ResolveSIPUriFromCacheCallback(lookupURI, PreferIPv6NameResolution);
 
-                    if (lookupResult == null)
+                    if (cacheResult == null)
                     {
-                        lookupResult = await ResolveSIPUriCallbackAsync(lookupURI, PreferIPv6NameResolution, m_cts.Token).ConfigureAwait(false);
+                        cacheResult = await ResolveSIPUriCallbackAsync(lookupURI, PreferIPv6NameResolution, m_cts.Token).ConfigureAwait(false);
                     }
 
-                    if (lookupResult != null && lookupResult != SIPEndPoint.Empty)
+                    if (cacheResult != null && cacheResult != SIPEndPoint.Empty)
                     {
-                        return await SendRequestAsync(lookupResult, sipRequest).ConfigureAwait(false);
+                        return await SendRequestAsync(cacheResult, sipRequest).ConfigureAwait(false);
                     }
                     else
                     {
                         return SocketError.HostNotFound;
                     }
                 }
+
                 else
                 {
                     // This is the HAPPY path.
@@ -685,13 +684,10 @@ namespace SIPSorcery.SIP
 
                 var cacheResult = ResolveSIPUriFromCacheCallback(topViaUri, PreferIPv6NameResolution);
 
-                if (cacheResult == null || cacheResult == SIPEndPoint.Empty)
-                {
-                    return SocketError.HostNotFound;
-                }
-                else if (cacheResult != null)
+                if (cacheResult != null && cacheResult != SIPEndPoint.Empty)
                 {
                     return await SendResponseAsync(cacheResult, sipResponse).ConfigureAwait(false);
+
                 }
                 else
                 {
@@ -699,11 +695,11 @@ namespace SIPSorcery.SIP
                     {
                         // UNHAPPY PATH.
                         // The send will block waiting for a DNS resolution.
-                        var lookupResult = await ResolveSIPUriCallbackAsync(topViaUri, PreferIPv6NameResolution, m_cts.Token).ConfigureAwait(false);
+                        cacheResult = await ResolveSIPUriCallbackAsync(topViaUri, PreferIPv6NameResolution, m_cts.Token).ConfigureAwait(false);
 
-                        if (lookupResult != null && lookupResult != SIPEndPoint.Empty)
+                        if (cacheResult != null && cacheResult != SIPEndPoint.Empty)
                         {
-                            return await SendResponseAsync(lookupResult, sipResponse).ConfigureAwait(false);
+                            return await SendResponseAsync(cacheResult, sipResponse).ConfigureAwait(false);
                         }
                         else
                         {
@@ -741,7 +737,7 @@ namespace SIPSorcery.SIP
                 throw new ArgumentNullException(nameof(sipResponse), "The SIP response must be set for SendResponseAsync.");
             }
 
-            if (dstEndPoint != null && dstEndPoint.Address.Equals(BlackholeAddress))
+            if (dstEndPoint.Address.Equals(BlackholeAddress))
             {
                 // Ignore packet, it's destined for the black-hole.
                 return Task.FromResult(SocketError.Success);
@@ -976,9 +972,7 @@ namespace SIPSorcery.SIP
                                     {
                                         SIPRequest sipRequest = SIPRequest.ParseSIPRequest(sipMessageBuffer,m_sipEncoding,m_sipBodyEncoding);
 
-                                        SIPValidationFieldsEnum sipRequestErrorField = SIPValidationFieldsEnum.Unknown;
-                                        string sipRequestValidationError = null;
-                                        if (!sipRequest.IsValid(out sipRequestErrorField, out sipRequestValidationError))
+                                        if (!sipRequest.IsValid(out var sipRequestErrorField, out var sipRequestValidationError))
                                         {
                                             throw new SIPValidationException(sipRequestErrorField, sipRequestValidationError);
                                         }
@@ -1155,13 +1149,11 @@ namespace SIPSorcery.SIP
             }
             else
             {
-                SIPChannel matchingChannel = null;
-
                 // There's at least one channel available. If there's an IPAddress.Any channel choose that first
                 // since it's able to use all the machine's active network interfaces and should be able to reach
                 // any remote end point.
                 IPAddress addrAny = (dst.AddressFamily == AddressFamily.InterNetworkV6) ? IPAddress.IPv6Any : IPAddress.Any;
-                matchingChannel = GetSIPChannel(protocol, addrAny);
+                var matchingChannel = GetSIPChannel(protocol, addrAny);
                 if (matchingChannel != null)
                 {
                     return matchingChannel;
@@ -1234,10 +1226,10 @@ namespace SIPSorcery.SIP
             return m_sipChannels.Select(x => x.Value).ToList();
         }
 
-        /// <summary>
-        /// Add a SIP transaction to the transaction engine for reliable request and response delivery.
-        /// </summary>
-        /// <param name="transaction">The transaction to add.</param>
+        // /// <summary>
+        // /// Add a SIP transaction to the transaction engine for reliable request and response delivery.
+        // /// </summary>
+        // /// <param name="transaction">The transaction to add.</param>
         //public void AddTransaction(SIPTransaction transaction)
         //{
         //    if (m_transactionEngine == null)


### PR DESCRIPTION
In the previous code, due to the order of logical condition checks in if, the code in else will never be executed