### PR TITLE
Enable generation of SIPSorcery.xml documentation file

### DIFF
--- a/src/SIPSorcery.csproj
+++ b/src/SIPSorcery.csproj
@@ -28,6 +28,9 @@
     <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.1;net461;net5.0;net6.0;net8.0</TargetFrameworks>
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
     <NoWarn>$(NoWarn);SYSLIB0050</NoWarn>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <!-- Disable warning for missing XML doc comments. -->
+    <NoWarn>$(NoWarn);CS1591;CS1573;CS1587</NoWarn>
     <Authors>Aaron Clauson, Christophe Irles, Rafael Soares &amp; Contributors</Authors>
     <Copyright>Copyright © 2010-2024 Aaron Clauson</Copyright>
     <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>

--- a/src/app/Media/Codecs/AudioEncoder.cs
+++ b/src/app/Media/Codecs/AudioEncoder.cs
@@ -123,9 +123,8 @@ namespace SIPSorcery.Media
         /// <summary>
         /// Event handler for receiving RTP packets from the remote party.
         /// </summary>
-        /// <param name="remoteEP">The remote end point the RTP was received from.</param>
+        /// <param name="encodedSample">Data received from an RTP socket.</param>
         /// <param name="format">The audio format of the encoded packets.</param>
-        /// <param name="rtpPacket">The RTP packet with the media sample.</param>
         public short[] DecodeAudio(byte[] encodedSample, AudioFormat format)
         {
             if (format.Codec == AudioCodecsEnum.G722)

--- a/src/app/Media/Codecs/G729Codec/CodLd8k.cs
+++ b/src/app/Media/Codecs/G729Codec/CodLd8k.cs
@@ -155,7 +155,7 @@ namespace SIPSorcery.Media.G729Codec
         /**
  * Initialization of variables for the encoder.
  * Initialize pointers to speech vector.
- *<pre>
+ *<pre> <![CDATA[
  *   |--------------------|-------------|-------------|------------|
  *     previous speech           sf1           sf2         L_NEXT
  *
@@ -166,7 +166,7 @@ namespace SIPSorcery.Media.G729Codec
  *     p_wind            |              |
  *                     speech           |
  *                             new_speech
- * </pre>
+ * ]]></pre>
  */
 
         public void init_coder_ld8k()

--- a/src/app/Media/Codecs/G729Codec/CorFunc.cs
+++ b/src/app/Media/Codecs/G729Codec/CorFunc.cs
@@ -59,7 +59,7 @@ namespace SIPSorcery.Media.G729Codec
  * @param xn        input : target vector x[0:l_subfr]
  * @param y1        input : filtered adaptive codebook vector
  * @param y2        input : filtered 1st codebook innovation
- * @param g_coeff   output: <y2,y2> , -2<xn,y2> , and 2<y1,y2>
+ * @param g_coeff   <![CDATA[ output: <y2,y2> , -2<xn,y2> , and 2<y1,y2> ]]>
  */
 
         public static void corr_xy2(

--- a/src/app/Media/Codecs/G729Codec/Gainpred.cs
+++ b/src/app/Media/Codecs/G729Codec/Gainpred.cs
@@ -118,13 +118,13 @@ namespace SIPSorcery.Media.G729Codec
 
         /**
  * Update table of past quantized energies (frame erasure).
- * <pre>
+ * <pre> <![CDATA[
  *     av_pred_en = 0.0;
  *     for (i = 0; i < 4; i++)
  *        av_pred_en += past_qua_en[i];
  *     av_pred_en = av_pred_en*0.25 - 4.0;
  *     if (av_pred_en < -14.0) av_pred_en = -14.0;
- * </pre>
+ * ]]></pre>
  *
  * @param past_qua_en   input/output:Past quantized energies
  */

--- a/src/app/Media/Codecs/G729Codec/Ld8k.cs
+++ b/src/app/Media/Codecs/G729Codec/Ld8k.cs
@@ -124,12 +124,12 @@ namespace SIPSorcery.Media.G729Codec
         public static float GAMMA2_PST = 0.55f;
 
         /**
- * tilt weighting factor when k1<0
+ * tilt weighting factor when k1 &lt; 0
  */
         public static float GAMMA3_MINUS = 0.9f;
 
         /**
- * tilt weighting factor when k1>0
+ * tilt weighting factor when k1 &gt; 0
  */
         public static float GAMMA3_PLUS = 0.2f;
 

--- a/src/app/Media/Codecs/G729Codec/Pitch.cs
+++ b/src/app/Media/Codecs/G729Codec/Pitch.cs
@@ -351,7 +351,7 @@ namespace SIPSorcery.Media.G729Codec
             }
         }
 
