### PR TITLE
LangVersion for net461

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+ <PropertyGroup Condition=" '$(Framework)' != 'NET461'">
+   <LangVersion>8.0</LangVersion>
+ </PropertyGroup>
+</Project>


### PR DESCRIPTION
When I checked out repo locally I have a problem with building with `dotnet build` because LanguageVersion for net461 is 7.3.  
```
\src\net\RTCP\RTCPCompoundPacket.cs(161,32): error CS8370
```

This PR bumps language version to 8.0 for net461 builds