### PR TITLE
Avoid Crash in RtpIceChannel and set RemoteRtpEvent PayloadID to 0 for VideoStream

### DIFF
--- a/src/net/ICE/RtpIceChannel.cs
+++ b/src/net/ICE/RtpIceChannel.cs
@@ -1113,6 +1113,11 @@ namespace SIPSorcery.Net
         {
             try
             {
+                if (_closed)
+                {
+                    return;
+                }
+
                 if (NominatedEntry == null || _activeIceServer == null)
                 {
                     return;
@@ -1513,6 +1518,11 @@ namespace SIPSorcery.Net
         /// </summary>
         private void DoConnectivityCheck(Object stateInfo)
         {
+            if (_closed)
+            {
+                return;
+            }
+
             switch (IceConnectionState)
             {
                 case RTCIceConnectionState.@new:

--- a/src/net/RTP/VideoStream.cs
+++ b/src/net/RTP/VideoStream.cs
@@ -320,6 +320,7 @@ namespace SIPSorcery.net.RTP
         public VideoStream(RtpSessionConfig config, int index) : base(config, index)
         {
             MediaType = SDPMediaTypesEnum.video;
+            RemoteRtpEventPayloadID = 0;
         }
     }
 }


### PR DESCRIPTION
RtpIceChannel:
Check closed status in methods called by a timer.

VideoStream:
No RtpEvent are expected in VideoStream. So set this PayloadId  to 0.