-        /**
+        /** <![CDATA[
  * Compute adaptive codebook gain and compute <y1,y1> , -2<xn,y1>
  *
  * @param xn        input : target vector
@@ -359,6 +359,7 @@ namespace SIPSorcery.Media.G729Codec
  * @param g_coeff   output: <y1,y1> and -2<xn,y1>
  * @param l_subfr   input : vector dimension
  * @return          pitch gain
+ * ]]>
  */
 
         public static float g_pitch(

--- a/src/app/Media/Codecs/G729Codec/Postfil.cs
+++ b/src/app/Media/Codecs/G729Codec/Postfil.cs
@@ -635,7 +635,7 @@ namespace SIPSorcery.Media.G729Codec
 
         /**
  * Compute delayed signal,
- * num & den of gain for fractional delay
+ * num &amp; den of gain for fractional delay
  * with long interpolation filter
  *
  * @param s_in           input signal with past

--- a/src/app/Media/IMediaSession.cs
+++ b/src/app/Media/IMediaSession.cs
@@ -102,7 +102,7 @@ namespace SIPSorcery.SIP.App
         /// if they are.
         /// </summary>
         /// <param name="sdpType">Whether the SDP being set is an offer or answer.</param>
-        /// <param name="sdp">The SDP description from the remote party.</param>
+        /// <param name="sessionDescription">The SDP description from the remote party.</param>
         /// <returns>If successful an OK enum result. If not an enum result indicating the 
         /// failure cause.</returns>
         SetDescriptionResultEnum SetRemoteDescription(SdpType sdpType, SDP sessionDescription);

--- a/src/app/Media/Sources/AudioSignalGenerator.cs
+++ b/src/app/Media/Sources/AudioSignalGenerator.cs
@@ -67,7 +67,7 @@ namespace SIPSorcery.Media
         /// Initializes a new instance for the Generator (UserDef SampleRate &amp; Channels)
         /// </summary>
         /// <param name="sampleRate">Desired sample rate</param>
-        /// <param name="channel">Number of channels</param>
+        /// <param name="channels">Number of channels</param>
         public SignalGenerator(int sampleRate, int channels)
         {
             phi = 0;

--- a/src/app/SIPUserAgents/SIPCallDescriptor.cs
+++ b/src/app/SIPUserAgents/SIPCallDescriptor.cs
@@ -265,7 +265,7 @@ namespace SIPSorcery.SIP.App
         /// </summary>
         /// <param name="fromDisplayName"></param>
         /// <param name="fromUsername"></param>
-        /// <param name="fromhost"></param>
+        /// <param name="fromHost"></param>
         public void SetGeneralFromHeaderFields(string fromDisplayName, string fromUsername, string fromHost)
         {
             if (!fromDisplayName.IsNullOrBlank() && FromDisplayName == null)

--- a/src/app/SIPUserAgents/SIPUserAgent.cs
+++ b/src/app/SIPUserAgents/SIPUserAgent.cs
@@ -416,7 +416,7 @@ namespace SIPSorcery.SIP.App
 
         /// <summary>
         /// Attempts to place a new outgoing call AND waits for the call to be answered or fail.
-        /// Use <see cref="InitiateCallAsync(SIPCallDescriptor, IMediaSession)"/> to start a call without
+        /// Use <see cref="InitiateCallAsync(SIPCallDescriptor, IMediaSession, int)"/> to start a call without
         /// waiting for it to complete and monitor <see cref="ClientCallAnsweredHandler"/> and
         /// <see cref="ClientCallFailedHandler"/> to detect an answer or failure.
         /// </summary>
@@ -464,7 +464,7 @@ namespace SIPSorcery.SIP.App
 
         /// <summary>
         /// Attempts to place a new outgoing call AND waits for the call to be answered or fail.
-        /// Use <see cref="InitiateCallAsync(SIPCallDescriptor, IMediaSession)"/> to start a call without
+        /// Use <see cref="InitiateCallAsync(SIPCallDescriptor, IMediaSession, int)"/> to start a call without
         /// waiting for it to complete and monitor <see cref="ClientCallAnsweredHandler"/> and
         /// <see cref="ClientCallFailedHandler"/> to detect an answer or failure.
         /// </summary>

--- a/src/net/DtlsSrtp/Transform/SrtcpTransformer.cs
+++ b/src/net/DtlsSrtp/Transform/SrtcpTransformer.cs
@@ -28,7 +28,7 @@ namespace SIPSorcery.Net
     /// It encapsulate the encryption / decryption logic for SRTCP packets
     ///
     /// @author Bing SU (nova.su @gmail.com)
-    /// @author Werner Dittmann<Werner.Dittmann@t-online.de>
+    /// @author Werner Dittmann (Werner.Dittmann@t-online.de)
     /// </summary>
     public class SrtcpTransformer : IPacketTransformer
     {

--- a/src/net/DtlsSrtp/Transform/SrtpCipherCTR.cs
+++ b/src/net/DtlsSrtp/Transform/SrtpCipherCTR.cs
@@ -33,7 +33,7 @@
  * limitations under the License.
  */
 
-/**
+/*
  * SRTPCipherF8 implements SRTP F8 Mode AES Encryption (AES-f8).
  * F8 Mode AES Encryption algorithm is defined in RFC3711, section 4.1.2.
  * 

--- a/src/net/DtlsSrtp/Transform/SrtpCipherF8.cs
+++ b/src/net/DtlsSrtp/Transform/SrtpCipherF8.cs
@@ -58,7 +58,7 @@
  * We use AESCipher to handle basic AES encryption / decryption.
  * 
  * @author Bing SU (nova.su@gmail.com)
- * @author Werner Dittmann <werner.dittmann@t-online.de>
+ * @author Werner Dittmann (werner.dittmann@t-online.de)
  */
 
 using System.IO;

--- a/src/net/ICE/RTCIceCandidate.cs
+++ b/src/net/ICE/RTCIceCandidate.cs
@@ -396,7 +396,7 @@ namespace SIPSorcery.Net
         /// protocol and IP end point. Primary use case is to check whether a candidate
         /// is a match for a remote end point that a message has been received from.
         /// </summary>
-        /// <param name="epProtocol">The protocol to check equivalence for.</param>
+        /// <param name="epPotocol">The protocol to check equivalence for.</param>
         /// <param name="ep">The IP end point to check equivalence for.</param>
         /// <returns>True if the candidate is deemed equivalent or false if not.</returns>
         public bool IsEquivalentEndPoint(RTCIceProtocol epPotocol, IPEndPoint ep)

--- a/src/net/ICE/RtpIceChannel.cs
+++ b/src/net/ICE/RtpIceChannel.cs
@@ -2601,7 +2601,6 @@ namespace SIPSorcery.Net
         /// <summary>
         /// Sends a packet via a TURN relay server.
         /// </summary>
-        /// <param name="sendOn">The local socket to send the packet from.</param>
         /// <param name="dstEndPoint">The peer destination end point.</param>
         /// <param name="buffer">The data to send to the peer.</param>
         /// <param name="relayEndPoint">The TURN server end point to send the relayed request to.</param>

--- a/src/net/RTCP/RTCPSession.cs
+++ b/src/net/RTCP/RTCPSession.cs
@@ -261,7 +261,7 @@ namespace SIPSorcery.Net
         /// Event handler for an RTCP packet being received from the remote party.
         /// </summary>
         /// <param name="remoteEndPoint">The end point the packet was received from.</param>
-        /// <param name="buffer">The data received.</param>
+        /// <param name="rtcpCompoundPacket">The data received.</param>
         public void ReportReceived(IPEndPoint remoteEndPoint, RTCPCompoundPacket rtcpCompoundPacket)
         {
             try

--- a/src/net/RTP/MediaStream.cs
+++ b/src/net/RTP/MediaStream.cs
@@ -402,11 +402,10 @@ namespace SIPSorcery.net.RTP
         /// <summary>
         /// Allows additional control for sending raw RTP payloads. No framing or other processing is carried out.
         /// </summary>
-        /// <param name="mediaType">The media type of the RTP packet being sent. Must be audio or video.</param>
-        /// <param name="payload">The RTP packet payload.</param>
+        /// <param name="data">The RTP packet payload.</param>
         /// <param name="timestamp">The timestamp to set on the RTP header.</param>
         /// <param name="markerBit">The value to set on the RTP header marker bit, should be 0 or 1.</param>
-        /// <param name="payloadTypeID">The payload ID to set in the RTP header.</param>
+        /// <param name="payloadType">The payload ID to set in the RTP header.</param>
         /// <param name="seqNum"> The RTP sequence number </param>
         public void SendRtpRaw(byte[] data, uint timestamp, int markerBit, int payloadType, ushort seqNum)
         {
@@ -416,11 +415,10 @@ namespace SIPSorcery.net.RTP
         /// <summary>
         /// Allows additional control for sending raw RTP payloads. No framing or other processing is carried out.
         /// </summary>
-        /// <param name="mediaType">The media type of the RTP packet being sent. Must be audio or video.</param>
-        /// <param name="payload">The RTP packet payload.</param>
+        /// <param name="data">The RTP packet payload.</param>
         /// <param name="timestamp">The timestamp to set on the RTP header.</param>
         /// <param name="markerBit">The value to set on the RTP header marker bit, should be 0 or 1.</param>
-        /// <param name="payloadTypeID">The payload ID to set in the RTP header.</param>
+        /// <param name="payloadType">The payload ID to set in the RTP header.</param>
         public void SendRtpRaw(byte[] data, uint timestamp, int markerBit, int payloadType)
         {
             SendRtpRaw(data, timestamp, markerBit, payloadType, false);
@@ -519,7 +517,6 @@ namespace SIPSorcery.net.RTP
         /// <summary>
         /// Allows sending of RTCP feedback reports.
         /// </summary>
-        /// <param name="mediaType">The media type of the RTCP report  being sent. Must be audio or video.</param>
         /// <param name="feedback">The feedback report to send.</param>
         public void SendRtcpFeedback(RTCPFeedback feedback)
         {
@@ -718,7 +715,6 @@ namespace SIPSorcery.net.RTP
         /// <summary>
         /// Adjusts the expected remote end point for a particular media type.
         /// </summary>
-        /// <param name="mediaType">The media type of the RTP packet received.</param>
         /// <param name="ssrc">The SSRC from the RTP packet header.</param>
         /// <param name="receivedOnEndPoint">The actual remote end point that the RTP packet came from.</param>
         /// <returns>True if remote end point for this media type was the expected one or it was adjusted. False if
@@ -773,8 +769,6 @@ namespace SIPSorcery.net.RTP
         /// <summary>
         /// Creates a new RTCP session for a media track belonging to this RTP session.
         /// </summary>
-        /// <param name="mediaType">The media type to create the RTP session for. Must be
-        /// audio or video.</param>
         /// <returns>A new RTCPSession object. The RTCPSession must have its Start method called
         /// in order to commence sending RTCP reports.</returns>
         public Boolean CreateRtcpSession()
@@ -791,7 +785,6 @@ namespace SIPSorcery.net.RTP
         /// <summary>
         /// Sets the remote end points for a media type supported by this RTP session.
         /// </summary>
-        /// <param name="mediaType">The media type, must be audio or video, to set the remote end point for.</param>
         /// <param name="rtpEndPoint">The remote end point for RTP packets corresponding to the media type.</param>
         /// <param name="rtcpEndPoint">The remote end point for RTCP packets corresponding to the media type.</param>
         public void SetDestination(IPEndPoint rtpEndPoint, IPEndPoint rtcpEndPoint)

--- a/src/net/RTP/MediaStreamTrack.cs
+++ b/src/net/RTP/MediaStreamTrack.cs
@@ -80,7 +80,7 @@ namespace SIPSorcery.Net
         /// </summary>
         public List<SDPAudioVideoMediaFormat> Capabilities { get; internal set; }
 
-        // <summary>
+        /// <summary>
         ///  a=extmap - Mapping for RTP header extensions
         /// </summary>
         public Dictionary<int, RTPHeaderExtension> HeaderExtensions { get; }
@@ -205,7 +205,7 @@ namespace SIPSorcery.Net
         /// <summary>
         /// Add a local audio track.
         /// </summary>
-        /// <param name="audioFormats">The audio formats that the local application supports.</param>
+        /// <param name="formats">The audio formats that the local application supports.</param>
         /// <param name="streamStatus">Optional. The stream status for the audio track, e.g. whether
         /// send and receive or only one of.</param>
         public MediaStreamTrack(
@@ -229,7 +229,7 @@ namespace SIPSorcery.Net
         /// <summary>
         /// Add a local video track.
         /// </summary>
-        /// <param name="videoFormats">The video formats that the local application supports.</param>
+        /// <param name="formats">The video formats that the local application supports.</param>
         /// <param name="streamStatus">Optional. The stream status for the video track, e.g. whether
         /// send and receive or only one of.</param>
         public MediaStreamTrack(

--- a/src/net/RTP/Packetisation/H264Depacketiser.cs
+++ b/src/net/RTP/Packetisation/H264Depacketiser.cs
@@ -1,16 +1,16 @@
-﻿/// <summary>
-/// Based in https://github.com/BogdanovKirill/RtspClientSharp/blob/master/RtspClientSharp/MediaParsers/H264VideoPayloadParser.cs 
-/// Distributed under MIT License
-/// 
-/// @author raf.csoares@kyubinteractive.com
-/// </summary>
-
+﻿
 using System;
 using System.Collections.Generic;
 using System.IO;
 
 namespace SIPSorcery.Net
 {
+    /// <summary>
+    /// Based in https://github.com/BogdanovKirill/RtspClientSharp/blob/master/RtspClientSharp/MediaParsers/H264VideoPayloadParser.cs 
+    /// Distributed under MIT License
+    /// 
+    /// @author raf.csoares@kyubinteractive.com
+    /// </summary>
     public class H264Depacketiser
     {
         const int SPS = 7;

--- a/src/net/RTP/RTPSession.cs
+++ b/src/net/RTP/RTPSession.cs
@@ -1585,7 +1585,7 @@ namespace SIPSorcery.Net
         /// <summary>
         /// Generates a session description from the provided list of MediaStream.
         /// </summary>
-        /// <param name="tracks">The list of tracks to generate the session description for.</param>
+        /// <param name="mediaStreamList">The list of tracks to generate the session description for.</param>
         /// <param name="connectionAddress">Optional. If set this address will be used as 
         /// the SDP Connection address. If not specified the Internet facing address will
         /// be used. IPAddress.Any and IPAddress. Any and IPv6Any are special cases. If they are set the respective
@@ -1799,7 +1799,6 @@ namespace SIPSorcery.Net
         /// Creates a new RTP channel (which manages the UDP socket sending and receiving RTP
         /// packets) for use with this session.
         /// </summary>
-        /// <param name="mediaType">The type of media the RTP channel is for. Must be audio or video.</param>
         /// <returns>A new RTPChannel instance.</returns>
         protected virtual RTPChannel CreateRtpChannel()
         {

--- a/src/net/RTP/VideoStream.cs
+++ b/src/net/RTP/VideoStream.cs
@@ -83,11 +83,11 @@ namespace SIPSorcery.net.RTP
         /// It's intended as a quick convenient way to send something like a test pattern image over an RTSP connection. More than likely it won't be suitable when a high
         /// quality image is required since the header used in this method does not support quantization tables.
         /// </summary>
+        /// <param name="duration">The duration in timestamp units of the payload (e.g. 3000 for 30fps).</param>
         /// <param name="jpegBytes">The raw encoded bytes of the JPEG image to transmit.</param>
         /// <param name="jpegQuality">The encoder quality of the JPEG image.</param>
         /// <param name="jpegWidth">The width of the JPEG image.</param>
         /// <param name="jpegHeight">The height of the JPEG image.</param>
-        /// <param name="framesPerSecond">The rate at which the JPEG frames are being transmitted at. used to calculate the timestamp.</param>
         public void SendJpegFrame(uint duration, int payloadTypeID, byte[] jpegBytes, int jpegQuality, int jpegWidth, int jpegHeight)
         {
             if (CheckIfCanSendRtpRaw())
@@ -129,8 +129,9 @@ namespace SIPSorcery.net.RTP
         /// An Access Unit can contain one or more NAL's. The NAL's have to be parsed in order to be able to package 
         /// in RTP packets.
         /// 
-        /// See https://www.itu.int/rec/dologin_pub.asp?lang=e&id=T-REC-H.264-201602-S!!PDF-E&type=items Annex B for byte stream specification.
+        /// See <see href="https://www.itu.int/rec/dologin_pub.asp?lang=e&amp;id=T-REC-H.264-201602-S!!PDF-E&amp;type=items" /> Annex B for byte stream specification.
         /// </remarks>
+        // The same URL without XML escape sequences: https://www.itu.int/rec/dologin_pub.asp?lang=e&id=T-REC-H.264-201602-S!!PDF-E&type=items
         public void SendH264Frame(uint duration, int payloadTypeID, byte[] accessUnit)
         {
             if (CheckIfCanSendRtpRaw())
@@ -150,8 +151,6 @@ namespace SIPSorcery.net.RTP
         /// <param name="nal">The buffer containing the NAL to send.</param>
         /// <param name="isLastNal">Should be set for the last NAL in the H264 access unit. Determines when the markbit gets set 
         /// and the timestamp incremented.</param>
-        /// <param name="dstEndPoint">The destination end point to send to.</param>
-        /// <param name="LocalTrack">The video track to send on.</param>
         private void SendH264Nal(uint duration, int payloadTypeID, byte[] nal, bool isLastNal)
         {
             //logger.LogDebug($"Send NAL {nal.Length}, is last {isLastNal}, timestamp {videoTrack.Timestamp}.");
@@ -204,7 +203,7 @@ namespace SIPSorcery.net.RTP
         /// <summary>
         /// Sends a VP8 frame as one or more RTP packets.
         /// </summary>
-        /// <param name="timestamp">The timestamp to place in the RTP header. Needs
+        /// <param name="duration"> The duration in timestamp units of the payload. Needs
         /// to be based on a 90Khz clock.</param>
         /// <param name="payloadTypeID">The payload ID to place in the RTP header.</param>
         /// <param name="buffer">The VP8 encoded payload.</param>

--- a/src/net/RTSP/Mjpeg.cs
+++ b/src/net/RTSP/Mjpeg.cs
@@ -321,7 +321,7 @@ namespace SIPSorcery.Net
         /// Creates a Jpeg QuantizationTableMarker for each table given in the tables
         /// </summary>
         /// <param name="tables">The tables verbatim, either 1 or 2 (Luminance and Chrominance)</param>
-        /// <returns>The table with marker and prefix/returns>
+        /// <returns>The table with marker and prefix</returns>
         static byte[] CreateQuantizationTablesMarker(ArraySegment<byte> tables, byte precision)
         {
             //List<byte> result = new List<byte>();

--- a/src/net/SCTP/Chunks/SctpDataChunk.cs
+++ b/src/net/SCTP/Chunks/SctpDataChunk.cs
@@ -98,7 +98,7 @@ namespace SIPSorcery.Net
         /// without requiring it to be delivered to the remote part in order.</param>
         /// <param name="isBegining">Must be set to true for the first chunk in a user data payload.</param>
         /// <param name="isEnd">Must be set to true for the last chunk in a user data payload. Note that
-        /// <see cref="isBegining"/> and <see cref="isEnd"/> must both be set to true when the full payload
+        /// <paramref name="isBegining"/> and <paramref name="isEnd"/> must both be set to true when the full payload
         /// is being sent in a single data chunk.</param>
         /// <param name="tsn">The Transmission Sequence Number for this chunk.</param>
         /// <param name="streamID">Optional. The stream ID for this data chunk.</param>

--- a/src/net/SCTP/SctpAssociation.cs
+++ b/src/net/SCTP/SctpAssociation.cs
@@ -588,7 +588,7 @@ namespace SIPSorcery.Net
         /// </summary>
         /// <param name="streamID">The stream ID to sent the data on.</param>
         /// <param name="ppid">The payload protocol ID for the data.</param>
-        /// <param name="message">The byte data to send.</param>
+        /// <param name="data">The byte data to send.</param>
         public void SendData(ushort streamID, uint ppid, byte[] data)
         {
             if (_wasAborted)

--- a/src/net/SCTP/SctpDataReceiver.cs
+++ b/src/net/SCTP/SctpDataReceiver.cs
@@ -33,6 +33,10 @@ namespace SIPSorcery.Net
         public uint PPID;
         public byte[] UserData;
 
+        /// <param name="streamID">The stream ID of the chunk.</param>
+        /// <param name="streamSeqNum">The stream sequence number of the chunk. Will be 0 for unordered streams.</param>
+        /// <param name="ppid">The payload protocol ID for the chunk.</param>
+        /// <param name="userData">The chunk data.</param>
         public SctpDataFrame(bool unordered, ushort streamID, ushort streamSeqNum, uint ppid, byte[] userData)
         {
             Unordered = unordered;

--- a/src/net/SCTP/SctpDataSender.cs
+++ b/src/net/SCTP/SctpDataSender.cs
@@ -305,7 +305,7 @@ namespace SIPSorcery.Net
         /// </summary>
         /// <param name="streamID">The stream ID to sent the data on.</param>
         /// <param name="ppid">The payload protocol ID for the data.</param>
-        /// <param name="message">The byte data to send.</param>
+        /// <param name="data">The byte data to send.</param>
         public void SendData(ushort streamID, uint ppid, byte[] data)
         {
             lock (_sendQueue)
@@ -665,7 +665,7 @@ namespace SIPSorcery.Net
         /// Updates the round trip time. 
         /// See https://datatracker.ietf.org/doc/html/rfc4960#section-6.3.1
         /// </summary>
-        /// <param name="rttMilliseconds">The last round trip time</param>
+        /// <param name="acknowledgedChunk">The last sent and acknowledged chunk used to calculate the round trip time</param>
         private void UpdateRoundTripTime(SctpDataChunk acknowledgedChunk)
         {
             // rfc 4960 6.3.1 C5: RTT measurements MUST NOT be made using packets that were retransmitted

--- a/src/net/SCTP/SctpPacket.cs
+++ b/src/net/SCTP/SctpPacket.cs
@@ -82,7 +82,7 @@ namespace SIPSorcery.Net
         public SctpHeader Header;
 
         /// <summary>
-        /// The list of one or recognised chunks after parsing with <see cref="GetChunks"/> 
+        /// The list of one or recognised chunks after parsing with <see cref="GetChunks"/>
         /// or chunks that have been manually added for an outgoing SCTP packet.
         /// </summary>
         public List<SctpChunk> Chunks;

--- a/src/net/SCTP/SctpTransport.cs
+++ b/src/net/SCTP/SctpTransport.cs
@@ -297,8 +297,8 @@ namespace SIPSorcery.Net
         /// <summary>
         /// Send an SCTP packet with one of the error type chunks (ABORT or ERROR) to the remote peer.
         /// </summary>
-        /// <param name=isAbort">Set to true to use an ABORT chunk otherwise an ERROR chunk will be used.</param>
-        /// <param name="desintationPort">The SCTP destination port.</param>
+        /// <param name="isAbort">Set to true to use an ABORT chunk otherwise an ERROR chunk will be used.</param>
+        /// <param name="destinationPort">The SCTP destination port.</param>
         /// <param name="sourcePort">The SCTP source port.</param>
         /// <param name="initiateTag">If available the initial tag for the remote peer.</param>
         /// <param name="error">The error to send.</param>

--- a/src/net/SDP/SDPAudioVideoMediaFormat.cs
+++ b/src/net/SDP/SDPAudioVideoMediaFormat.cs
@@ -54,7 +54,7 @@ namespace SIPSorcery.Net
         /// Note (rj2): FormatID MUST be string (not int), in case ID is 't38' and type is 'image'
         /// Note to above: The FormatID is always numeric for profile "RTP/AVP" and "RTP/SAVP", see 
         /// https://tools.ietf.org/html/rfc4566#section-5.14 and section on "fmt":
-        /// "If the <proto> sub-field is "RTP/AVP" or "RTP/SAVP" the <fmt>
+        /// "If the [proto] sub-field is "RTP/AVP" or "RTP/SAVP" the [fmt]
         /// sub-fields contain RTP payload type numbers"
         /// In the case of T38 the format name is "t38" but the formatID must be set as a dynamic ID.
         /// <code>
@@ -79,7 +79,7 @@ namespace SIPSorcery.Net
         /// <code>
         /// // Example
         /// a=rtpmap:0 PCMU/8000
-        /// a=rtpmap:101 telephone-event/8000 <-- "101 telephone-event/8000" is the rtpmap properties.
+        /// a=rtpmap:101 telephone-event/8000 ← "101 telephone-event/8000" is the rtpmap properties.
         /// a=fmtp:101 0-16
         /// </code>
         /// </summary>
@@ -91,7 +91,7 @@ namespace SIPSorcery.Net
         /// // Example
         /// a=rtpmap:0 PCMU/8000
         /// a=rtpmap:101 telephone-event/8000 
-        /// a=fmtp:101 0-16                     <-- "101 0-16" is the fmtp attribute.
+        /// a=fmtp:101 0-16                     ← "101 0-16" is the fmtp attribute.
         /// </code>
         /// </summary>
         public string Fmtp { get; }
@@ -108,7 +108,7 @@ namespace SIPSorcery.Net
         /// The standard name of the media format.
         /// <code>
         /// // Example
-        /// a=rtpmap:0 PCMU/8000                <-- "PCMU" is the media format name.
+        /// a=rtpmap:0 PCMU/8000                ← "PCMU" is the media format name.
         /// a=rtpmap:101 telephone-event/8000 
         /// a=fmtp:101 0-16
         /// </code>

--- a/src/net/WebRTC/IRTCPeerConnection.cs
+++ b/src/net/WebRTC/IRTCPeerConnection.cs
@@ -54,6 +54,7 @@ namespace SIPSorcery.Net
     /// </remarks>
     public class RTCAnswerOptions
     {
+        /// <summary>
         /// If set it indicates that any available ICE candidates should NOT be added
         /// to the offer SDP. By default "host" candidates should always be available
         /// and will be added to the offer SDP.

--- a/src/net/WebRTC/RTCPeerConnection.cs
+++ b/src/net/WebRTC/RTCPeerConnection.cs
@@ -518,7 +518,7 @@ namespace SIPSorcery.Net
         /// <summary>
         /// Event handler for ICE connection state changes.
         /// </summary>
-        /// <param name="state">The new ICE connection state.</param>
+        /// <param name="iceState">The new ICE connection state.</param>
         private async void IceConnectionStateChange(RTCIceConnectionState iceState)
         {
             oniceconnectionstatechange?.Invoke(iceConnectionState);
@@ -624,7 +624,6 @@ namespace SIPSorcery.Net
         /// Creates a new RTP ICE channel (which manages the UDP socket sending and receiving RTP
         /// packets) for use with this session.
         /// </summary>
-        /// <param name="mediaType">The type of media the RTP channel is for. Must be audio or video.</param>
         /// <returns>A new RTPChannel instance.</returns>
         protected override RTPChannel CreateRtpChannel()
         {
@@ -1258,7 +1257,7 @@ namespace SIPSorcery.Net
         }
 
         /// <summary>
-        /// From RFC5764:
+        /// From RFC5764: <![CDATA[
         ///             +----------------+
         ///             | 127 < B< 192  -+--> forward to RTP
         ///             |                |
@@ -1266,6 +1265,7 @@ namespace SIPSorcery.Net
         ///             |                |
         ///             |       B< 2    -+--> forward to STUN
         ///             +----------------+
+        /// ]]>
         /// </summary>
         /// <paramref name="localPort">The local port on the RTP socket that received the packet.</paramref>
         /// <param name="remoteEP">The remote end point the packet was received from.</param>
@@ -1314,7 +1314,7 @@ namespace SIPSorcery.Net
         /// example is when a machine is behind a 1:1 NAT and the application wants a host 
         /// candidate with the public IP address to be included.
         /// </summary>
-        /// <param name="candidateInit">The ICE candidate to add.</param>
+        /// <param name="candidate">The ICE candidate to add.</param>
         /// <example>
         /// var natCandidate = new RTCIceCandidate(RTCIceProtocol.udp, natAddress, natPort, RTCIceCandidateType.host);
         /// pc.addLocalIceCandidate(natCandidate);
@@ -1538,10 +1538,6 @@ namespace SIPSorcery.Net
         /// <summary>
         /// Event handler for an SCTP DATA chunk being received on the SCTP association.
         /// </summary>
-        /// <param name="streamID">The stream ID of the chunk.</param>
-        /// <param name="streamSeqNum">The stream sequence number of the chunk. Will be 0 for unordered streams.</param>
-        /// <param name="ppID">The payload protocol ID for the chunk.</param>
-        /// <param name="data">The chunk data.</param>
         private void OnSctpAssociationDataChunk(SctpDataFrame frame)
         {
             if (dataChannels.TryGetChannel(frame.StreamID, out var dc))

--- a/src/net/WebRTC/RTCPeerSctpAssociation.cs
+++ b/src/net/WebRTC/RTCPeerSctpAssociation.cs
@@ -69,8 +69,6 @@ namespace SIPSorcery.Net
         /// </summary>
         /// <param name="rtcSctpTransport">The DTLS transport that will be used to encapsulate the
         /// SCTP packets.</param>
-        /// <param name="isClient">True if this peer will be the client within the association. This
-        /// dictates whether streams created use odd or even ID's.</param>
         /// <param name="srcPort">The source port to use when forming the association.</param>
         /// <param name="dstPort">The destination port to use when forming the association.</param>
         /// <param name="dtlsPort">Optional. The local UDP port being used for the DTLS connection. This

--- a/src/net/WebRTC/RTCSctpTransport.cs
+++ b/src/net/WebRTC/RTCSctpTransport.cs
@@ -179,8 +179,6 @@ namespace SIPSorcery.Net
         /// <summary>
         /// Attempts to create and initialise a new SCTP association with the remote party.
         /// </summary>
-        /// <param name="sourcePort">The source port to use for the SCTP association.</param>
-        /// <param name="destinationPort">The destination port to use for the SCTP association.</param>
         public void Associate()
         {
             SetState(RTCSctpTransportState.Connecting);


### PR DESCRIPTION
It should provide the summaries on hover in IDEs, when using the SIPSorcery nuget package. Currently it only works when SIPSorcery is referenced from source (at least in VSCode and Rider)

* Enabled GenerateDocumentationFile in SIPSorcery.csproj
* Disabled "missing XML comment" warnings
* Fixed most malformed XML comments (warnings about these are not disabled)