### PR TITLE
Introduce SIPUASCancelDelegate

### DIFF
--- a/src/app/SIPUserAgents/ISIPServerUserAgent.cs
+++ b/src/app/SIPUserAgents/ISIPServerUserAgent.cs
@@ -18,6 +18,8 @@ namespace SIPSorcery.SIP.App
 {
     public delegate void SIPUASDelegate(ISIPServerUserAgent uas);
 
+    public delegate void SIPUASCancelDelegate(ISIPServerUserAgent uas, string reasonPhrase, string[] customHeaders);
+
     /// <summary>
     /// Interface for classes implementing SIP server user agent functionality. The
     /// main function of a SIP client user agent is the ability to receive calls.
@@ -35,7 +37,7 @@ namespace SIPSorcery.SIP.App
         string CallDestination { get; }
         bool IsUASAnswered { get; }
 
-        event SIPUASDelegate CallCancelled;
+        event SIPUASCancelDelegate CallCancelled;
         event SIPUASDelegate NoRingTimeout;
 
         bool AuthenticateCall();

--- a/src/app/SIPUserAgents/ISIPServerUserAgent.cs
+++ b/src/app/SIPUserAgents/ISIPServerUserAgent.cs
@@ -18,7 +18,7 @@ namespace SIPSorcery.SIP.App
 {
     public delegate void SIPUASDelegate(ISIPServerUserAgent uas);
 
-    public delegate void SIPUASCancelDelegate(ISIPServerUserAgent uas, string reasonPhrase, string[] customHeaders);
+    public delegate void SIPUASCancelDelegate(ISIPServerUserAgent uas, SIPRequest cancelRequest);
 
     /// <summary>
     /// Interface for classes implementing SIP server user agent functionality. The

--- a/src/app/SIPUserAgents/SIPB2BUserAgent.cs
+++ b/src/app/SIPUserAgents/SIPB2BUserAgent.cs
@@ -51,7 +51,7 @@ namespace SIPSorcery.SIP.App
             base.CallCancelled += SIPServerUserAgent_CallCancelled;
         }
 
-        private void SIPServerUserAgent_CallCancelled(ISIPServerUserAgent uas)
+        private void SIPServerUserAgent_CallCancelled(ISIPServerUserAgent uas, string reason, string[] customHeaders)
         {
             logger.LogDebug("B2BUserAgent server call was cancelled.");
             m_uac?.Cancel();

--- a/src/app/SIPUserAgents/SIPB2BUserAgent.cs
+++ b/src/app/SIPUserAgents/SIPB2BUserAgent.cs
@@ -51,9 +51,9 @@ namespace SIPSorcery.SIP.App
             base.CallCancelled += SIPServerUserAgent_CallCancelled;
         }
 
-        private void SIPServerUserAgent_CallCancelled(ISIPServerUserAgent uas, string reason, string[] customHeaders)
+        private void SIPServerUserAgent_CallCancelled(ISIPServerUserAgent uas, SIPRequest sipCancelRequest)
         {
-            logger.LogDebug("B2BUserAgent server call was cancelled.");
+            logger.LogDebug($"B2BUserAgent server call was cancelled with reason {sipCancelRequest?.Header.Reason}");
             m_uac?.Cancel();
         }
 

--- a/src/app/SIPUserAgents/SIPNonInviteServerUserAgent.cs
+++ b/src/app/SIPUserAgents/SIPNonInviteServerUserAgent.cs
@@ -78,7 +78,7 @@ namespace SIPSorcery.SIP.App
         public UASInviteTransaction ClientTransaction => throw new NotImplementedException();
 
 #pragma warning disable CS0067
-        public event SIPUASDelegate CallCancelled;
+        public event SIPUASCancelDelegate CallCancelled;
         public event SIPUASDelegate NoRingTimeout;
         public event SIPUASDelegate TransactionComplete;
 #pragma warning restore

--- a/src/app/SIPUserAgents/SIPServerUserAgent.cs
+++ b/src/app/SIPUserAgents/SIPServerUserAgent.cs
@@ -493,7 +493,7 @@ namespace SIPSorcery.SIP.App
         {
             logger.LogDebug("SIPServerUserAgent got cancellation request.");
             m_isCancelled = true;
-            CallCancelled?.Invoke(this, sipCancelRequest.Header.Reason, sipCancelRequest.Header.UnknownHeaders.ToArray());
+            CallCancelled?.Invoke(this, sipCancelRequest?.Header.Reason, sipCancelRequest?.Header.UnknownHeaders.ToArray());
         }
 
         private void ClientTransactionFailed(SIPTransaction sipTransaction, SocketError failureReason)

--- a/src/app/SIPUserAgents/SIPServerUserAgent.cs
+++ b/src/app/SIPUserAgents/SIPServerUserAgent.cs
@@ -93,7 +93,7 @@ namespace SIPSorcery.SIP.App
         /// <summary>
         /// The caller cancelled the call request.
         /// </summary>
-        public event SIPUASDelegate CallCancelled;
+        public event SIPUASCancelDelegate CallCancelled;
 
         /// <summary>
         /// This end of the call timed out providing a ringing response. This situation can occur for SIP servers.
@@ -489,11 +489,11 @@ namespace SIPSorcery.SIP.App
             }
         }
 
