### PR TITLE
Replace null coalescing operator with simple if

### DIFF
--- a/src/net/RTCP/RTCPCompoundPacket.cs
+++ b/src/net/RTCP/RTCPCompoundPacket.cs
@@ -158,7 +158,11 @@ namespace SIPSorcery.Net
             RTCPCompoundPacket rtcpCompoundPacket,
             out int consumed)
         {
-            rtcpCompoundPacket ??= new RTCPCompoundPacket();
+            if (rtcpCompoundPacket == null)
+            {
+                rtcpCompoundPacket = new RTCPCompoundPacket();
+            }
+
             int offset = 0;
             while (offset < packet.Length)
             {

--- a/test/unit/net/RTP/RTPHeaderUnitTest.cs
+++ b/test/unit/net/RTP/RTPHeaderUnitTest.cs
@@ -167,18 +167,18 @@ namespace SIPSorcery.Net.UnitTests
             RTPPacket rtpPacket = new RTPPacket(rtpBytes);
             Verify(rtpPacket);
 
-            static void Verify(RTPPacket rtpPacket)
+            void Verify(RTPPacket localRtpPacket)
             {
-                Assert.True(2 == rtpPacket.Header.Version, "Version was mismatched.");
-                Assert.True(0 == rtpPacket.Header.PaddingFlag, "PaddingFlag was mismatched.");
-                Assert.True(1 == rtpPacket.Header.HeaderExtensionFlag, "HeaderExtensionFlag was mismatched.");
-                Assert.True(0 == rtpPacket.Header.CSRCCount, "CSRCCount was mismatched.");
-                Assert.True(1 == rtpPacket.Header.MarkerBit, "MarkerBit was mismatched.");
-                Assert.True(59133 == rtpPacket.Header.SequenceNumber, "SequenceNumber was mismatched..");
-                Assert.True(240U == rtpPacket.Header.Timestamp, "Timestamp was mismatched.");
-                Assert.True(3739283087 == rtpPacket.Header.SyncSource, "SyncSource was mismatched.");
-                Assert.True(1U == rtpPacket.Header.ExtensionLength, "Extension Length was mismatched.");
-                Assert.True(rtpPacket.Header.ExtensionPayload.Length == rtpPacket.Header.ExtensionLength * 4, "Extension length and payload were mismatched.");
+                Assert.True(2 == localRtpPacket.Header.Version, "Version was mismatched.");
+                Assert.True(0 == localRtpPacket.Header.PaddingFlag, "PaddingFlag was mismatched.");
+                Assert.True(1 == localRtpPacket.Header.HeaderExtensionFlag, "HeaderExtensionFlag was mismatched.");
+                Assert.True(0 == localRtpPacket.Header.CSRCCount, "CSRCCount was mismatched.");
+                Assert.True(1 == localRtpPacket.Header.MarkerBit, "MarkerBit was mismatched.");
+                Assert.True(59133 == localRtpPacket.Header.SequenceNumber, "SequenceNumber was mismatched..");
+                Assert.True(240U == localRtpPacket.Header.Timestamp, "Timestamp was mismatched.");
+                Assert.True(3739283087 == localRtpPacket.Header.SyncSource, "SyncSource was mismatched.");
+                Assert.True(1U == localRtpPacket.Header.ExtensionLength, "Extension Length was mismatched.");
+                Assert.True(localRtpPacket.Header.ExtensionPayload.Length == localRtpPacket.Header.ExtensionLength * 4, "Extension length and payload were mismatched.");
             }
 
             var result = RTPPacket.TryParse(rtpBytes, out var p, out var consumed);


### PR DESCRIPTION
Hello!

Commit https://github.com/sipsorcery-org/sipsorcery/commit/65e444557fa186b2c932f2e53966283555903fc5 introduces null-coalescing operator, which is not supported in default language version of project

This also should fix failing github action:
![image](https://github.com/sipsorcery-org/sipsorcery/assets/10367317/28871291-1a04-42c5-8721-a33d24a77ed6)
