### PR TITLE
SDPAudioVideoMediaFormat WithUpdated methods should use current object not a format parameter

### DIFF
--- a/src/net/SDP/SDP.cs
+++ b/src/net/SDP/SDP.cs
@@ -450,7 +450,7 @@ namespace SIPSorcery.Net
                                             {
                                                 if (activeAnnouncement.MediaFormats.ContainsKey(id))
                                                 {
-                                                    activeAnnouncement.MediaFormats[id] = activeAnnouncement.MediaFormats[id].WithUpdatedRtpmap(rtpmap, activeAnnouncement.MediaFormats[id]);
+                                                    activeAnnouncement.MediaFormats[id] = activeAnnouncement.MediaFormats[id].WithUpdatedRtpmap(rtpmap);
                                                 }
                                                 else
                                                 {
@@ -514,7 +514,7 @@ namespace SIPSorcery.Net
                                             {
                                                 if (activeAnnouncement.MediaFormats.ContainsKey(id))
                                                 {
-                                                    activeAnnouncement.MediaFormats[id] = activeAnnouncement.MediaFormats[id].WithUpdatedFmtp(fmtp, activeAnnouncement.MediaFormats[id]);
+                                                    activeAnnouncement.MediaFormats[id] = activeAnnouncement.MediaFormats[id].WithUpdatedFmtp(fmtp);
                                                 }
                                                 else
                                                 {

--- a/src/net/SDP/SDPAudioVideoMediaFormat.cs
+++ b/src/net/SDP/SDPAudioVideoMediaFormat.cs
@@ -256,16 +256,15 @@ namespace SIPSorcery.Net
         /// equivalent type need to be adjusted by one party.
         /// </summary>
         /// <param name="id">The ID to set on the new format.</param>
-        /// <param name="format">The existing format to copy all properties except the ID from.</param>
         /// <returns>A new format.</returns>
-        public SDPAudioVideoMediaFormat WithUpdatedID(int id, SDPAudioVideoMediaFormat format) =>
-            new SDPAudioVideoMediaFormat(format.Kind, id, format.Rtpmap, format.Fmtp);
+        public SDPAudioVideoMediaFormat WithUpdatedID(int id) =>
+            new SDPAudioVideoMediaFormat(Kind, id, Rtpmap, Fmtp);
 
-        public SDPAudioVideoMediaFormat WithUpdatedRtpmap(string rtpmap, SDPAudioVideoMediaFormat format) =>
-            new SDPAudioVideoMediaFormat(format.Kind, format.ID, rtpmap, format.Fmtp);
+        public SDPAudioVideoMediaFormat WithUpdatedRtpmap(string rtpmap) =>
+            new SDPAudioVideoMediaFormat(Kind, ID, rtpmap, Fmtp);
 
-        public SDPAudioVideoMediaFormat WithUpdatedFmtp(string fmtp, SDPAudioVideoMediaFormat format) =>
-            new SDPAudioVideoMediaFormat(format.Kind, format.ID, format.Rtpmap, fmtp);
+        public SDPAudioVideoMediaFormat WithUpdatedFmtp(string fmtp) =>
+            new SDPAudioVideoMediaFormat(Kind, ID, Rtpmap, fmtp);
 
         /// <summary>
         /// Maps an audio SDP media type to a media abstraction layer audio format.


### PR DESCRIPTION
SDPAudioVideoMediaFormat has 3 WithUpdated methods:

```
        public SDPAudioVideoMediaFormat WithUpdatedID(int id, SDPAudioVideoMediaFormat format)
        public SDPAudioVideoMediaFormat WithUpdatedRtpmap(string rtpmap, SDPAudioVideoMediaFormat format)
        public SDPAudioVideoMediaFormat WithUpdatedFmtp(string fmtp, SDPAudioVideoMediaFormat format)
```

This format parameter would suggest these are static methods, but they are object methods. As such it would make more sense to copy the `this` object.

This is the approach already used on SDPApplicationMediaFormat:

```
        public SDPApplicationMediaFormat WithUpdatedID(string id)
        public SDPApplicationMediaFormat WithUpdatedRtpmap(string rtpmap)
        public SDPApplicationMediaFormat WithUpdatedFmtp(string fmtp)
```

It would make sense to use this interface on both for consistency.