### PR TITLE
Fix reading of From or PAI if <> is used in name

### DIFF
--- a/src/core/SIP/SIPUserField.cs
+++ b/src/core/SIP/SIPUserField.cs
@@ -80,6 +80,20 @@ namespace SIPSorcery.SIP
 
             int position = trimUserField.IndexOf('<');
 
+            // fix for some stupid switches/pbxes that add <> to teh name like: "<01234>" <sip:01234@localhost>
+            // position is wrong if the user "name" contains a < character
+            int positionFirstQuote = trimUserField.IndexOf('"');
+            if (positionFirstQuote > -1 && positionFirstQuote < position)
+            {
+                int positionSecondQuote = trimUserField.IndexOf('"', positionFirstQuote + 1);
+                if (positionSecondQuote > position)
+                {
+                    // skip past "name" portion to find the url part because the "name" contained a <
+                    // for example: From: "<00412222222>" <sip:00412222222@xyz.example.com;user=phone>;tag=1111-XX-111111-22222
+                    position = trimUserField.IndexOf('<', positionSecondQuote + 1);
+                }
+            }
+
             if (position == -1)
             {
                 // Treat the field as a URI only, except that all parameters are Header parameters and not URI parameters 


### PR DESCRIPTION
Hello,

I have identified and resolved an issue related to the parsing of names in the context of certain switches/PBX systems. Specifically, these systems sometimes insert angle brackets (<>) into the name portion of their headers, as demonstrated in the following example:

From: "<00412222222>" <sip:00412222222@xyz.example.com;user=phone>;tag=1111-XX-111111-22222

In the current implementation, our parsing logic fails to handle this format correctly.

With the changes proposed in this pull request, our parser has been updated to properly handle such cases. The updated logic now correctly identifies and processes names, even when they're encapsulated within angle brackets.

Please review the changes and let me know if you have any feedback or require any further modifications. I look forward to your thoughts on this enhancement.

Thank you for your time and consideration.

Best Regards