-        private void UASTransactionCancelled(SIPTransaction sipTransaction)
+        private void UASTransactionCancelled(SIPTransaction sipTransaction, SIPRequest sipCancelRequest)
         {
             logger.LogDebug("SIPServerUserAgent got cancellation request.");
             m_isCancelled = true;
-            CallCancelled?.Invoke(this);
+            CallCancelled?.Invoke(this, sipCancelRequest.Header.Reason, sipCancelRequest.Header.UnknownHeaders.ToArray());
         }
 
         private void ClientTransactionFailed(SIPTransaction sipTransaction, SocketError failureReason)

--- a/src/app/SIPUserAgents/SIPServerUserAgent.cs
+++ b/src/app/SIPUserAgents/SIPServerUserAgent.cs
@@ -493,7 +493,7 @@ namespace SIPSorcery.SIP.App
         {
             logger.LogDebug("SIPServerUserAgent got cancellation request.");
             m_isCancelled = true;
-            CallCancelled?.Invoke(this, sipCancelRequest?.Header.Reason, sipCancelRequest?.Header.UnknownHeaders.ToArray());
+            CallCancelled?.Invoke(this, sipCancelRequest);
         }
 
         private void ClientTransactionFailed(SIPTransaction sipTransaction, SocketError failureReason)

--- a/src/app/SIPUserAgents/SIPUserAgent.cs
+++ b/src/app/SIPUserAgents/SIPUserAgent.cs
@@ -617,10 +617,10 @@ namespace SIPSorcery.SIP.App
             SIPServerUserAgent uas = new SIPServerUserAgent(m_transport, m_outboundProxy, uasTransaction, m_answerSipAccount);
             uas.ClientTransaction.TransactionStateChanged += (tx) => OnTransactionStateChange?.Invoke(tx);
             uas.ClientTransaction.TransactionTraceMessage += (tx, msg) => OnTransactionTraceMessage?.Invoke(tx, msg);
