### PR TITLE
Support for abs-send-time - closes #1081

### DIFF
--- a/src/net/RTP/MediaStream.cs
+++ b/src/net/RTP/MediaStream.cs
@@ -399,10 +399,13 @@ namespace SIPSorcery.net.RTP
             }
         }
 
+        // DateTimeOffset.UnixEpoch only available in newer target frameworks
+        private static readonly DateTimeOffset UnixEpoch = new DateTimeOffset(1970, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        
         private byte[] AbsSendTime()
         {
             var t = DateTimeOffset.Now;
-            ulong u = (ulong)((t - DateTimeOffset.UnixEpoch).Ticks * 100L);
+            ulong u = (ulong)((t - UnixEpoch).Ticks * 100L);
             var s = u / (ulong)1e9;
             s += 0x83AA7E80UL;
             var f = u % (ulong)1e9;

--- a/src/net/RTP/MediaStream.cs
+++ b/src/net/RTP/MediaStream.cs
@@ -367,10 +367,7 @@ namespace SIPSorcery.net.RTP
                 rtpPacket.Header.PayloadType = payloadType;
 
                 // abs-send-time
-                rtpPacket.Header.HeaderExtensionFlag = 1;
-                rtpPacket.Header.ExtensionProfile = 0xBEDE; // one byte extension
-                rtpPacket.Header.ExtensionLength = 1;
-                rtpPacket.Header.ExtensionPayload = AbsSendTime();
+                rtpPacket.Header.AddAbsSendTimeExtension();
 
                 Buffer.BlockCopy(data, 0, rtpPacket.Payload, 0, data.Length);
 
@@ -397,31 +394,6 @@ namespace SIPSorcery.net.RTP
 
                 RtcpSession?.RecordRtpPacketSend(rtpPacket);
             }
-        }
-
-        // DateTimeOffset.UnixEpoch only available in newer target frameworks
-        private static readonly DateTimeOffset UnixEpoch = new DateTimeOffset(1970, 1, 1, 0, 0, 0, TimeSpan.Zero);
-        
-        private byte[] AbsSendTime()
-        {
-            var t = DateTimeOffset.Now;
-            ulong u = (ulong)((t - UnixEpoch).Ticks * 100L);
-            var s = u / (ulong)1e9;
-            s += 0x83AA7E80UL;
-            var f = u % (ulong)1e9;
-            f <<= 32;
-            f /= (ulong)1e9;
-            s <<= 32;
-            var ntp = s | f;
-            var abs = ntp >> 14;
-
-            return new byte[]
-            {
-                0x22, // ID = 2; L = 2 (3-1)
-                (byte)((abs & 0xff0000UL) >> 16),
-                (byte)((abs & 0xff00UL) >> 8),
-                (byte)(abs & 0xffUL) 
-            };
         }
 
         /// <summary>

--- a/src/net/RTP/MediaStream.cs
+++ b/src/net/RTP/MediaStream.cs
@@ -366,8 +366,11 @@ namespace SIPSorcery.net.RTP
                 rtpPacket.Header.MarkerBit = markerBit;
                 rtpPacket.Header.PayloadType = payloadType;
 
-                // abs-send-time
-                rtpPacket.Header.AddAbsSendTimeExtension();
+                if (RemoteTrack.HeaderExtensions.TryGetValue(SDPMediaAnnouncement.RTP_HEADER_EXTENSION_ID_ABS_SEND_TIME, out var ext) &&
+                    ext.Uri == SDPMediaAnnouncement.RTP_HEADER_EXTENSION_URI_ABS_SEND_TIME)
+                {
+                    rtpPacket.Header.AddAbsSendTimeExtension();
+                }
 
                 Buffer.BlockCopy(data, 0, rtpPacket.Payload, 0, data.Length);
 

--- a/src/net/RTP/RTPHeader.cs
+++ b/src/net/RTP/RTPHeader.cs
@@ -329,9 +329,8 @@ namespace SIPSorcery.Net
         private static readonly DateTimeOffset UnixEpoch = new DateTimeOffset(1970, 1, 1, 0, 0, 0, TimeSpan.Zero);
 
         // inspired by https://github.com/pion/rtp/blob/master/abssendtimeextension.go
