### PR TITLE
When RTCPeerConnection is closed, we also close DataChannels

### DIFF
--- a/src/net/WebRTC/RTCPeerConnection.cs
+++ b/src/net/WebRTC/RTCPeerConnection.cs
@@ -873,12 +873,21 @@ namespace SIPSorcery.Net
             {
                 logger.LogDebug($"Peer connection closed with reason {(reason != null ? reason : "<none>")}.");
 
+                // Close all DataChannels
+                if (DataChannels?.Count >0)
+                {
+                    foreach(var dc in DataChannels)
+                    {
+                        dc?.close();
+                    }
+                }
+
                 _rtpIceChannel?.Close();
                 _dtlsHandle?.Close();
 
                 sctp?.Close();
 
-                base.Close(reason);
+                base.Close(reason); // Here Audio and/or Video Streams are closed
 
                 connectionState = RTCPeerConnectionState.closed;
                 onconnectionstatechange?.Invoke(RTCPeerConnectionState.closed);


### PR DESCRIPTION
Like Audio and/or Video Streams, when the the RTCPeerConnection is closed, existing DataChannels are also closed

Related to #1058