### PR TITLE
Call of RefreshTurn while _activeIceServer is not initilized leads NullReferenceException

### DIFF
--- a/src/net/ICE/RtpIceChannel.cs
+++ b/src/net/ICE/RtpIceChannel.cs
@@ -1105,7 +1105,7 @@ namespace SIPSorcery.Net
         //
         private void RefreshTurn(Object state)
         {
-            if (NominatedEntry == null)
+            if (NominatedEntry == null || _activeIceServer == null)
             {
                 return;
             }


### PR DESCRIPTION
The method CheckIceServers which initiate _refreshTurnTimer can be invoked again even a previous invocation is not completed. I observe the following situation:
On first invocation:
- IceGatheringState=gathering, IceConnectionState=checking, _activeIceServer = null
it starts _activeIceServer initialization and before completion the second invocation (in another thread) occurs:
- IceGatheringState=gathering, IceConnectionState=connected, _activeIceServer = null (still null)
it initializes _refreshTurnTimer (_refreshTurnTimer = new Timer(RefreshTurn, null, 0, 2000);) and invokes it immediately (because of  third parameter of Timer). Then NRE occurs:
```
Unhandled exception. System.NullReferenceException: Object reference not set to an instance of an object.
   at SIPSorcery.Net.RtpIceChannel.RefreshTurn(Object state) in D:\GitHub\sipsorcery\src\net\ICE\RtpIceChannel.cs:line 1112
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
--- End of stack trace from previous location ---
   at System.Threading.TimerQueueTimer.Fire(Boolean isThreadPool)
   at System.Threading.TimerQueue.FireNextTimers()
```
In order to prevent NRE I suggest to check `_activeIceServer` for null like it did for `NominatedEntry` in RefreshTurn method.