### PR TITLE
Call AudioSink and AudioSource start/close methods

### DIFF
--- a/src/app/Media/VoIPMediaSession.cs
+++ b/src/app/Media/VoIPMediaSession.cs
@@ -210,6 +210,10 @@ namespace SIPSorcery.Media
                     {
                         await Media.AudioSource.StartAudio().ConfigureAwait(false);
                     }
+                    if (Media.AudioSink != null)
+                    {
+                        await Media.AudioSink.StartAudioSink().ConfigureAwait(false);
+                    }
                 }
 
                 if (HasVideo)
@@ -253,6 +257,11 @@ namespace SIPSorcery.Media
                 if (Media.AudioSource != null)
                 {
                     await Media.AudioSource.CloseAudio().ConfigureAwait(false);
+                }
+
+                if (Media.AudioSink != null)
+                {
+                    await Media.AudioSink.CloseAudioSink().ConfigureAwait(false);
                 }
 
                 if (Media.VideoSource != null)


### PR DESCRIPTION
Previously, only the AudioSource start and close were called, this was working with the current implementation of WindowsAudioEndpoint which grouped audiosink and source in the audiosource methods, but this does not work if only the audiosink is used. This requires also a change in WindowsAudioEndpoint were the code for the audiosink is moved at the right place (the placeholders do exist but are empty)

I'll suggest also a pull request for the changes to bring into the other repository (WindowsAudioEndpoint). This current request does not affect the behaviour as current WindowsAudioEndpoint implementation provides empty placeholders for the fucntions calls added by this commit.