### PR TITLE
Pass encoder to VoIPMediaSession audio extras

### DIFF
--- a/src/app/Media/Codecs/AudioEncoder.cs
+++ b/src/app/Media/Codecs/AudioEncoder.cs
@@ -176,36 +176,10 @@ namespace SIPSorcery.Media
             }
         }
 
+        [Obsolete("No longer used. Use SIPSorcery.Media.PcmResampler.Resample instead.")]
         public short[] Resample(short[] pcm, int inRate, int outRate)
         {
-            if (inRate == outRate)
-            {
-                return pcm;
-            }
-            else if (inRate == 8000 && outRate == 16000)
-            {
-                // Crude up-sample to 16Khz by doubling each sample.
-                return pcm.SelectMany(x => new short[] { x, x }).ToArray();
-            }
-            else if (inRate == 8000 && outRate == 48000)
-            {
-                // Crude up-sample to 48Khz by 6x each sample. This sounds bad, use for testing only.
-                return pcm.SelectMany(x => new short[] { x, x, x, x, x, x }).ToArray();
-            }
-            else if (inRate == 16000 && outRate == 8000)
-            {
-                // Crude down-sample to 8Khz by skipping every second sample.
-                return pcm.Where((x, i) => i % 2 == 0).ToArray();
-            }
-            else if (inRate == 16000 && outRate == 48000)
-            {
-                // Crude up-sample to 48Khz by 3x each sample. This sounds bad, use for testing only.
-                return pcm.SelectMany(x => new short[] { x, x, x }).ToArray();
-            }
-            else
-            {
-                throw new ApplicationException($"Sorry don't know how to re-sample PCM from {inRate} to {outRate}. Pull requests welcome!");
-            }
+            return PcmResampler.Resample(pcm, inRate, outRate);
         }
     }
 }

--- a/src/app/Media/Codecs/PcmResampler.cs
+++ b/src/app/Media/Codecs/PcmResampler.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Linq;
+
+namespace SIPSorcery.Media
+{
+    internal static class PcmResampler
+    {
+        public static short[] Resample(short[] pcm, int inRate, int outRate)
+        {
+            if (inRate == outRate)
+            {
+                return pcm;
+            }
+            else if (inRate == 8000 && outRate == 16000)
+            {
+                // Crude up-sample to 16Khz by doubling each sample.
+                return pcm.SelectMany(x => new short[] { x, x }).ToArray();
+            }
+            else if (inRate == 8000 && outRate == 48000)
+            {
+                // Crude up-sample to 48Khz by 6x each sample. This sounds bad, use for testing only.
+                return pcm.SelectMany(x => new short[] { x, x, x, x, x, x }).ToArray();
+            }
+            else if (inRate == 16000 && outRate == 8000)
+            {
+                // Crude down-sample to 8Khz by skipping every second sample.
+                return pcm.Where((x, i) => i % 2 == 0).ToArray();
+            }
+            else if (inRate == 16000 && outRate == 48000)
+            {
+                // Crude up-sample to 48Khz by 3x each sample. This sounds bad, use for testing only.
+                return pcm.SelectMany(x => new short[] { x, x, x }).ToArray();
+            }
+            else
+            {
+                throw new ApplicationException($"Sorry don't know how to re-sample PCM from {inRate} to {outRate}. Pull requests welcome!");
+            }
+        }
+    }
+}

--- a/src/app/Media/Sources/AudioExtrasSource.cs
+++ b/src/app/Media/Sources/AudioExtrasSource.cs
@@ -111,7 +111,7 @@ namespace SIPSorcery.Media
         private bool _isStarted;
         private bool _isPaused;
         private bool _isClosed;
-        private AudioEncoder _audioEncoder;
+        private IAudioEncoder _audioEncoder;
 
         // Fields for interrupting the main audio source with a different stream. For example playing
         // an announcement over music etc.
@@ -173,7 +173,7 @@ namespace SIPSorcery.Media
         /// <param name="audioOptions">Optional. The options that determine the type of audio to stream to the remote party. 
         /// Example type of audio sources are music, silence, white noise etc.</param>
         public AudioExtrasSource(
-            AudioEncoder audioEncoder,
+            IAudioEncoder audioEncoder,
             AudioSourceOptions audioOptions = null)
         {
             _audioEncoder = audioEncoder;
@@ -546,7 +546,7 @@ namespace SIPSorcery.Media
             {
                 if (pcmSampleRate != _audioFormatManager.SelectedFormat.ClockRate)
                 {
-                    pcm = _audioEncoder.Resample(pcm, pcmSampleRate, _audioFormatManager.SelectedFormat.ClockRate);
+                    pcm = PcmResampler.Resample(pcm, pcmSampleRate, _audioFormatManager.SelectedFormat.ClockRate);
                 }
 
                 byte[] encodedSample = _audioEncoder.EncodeAudio(pcm, _audioFormatManager.SelectedFormat);

--- a/src/app/Media/VoIPMediaSession.cs
+++ b/src/app/Media/VoIPMediaSession.cs
@@ -124,7 +124,7 @@ namespace SIPSorcery.Media
             Media = config.MediaEndPoint;
 
             // The audio extras source is used for on-hold music.
-            _audioExtrasSource = new AudioExtrasSource();
+            _audioExtrasSource = new AudioExtrasSource(config.AudioExtrasEncoder);
             _audioExtrasSource.OnAudioSourceEncodedSample += SendAudio;
 
             // Wire up the audio and video sample event handlers.

--- a/src/app/Media/VoIPMediaSessionConfig.cs
+++ b/src/app/Media/VoIPMediaSessionConfig.cs
@@ -33,5 +33,7 @@ namespace SIPSorcery.Media
         public VideoTestPatternSource TestPatternSource { get; set; }
 
         public PortRange RtpPortRange { get; set; }
+
+        public IAudioEncoder AudioExtrasEncoder { get; set; } = new AudioEncoder();
     }
 }


### PR DESCRIPTION
Currently audio extras in `VoIPMediaSession` use `AudioEncoder` for encoding audio extras. It leads to problems if we are using custom encoder: `AudioEncoder.EncodeAudio` method throws an exception because of unsupported audio format. So we need a way to inject a custom encoder for `VoIPMediaSession` audio extras.