### PR TITLE
Safely release SIP user agent semaphore

### DIFF
--- a/src/app/SIPUserAgents/SIPUserAgent.cs
+++ b/src/app/SIPUserAgents/SIPUserAgent.cs
@@ -664,7 +664,7 @@ namespace SIPSorcery.SIP.App
             }
             finally
             {
-                m_semaphoreSlim.Release();
+                TryReleaseSemaphore();
             }
         }
 
@@ -1753,7 +1753,7 @@ namespace SIPSorcery.SIP.App
             }
             finally
             {
-                m_semaphoreSlim.Release();
+                TryReleaseSemaphore();
             }
         }
 
@@ -1940,8 +1940,20 @@ namespace SIPSorcery.SIP.App
 
             // Wait for completion of CallEnded and Answer methods
             m_semaphoreSlim.Wait();
-            m_semaphoreSlim.Release();
+            TryReleaseSemaphore();
             m_semaphoreSlim.Dispose();
         }
+		
+		private void TryReleaseSemaphore()
+		{
+			try
+			{
+				m_semaphoreSlim.Release();
+			}
+			catch (ObjectDisposedException)
+			{
+				//Swallow it
+			}
+		}
     }
 }


### PR DESCRIPTION
Explicitly disposing a SIPUserAgent after a failed call attempt as it attempts to execute the CallEnded() method from within the ClientCallAnsweredHandler() method can result in attempting to Release() an already disposed SemaphoreSlim instance. This can occur because the ClientCallFailed event handler is invoked before executing the CallEnded() method. This scenario throws an uncaught ObjectDisposedException which can bring down the entire application.

This commit wraps all SemaphoreSlim.Release() calls within SIPUserAgent in a try/catch block to swallow the ObjectDisposedException to avoid potentially crashing the application.