### PR TITLE
ResolveMdnsName returns empty array instead of null when mDNS lookup fails

### DIFF
--- a/src/net/ICE/RtpIceChannel.cs
+++ b/src/net/ICE/RtpIceChannel.cs
@@ -2642,7 +2642,7 @@ namespace SIPSorcery.Net
             if (MdnsResolve != null)
             {
                 var address = await MdnsResolve(candidate.address).ConfigureAwait(false);
-                return address != null ? new IPAddress[] { address } : null;
+                return address != null ? new IPAddress[] { address } : Array.Empty<IPAddress>();
             }
 
 


### PR DESCRIPTION
I made this issue about it (https://github.com/sipsorcery-org/sipsorcery/issues/1116). Nothing big