-        private byte[] AbsSendTime()
+        internal static byte[] AbsSendTime(DateTimeOffset now)
         {
-            var now = DateTimeOffset.Now;
             ulong unixNanoseconds = (ulong)((now - UnixEpoch).Ticks * 100L);
             var seconds = unixNanoseconds / (ulong)1e9;
             seconds += 0x83AA7E80UL; // offset in seconds between unix epoch and ntp epoch
@@ -374,7 +373,7 @@ namespace SIPSorcery.Net
             HeaderExtensionFlag = 1;
             ExtensionProfile = ONE_BYTE_EXTENSION_PROFILE;
             ExtensionLength = 1; // only abs-send-time for now
-            ExtensionPayload = AbsSendTime();
+            ExtensionPayload = AbsSendTime(DateTimeOffset.Now);
         }
     }
 }

--- a/src/net/SDP/SDP.cs
+++ b/src/net/SDP/SDP.cs
@@ -434,13 +434,13 @@ namespace SIPSorcery.Net
                                 }
 
                                 break;
-                            case var l when l.StartsWith(SDPMediaAnnouncement.MEDIA_FORMAT_ATTRIBUE_PREFIX):
+                            case var l when l.StartsWith(SDPMediaAnnouncement.MEDIA_FORMAT_ATTRIBUTE_PREFIX):
                                 if (activeAnnouncement != null)
                                 {
                                     if (activeAnnouncement.Media == SDPMediaTypesEnum.audio || activeAnnouncement.Media == SDPMediaTypesEnum.video)
                                     {
                                         // Parse the rtpmap attribute for audio/video announcements.
-                                        Match formatAttributeMatch = Regex.Match(sdpLineTrimmed, SDPMediaAnnouncement.MEDIA_FORMAT_ATTRIBUE_PREFIX + @"(?<id>\d+)\s+(?<attribute>.*)$");
+                                        Match formatAttributeMatch = Regex.Match(sdpLineTrimmed, SDPMediaAnnouncement.MEDIA_FORMAT_ATTRIBUTE_PREFIX + @"(?<id>\d+)\s+(?<attribute>.*)$");
                                         if (formatAttributeMatch.Success)
                                         {
                                             string formatID = formatAttributeMatch.Result("${id}");
@@ -471,7 +471,7 @@ namespace SIPSorcery.Net
                                     else
                                     {
                                         // Parse the rtpmap attribute for NON audio/video announcements.
-                                        Match formatAttributeMatch = Regex.Match(sdpLineTrimmed, SDPMediaAnnouncement.MEDIA_FORMAT_ATTRIBUE_PREFIX + @"(?<id>\S+)\s+(?<attribute>.*)$");
+                                        Match formatAttributeMatch = Regex.Match(sdpLineTrimmed, SDPMediaAnnouncement.MEDIA_FORMAT_ATTRIBUTE_PREFIX + @"(?<id>\S+)\s+(?<attribute>.*)$");
                                         if (formatAttributeMatch.Success)
                                         {
                                             string formatID = formatAttributeMatch.Result("${id}");

--- a/src/net/SDP/SDPAudioVideoMediaFormat.cs
+++ b/src/net/SDP/SDPAudioVideoMediaFormat.cs
@@ -96,6 +96,14 @@ namespace SIPSorcery.Net
         /// </summary>
         public string Fmtp { get; }
 
+        public IEnumerable<string> SupportedRtcpFeedbackMessages
+        {
+            get
+            {
+                yield return "goog-remb";
+            }
+        }
+
         /// <summary>
         /// The standard name of the media format.
         /// <code>

--- a/src/net/SDP/SDPMediaAnnouncement.cs
+++ b/src/net/SDP/SDPMediaAnnouncement.cs
@@ -82,7 +82,7 @@ namespace SIPSorcery.Net
         public const string MEDIA_FORMAT_PATH_ACCEPT_TYPES_PREFIX = "a=accept-types:";
         public const string TIAS_BANDWIDTH_ATTRIBUE_PREFIX = "b=TIAS:";
         public const int RTP_HEADER_EXTENSION_ID_ABS_SEND_TIME = 2;
-        private const string RTP_HEADER_EXTENSION_URI_ABS_SEND_TIME = "http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time";
+        public const string RTP_HEADER_EXTENSION_URI_ABS_SEND_TIME = "http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time";
 
         public const MediaStreamStatusEnum DEFAULT_STREAM_STATUS = MediaStreamStatusEnum.SendRecv;
 

--- a/src/net/SDP/SDPMediaAnnouncement.cs
+++ b/src/net/SDP/SDPMediaAnnouncement.cs
@@ -81,6 +81,9 @@ namespace SIPSorcery.Net
         public const string MEDIA_FORMAT_PATH_MSRP_PREFIX = "a=path:msrp:";
         public const string MEDIA_FORMAT_PATH_ACCEPT_TYPES_PREFIX = "a=accept-types:";
         public const string TIAS_BANDWIDTH_ATTRIBUE_PREFIX = "b=TIAS:";
+        private const int RTP_HEADER_EXTENSION_ID_ABS_SEND_TIME = 2;
+        private const string RTP_HEADER_EXTENSION_URI_ABS_SEND_TIME = "http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time";
+
         public const MediaStreamStatusEnum DEFAULT_STREAM_STATUS = MediaStreamStatusEnum.SendRecv;
 
         public const string m_CRLF = "\r\n";
@@ -207,6 +210,16 @@ namespace SIPSorcery.Net
                     }
                 }
             }
+
+            HeaderExtensions = new Dictionary<int, RTPHeaderExtension>
+            {
+                {
+                    RTP_HEADER_EXTENSION_ID_ABS_SEND_TIME,
+                    new RTPHeaderExtension(
+                        RTP_HEADER_EXTENSION_ID_ABS_SEND_TIME,
+                        RTP_HEADER_EXTENSION_URI_ABS_SEND_TIME)
+                }
+            };
         }
 
         public SDPMediaAnnouncement(SDPMediaTypesEnum mediaType, int port, List<SDPApplicationMediaFormat> appMediaFormats)

--- a/src/net/SDP/SDPMediaAnnouncement.cs
+++ b/src/net/SDP/SDPMediaAnnouncement.cs
@@ -81,7 +81,7 @@ namespace SIPSorcery.Net
         public const string MEDIA_FORMAT_PATH_MSRP_PREFIX = "a=path:msrp:";
         public const string MEDIA_FORMAT_PATH_ACCEPT_TYPES_PREFIX = "a=accept-types:";
         public const string TIAS_BANDWIDTH_ATTRIBUE_PREFIX = "b=TIAS:";
-        private const int RTP_HEADER_EXTENSION_ID_ABS_SEND_TIME = 2;
+        public const int RTP_HEADER_EXTENSION_ID_ABS_SEND_TIME = 2;
         private const string RTP_HEADER_EXTENSION_URI_ABS_SEND_TIME = "http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time";
 
         public const MediaStreamStatusEnum DEFAULT_STREAM_STATUS = MediaStreamStatusEnum.SendRecv;

--- a/src/net/SDP/SDPMediaAnnouncement.cs
+++ b/src/net/SDP/SDPMediaAnnouncement.cs
@@ -70,7 +70,8 @@ namespace SIPSorcery.Net
     public class SDPMediaAnnouncement
     {
         public const string MEDIA_EXTENSION_MAP_ATTRIBUE_PREFIX = "a=extmap:";
-        public const string MEDIA_FORMAT_ATTRIBUE_PREFIX = "a=rtpmap:";
+        public const string MEDIA_FORMAT_ATTRIBUTE_PREFIX = "a=rtpmap:";
+        public const string MEDIA_FORMAT_FEEDBACK_PREFIX = "a=rtcp-fb:";
         public const string MEDIA_FORMAT_PARAMETERS_ATTRIBUE_PREFIX = "a=fmtp:";
         public const string MEDIA_FORMAT_SSRC_ATTRIBUE_PREFIX = "a=ssrc:";
         public const string MEDIA_FORMAT_SSRC_GROUP_ATTRIBUE_PREFIX = "a=ssrc-group:";
@@ -422,7 +423,7 @@ namespace SIPSorcery.Net
                     {
                         if (appFormat.Value.Rtpmap != null)
                         {
-                            sb.Append($"{MEDIA_FORMAT_ATTRIBUE_PREFIX}{appFormat.Key} {appFormat.Value.Rtpmap}{m_CRLF}");
+                            sb.Append($"{MEDIA_FORMAT_ATTRIBUTE_PREFIX}{appFormat.Key} {appFormat.Value.Rtpmap}{m_CRLF}");
                         }
 
                         if (appFormat.Value.Fmtp != null)
@@ -474,11 +475,16 @@ namespace SIPSorcery.Net
                         {
                             // Well known media formats are not required to add an rtpmap but we do so any way as some SIP
                             // stacks don't work without it.
-                            formatAttributes += MEDIA_FORMAT_ATTRIBUE_PREFIX + mediaFormat.ID + " " + mediaFormat.Name() + "/" + mediaFormat.ClockRate() + m_CRLF;
+                            formatAttributes += MEDIA_FORMAT_ATTRIBUTE_PREFIX + mediaFormat.ID + " " + mediaFormat.Name() + "/" + mediaFormat.ClockRate() + m_CRLF;
                         }
                         else
                         {
-                            formatAttributes += MEDIA_FORMAT_ATTRIBUE_PREFIX + mediaFormat.ID + " " + mediaFormat.Rtpmap + m_CRLF;
+                            formatAttributes += MEDIA_FORMAT_ATTRIBUTE_PREFIX + mediaFormat.ID + " " + mediaFormat.Rtpmap + m_CRLF;
+                        }
+
+                        foreach (var rtcpFeedbackMessage in mediaFormat.SupportedRtcpFeedbackMessages)
+                        {
+                            formatAttributes += MEDIA_FORMAT_FEEDBACK_PREFIX + mediaFormat.ID + " " + rtcpFeedbackMessage + m_CRLF;
                         }
 
                         if (mediaFormat.Fmtp != null)

--- a/src/net/WebRTC/RTCPeerConnection.cs
+++ b/src/net/WebRTC/RTCPeerConnection.cs
@@ -1141,15 +1141,9 @@ namespace SIPSorcery.Net
                 else
                 {
                     SDPMediaAnnouncement announcement = new SDPMediaAnnouncement(
-                     mediaStream.LocalTrack.Kind,
-                     SDP.IGNORE_RTP_PORT_NUMBER,
-                     mediaStream.LocalTrack.Capabilities)
-                    {
-                        HeaderExtensions = new Dictionary<int, RTPHeaderExtension>
-                        {
-                            {2, new RTPHeaderExtension(2, "http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time")}
-                        }
-                    };
+                        mediaStream.LocalTrack.Kind,
+                        SDP.IGNORE_RTP_PORT_NUMBER,
+                        mediaStream.LocalTrack.Capabilities);
 
                     announcement.Transport = RTP_MEDIA_PROFILE;
                     announcement.Connection = new SDPConnectionInformation(IPAddress.Any);

--- a/src/net/WebRTC/RTCPeerConnection.cs
+++ b/src/net/WebRTC/RTCPeerConnection.cs
@@ -1141,9 +1141,9 @@ namespace SIPSorcery.Net
                 else
                 {
                     SDPMediaAnnouncement announcement = new SDPMediaAnnouncement(
-                        mediaStream.LocalTrack.Kind,
-                        SDP.IGNORE_RTP_PORT_NUMBER,
-                        mediaStream.LocalTrack.Capabilities);
+                     mediaStream.LocalTrack.Kind,
+                     SDP.IGNORE_RTP_PORT_NUMBER,
+                     mediaStream.LocalTrack.Capabilities);
 
                     announcement.Transport = RTP_MEDIA_PROFILE;
                     announcement.Connection = new SDPConnectionInformation(IPAddress.Any);

--- a/src/net/WebRTC/RTCPeerConnection.cs
+++ b/src/net/WebRTC/RTCPeerConnection.cs
@@ -1143,7 +1143,13 @@ namespace SIPSorcery.Net
                     SDPMediaAnnouncement announcement = new SDPMediaAnnouncement(
                      mediaStream.LocalTrack.Kind,
                      SDP.IGNORE_RTP_PORT_NUMBER,
-                     mediaStream.LocalTrack.Capabilities);
+                     mediaStream.LocalTrack.Capabilities)
+                    {
+                        HeaderExtensions = new Dictionary<int, RTPHeaderExtension>
+                        {
+                            {2, new RTPHeaderExtension(2, "http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time")}
+                        }
+                    };
 
                     announcement.Transport = RTP_MEDIA_PROFILE;
                     announcement.Connection = new SDPConnectionInformation(IPAddress.Any);

--- a/test/unit/net/RTP/RTPHeaderExtensionUnitTest.cs
+++ b/test/unit/net/RTP/RTPHeaderExtensionUnitTest.cs
@@ -67,5 +67,20 @@ namespace SIPSorcery.UnitTests.net.RTP
 
             Assert.Null(timestamps);
         }
+
+        [Fact]
+        public void AbsSendTime()
+        {
+            logger.LogDebug("--> " + System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+
+            var time = new DateTimeOffset(2024, 2, 11, 14, 51, 02, 999, new TimeSpan(-5, 0, 0));
+            var bytes = RTPHeader.AbsSendTime(time);
+            
+            Assert.Equal(0x22, bytes[0]); // 2 for ID and 2 for Length (3-1)
+            Assert.Equal(155, bytes[1]);
+            Assert.Equal(254, bytes[2]);
+            Assert.Equal(249, bytes[3]);
+        }
     }
 }


### PR DESCRIPTION
* added `a=extmap:` http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time to SDP extension headers
* added `a=rtcp-fb goog-remb` for all media tracks to SDP
* the header extension is added only when remote track supports it
* for now the method can only accept a single extension to be added, but could be made more generic for subsequent extensions
* fixed typo `ATTRIBUE` in one of the consts

closes #1081