### PR TITLE
Pass negotiated video format to video test pattern source

### DIFF
--- a/src/app/Media/VoIPMediaSession.cs
+++ b/src/app/Media/VoIPMediaSession.cs
@@ -196,6 +196,7 @@ namespace SIPSorcery.Media
             logger.LogDebug($"Setting video sink and source format to {videoFormat.FormatID}:{videoFormat.Codec}.");
             Media.VideoSink?.SetVideoSinkFormat(videoFormat);
             Media.VideoSource?.SetVideoSourceFormat(videoFormat);
+            _videoTestPatternSource?.SetVideoSourceFormat(videoFormat);
         }
 
         public async override Task Start()


### PR DESCRIPTION
When using the VoIPMediaSession class the VideoFormatsNegotiated event handler does not pass along the negotiated video format to the video test pattern source. As a result the video test pattern source would always use VP8 even if H264 was the negotiated format.