### PR TITLE
Adding ECDSA as certificate type Fixes #1104

### DIFF
--- a/src/net/DtlsSrtp/DtlsSrtpClient.cs
+++ b/src/net/DtlsSrtp/DtlsSrtpClient.cs
@@ -45,7 +45,7 @@ namespace SIPSorcery.Net
         public virtual TlsCredentials GetClientCredentials(CertificateRequest certificateRequest)
         {
             byte[] certificateTypes = certificateRequest.CertificateTypes;
-            if (certificateTypes == null || !Arrays.Contains(certificateTypes, ClientCertificateType.rsa_sign))
+            if (certificateTypes == null || !Arrays.Contains(certificateTypes, ClientCertificateType.rsa_sign) || !Arrays.Contains(certificateTypes, ClientCertificateType.ecdsa_sign))
             {
                 return null;
             }

--- a/src/net/DtlsSrtp/DtlsSrtpServer.cs
+++ b/src/net/DtlsSrtp/DtlsSrtpServer.cs
@@ -248,7 +248,7 @@ namespace SIPSorcery.Net
                     }
                 }
             }
-            return new CertificateRequest(new byte[] { ClientCertificateType.rsa_sign }, serverSigAlgs, null);
+            return new CertificateRequest(new byte[] { ClientCertificateType.rsa_sign, ClientCertificateType.ecdsa_sign }, serverSigAlgs, null);
         }
 
         public override void NotifyClientCertificate(Certificate clientCertificate)


### PR DESCRIPTION
Chrome is now checking certificate type and needs to be passed the correct one in Certificate Request. WebRTC primarily uses ECDSA, I believe the intent is to support ECDSA, per TLS protocol, you need to say so in the CertificateRequest message.

Adding ECDSA to DtlsSrtpClient.cs as just to remain in sync with the server code but I have no way to verify that direction.

Fixes https://github.com/sipsorcery-org/sipsorcery/issues/1104