### PR TITLE
REMB - fix serialisation

### DIFF
--- a/src/net/RTCP/RTCPFeedback.cs
+++ b/src/net/RTCP/RTCPFeedback.cs
@@ -215,7 +215,7 @@ namespace SIPSorcery.Net
                         BitrateExp = (byte)(packet[currentCounter] >> 2);
 
                         // Now read next 18 bits
-                        var remaininMantissaBytes = new byte[] { (byte)0, (byte)(packet[currentCounter] & 4), packet[currentCounter + 1], packet[currentCounter + 2] };
+                        var remaininMantissaBytes = new byte[] { (byte)0, (byte)(packet[currentCounter] & 3), packet[currentCounter + 1], packet[currentCounter + 2] };
                         if (BitConverter.IsLittleEndian)
                         {
                             BitrateMantissa = NetConvert.DoReverseEndian(BitConverter.ToUInt32(remaininMantissaBytes, 0));
@@ -339,7 +339,7 @@ namespace SIPSorcery.Net
                         {
                             remaininMantissaBytes = BitConverter.GetBytes(BitrateMantissa);
                         }
-                        buffer[currentCounter] = (byte)((BitrateExp << 2) & (remaininMantissaBytes[1] & 4));
+                        buffer[currentCounter] = (byte)((BitrateExp << 2) | (remaininMantissaBytes[1] & 3));
                         buffer[currentCounter + 1] = remaininMantissaBytes[2];
                         buffer[currentCounter + 2] = remaininMantissaBytes[3];
 

--- a/test/unit/net/RTCP/RTCFeedbackUnitTest.cs
+++ b/test/unit/net/RTCP/RTCFeedbackUnitTest.cs
@@ -55,5 +55,44 @@ namespace SIPSorcery.Net.UnitTests
             Assert.Equal(mediaSsrc, parsedPli.MediaSSRC);
             Assert.Equal(2, parsedPli.Header.Length);
         }
+
+        /// <summary>
+        /// Tests that an RTCPFeedback for REMB payload can
+        /// be correctly serialised and deserialised.
+        /// </summary>
+        [Fact]
+        public void RoundtripREMBUnitTest()
+        {
+            logger.LogDebug("--> " + System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+
+            uint senderSsrc = 33;
+            uint mediaSsrc = 44;
+
+            RTCPFeedback rtcpREMB = new RTCPFeedback(senderSsrc, mediaSsrc, PSFBFeedbackTypesEnum.AFB)
+            {
+                SENDER_PAYLOAD_SIZE = 8 + 12, // 8 bytes from (SenderSSRC + MediaSSRC) + extra 12 bytes from REMB Definition
+                UniqueID = "REMB",
+                NumSsrcs = 1,
+                BitrateExp = 4,
+                BitrateMantissa = 222242u,
+                FeedbackSSRC = 0x4a8eec30
+            };
+            byte[] buffer = rtcpREMB.GetBytes();
+
+            logger.LogDebug($"Serialised REMB: {BufferUtils.HexStr(buffer)}.");
+
+            RTCPFeedback parsedREMB = new RTCPFeedback(buffer);
+
+            Assert.Equal(RTCPReportTypesEnum.PSFB, parsedREMB.Header.PacketType);
+            Assert.Equal(PSFBFeedbackTypesEnum.AFB, parsedREMB.Header.PayloadFeedbackMessageType);
+            Assert.Equal(senderSsrc, parsedREMB.SenderSSRC);
+            Assert.Equal(mediaSsrc, parsedREMB.MediaSSRC);
+            Assert.Equal(rtcpREMB.UniqueID, parsedREMB.UniqueID);
+            Assert.Equal(rtcpREMB.NumSsrcs, parsedREMB.NumSsrcs);
+            Assert.Equal(rtcpREMB.BitrateExp, parsedREMB.BitrateExp);
+            Assert.Equal(rtcpREMB.BitrateMantissa, parsedREMB.BitrateMantissa);
+            Assert.Equal(rtcpREMB.FeedbackSSRC, parsedREMB.FeedbackSSRC);
+        }
     }
 }


### PR DESCRIPTION
I've found a bug in REMB packet serialisation.

For reference, here's the layout:

```
// 0                   1                   2                   3
// 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
//+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
//|  Unique identifier 'R' 'E' 'M' 'B'                            |
//+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
//|  Num SSRC     | BR Exp    |  BR Mantissa                      |
//+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
//|   SSRC feedback                                               |
```

Based on sample Wireshark dissect:

![image](https://github.com/sipsorcery-org/sipsorcery/assets/5909015/8dec964e-c379-426e-af71-898017bde7c0)

current code reads mantissa as `..00 0110 0100 0010 0010` (first two bits are always 0)

Made following changes:

* Mantissa is using 2 least significant bits from first byte, so it needs to be AND-ed with 3 (`0000 0011` instead of 4 `0000 0100`) - fixed this both ways
* Also added a roundtrip unit test - pretty much copied and adjusted the one above it.
* The unit test showed another issue - when serialising REMB, the exponent and mantissa need to be OR-ed (instead of AND-ed) for the shared byte - otherwise that byte would always be 0, so fixed that as well