-            uas.CallCancelled += (pendingUas, reason, customHeaders) =>
+            uas.CallCancelled += (pendingUas, sipCancelRequest) =>
             {
                 CallEnded(inviteRequest.Header.CallId);
-                ServerCallCancelled?.Invoke(pendingUas, reason, customHeaders);
+                ServerCallCancelled?.Invoke(pendingUas, sipCancelRequest);
             };
             uas.NoRingTimeout += (pendingUas) =>
             {

--- a/src/app/SIPUserAgents/SIPUserAgent.cs
+++ b/src/app/SIPUserAgents/SIPUserAgent.cs
@@ -276,7 +276,7 @@ namespace SIPSorcery.SIP.App
         /// For calls accepted by this user agent this event will be fired if the call
         /// is cancelled before it gets answered.
         /// </summary>
-        public event SIPUASDelegate ServerCallCancelled;
+        public event SIPUASCancelDelegate ServerCallCancelled;
 
         /// <summary>
         /// For calls accepted by this user agent this event will be fired if the call
@@ -617,10 +617,10 @@ namespace SIPSorcery.SIP.App
             SIPServerUserAgent uas = new SIPServerUserAgent(m_transport, m_outboundProxy, uasTransaction, m_answerSipAccount);
             uas.ClientTransaction.TransactionStateChanged += (tx) => OnTransactionStateChange?.Invoke(tx);
             uas.ClientTransaction.TransactionTraceMessage += (tx, msg) => OnTransactionTraceMessage?.Invoke(tx, msg);
-            uas.CallCancelled += (pendingUas) =>
+            uas.CallCancelled += (pendingUas, reason, customHeaders) =>
             {
                 CallEnded(inviteRequest.Header.CallId);
-                ServerCallCancelled?.Invoke(pendingUas);
+                ServerCallCancelled?.Invoke(pendingUas, reason, customHeaders);
             };
             uas.NoRingTimeout += (pendingUas) =>
             {

--- a/src/core/SIP/SIPTransport.cs
+++ b/src/core/SIP/SIPTransport.cs
@@ -1034,7 +1034,7 @@ namespace SIPSorcery.SIP
                                             if (inviteTransaction != null)
                                             {
                                                 // Note: this will generate the INVITE request response.
-                                                inviteTransaction.CancelCall();
+                                                inviteTransaction.CancelCall(sipRequest);
 
                                                 // Note: this will generate the CANCEL request response.
                                                 SIPResponse okResponse = SIPResponse.GetResponse(sipRequest, SIPResponseStatusCodesEnum.Ok, null);

--- a/src/core/SIPFunctionDelegates.cs
+++ b/src/core/SIPFunctionDelegates.cs
@@ -38,7 +38,7 @@ namespace SIPSorcery.SIP
     public delegate void SIPTransactionStateChangeDelegate(SIPTransaction sipTransaction);
     public delegate Task<SocketError> SIPTransactionResponseReceivedDelegate(SIPEndPoint localSIPEndPoint, SIPEndPoint remoteEndPoint, SIPTransaction sipTransaction, SIPResponse sipResponse);
     public delegate Task<SocketError> SIPTransactionRequestReceivedDelegate(SIPEndPoint localSIPEndPoint, SIPEndPoint remoteEndPoint, SIPTransaction sipTransaction, SIPRequest sipRequest);
-    public delegate void SIPTransactionCancelledDelegate(SIPTransaction sipTransaction);
+    public delegate void SIPTransactionCancelledDelegate(SIPTransaction sipTransaction, SIPRequest sipCancelRequest);
     public delegate void SIPTransactionFailedDelegate(SIPTransaction sipTransaction, SocketError failureReason);
     public delegate void SIPTransactionRequestRetransmitDelegate(SIPTransaction sipTransaction, SIPRequest sipRequest, int retransmitNumber);
     public delegate void SIPTransactionResponseRetransmitDelegate(SIPTransaction sipTransaction, SIPResponse sipResponse, int retransmitNumber);

--- a/src/core/SIPTransactions/UASInviteTransaction.cs
+++ b/src/core/SIPTransactions/UASInviteTransaction.cs
@@ -121,7 +121,7 @@ namespace SIPSorcery.SIP
         /// generated final response.
         /// </summary>
         /// <returns>A socket error with the result of the cancel.</returns>
-        public void CancelCall(SIPRequest sipCancelRequest)
+        public void CancelCall(SIPRequest sipCancelRequest = null)
         {
             if (TransactionState == SIPTransactionStatesEnum.Calling || TransactionState == SIPTransactionStatesEnum.Trying || TransactionState == SIPTransactionStatesEnum.Proceeding)
             {

--- a/src/core/SIPTransactions/UASInviteTransaction.cs
+++ b/src/core/SIPTransactions/UASInviteTransaction.cs
@@ -121,12 +121,12 @@ namespace SIPSorcery.SIP
         /// generated final response.
         /// </summary>
         /// <returns>A socket error with the result of the cancel.</returns>
-        public void CancelCall()
+        public void CancelCall(SIPRequest sipCancelRequest)
         {
             if (TransactionState == SIPTransactionStatesEnum.Calling || TransactionState == SIPTransactionStatesEnum.Trying || TransactionState == SIPTransactionStatesEnum.Proceeding)
             {
                 base.UpdateTransactionState(SIPTransactionStatesEnum.Cancelled);
-                UASInviteTransactionCancelled?.Invoke(this);
+                UASInviteTransactionCancelled?.Invoke(this, sipCancelRequest);
 
                 SIPResponse cancelResponse = SIPResponse.GetResponse(TransactionRequest, SIPResponseStatusCodesEnum.RequestTerminated, null);
                 cancelResponse.Header.To.ToTag = LocalTag;


### PR DESCRIPTION
Introduce a SIPUASCancelDelegate so that reason and other information can be passed to the application when a call is cancelled.