### PR TITLE
Incremented CSeq number with each REGISTER request

### DIFF
--- a/src/app/SIPUserAgents/SIPRegistrationUserAgent.cs
+++ b/src/app/SIPUserAgents/SIPRegistrationUserAgent.cs
@@ -446,6 +446,9 @@ namespace SIPSorcery.SIP.App
                                 };
                                 regAuthTransaction.NonInviteTransactionFailed += RegistrationTransactionFailed;
                                 regAuthTransaction.SendRequest();
+
+                                // make sure CSeq does not decrease
+                                m_cseq = Math.Max(m_cseq, authenticatedRequest.Header.CSeq);
                             }
                         }
                     }


### PR DESCRIPTION
Currently, after receiving `401 Unauthorized` response for an initial `REGISTER` request (with `CSeq=1`), we add the authorization info to the request (incrementing its `CSeq` to 2) and resend it. The problem is that the SIPRegistrationUserAgent instance is not aware that `CSeq` was incremented, and, so, when we call `SIPRegistrationUserAgent.Stop()` in order to remove the registration on the server side, the corresponding request with `Expires=0` is sent with `CSeq=2` and so is ignored by the server, since `CSeq` must be incremented with each subsequent request (or at least be unique).