### PR TITLE
Increase SDP AnnouncementVersion to an unsigned 64-bit integer.

### DIFF
--- a/src/net/RTP/RTPSession.cs
+++ b/src/net/RTP/RTPSession.cs
@@ -180,7 +180,7 @@ namespace SIPSorcery.Net
 
         private Boolean m_acceptRtpFromAny = false;
         private string m_sdpSessionID = null;           // Need to maintain the same SDP session ID for all offers and answers.
-        private int m_sdpAnnouncementVersion = 0;       // The SDP version needs to increase whenever the local SDP is modified (see https://tools.ietf.org/html/rfc6337#section-5.2.5).
+        private ulong m_sdpAnnouncementVersion = 0;       // The SDP version needs to increase whenever the local SDP is modified (see https://tools.ietf.org/html/rfc6337#section-5.2.5).
         internal int m_rtpChannelsCount = 0;            // Need to know the number of RTP Channels
 
         // The stream used for the underlying RTP session to create a single RTP channel that will

--- a/src/net/SDP/SDP.cs
+++ b/src/net/SDP/SDP.cs
@@ -148,7 +148,7 @@ namespace SIPSorcery.Net
         // Owner fields.
         public string Username = "-";       // Username of the session originator.
         public string SessionId = "-";      // Unique Id for the session.
-        public int AnnouncementVersion = 0; // Version number for each announcement, number must be increased for each subsequent SDP modification.
+        public ulong AnnouncementVersion = 0; // Version number for each announcement, number must be increased for each subsequent SDP modification.
         public string NetworkType = "IN";   // Type of network, IN = Internet.
         public string AddressType = ADDRESS_TYPE_IPV4;  // Address type, typically IP4 or IP6.
         public string AddressOrHost;         // IP Address or Host of the machine that created the session, either FQDN or dotted quad or textual for IPv6.
@@ -237,7 +237,7 @@ namespace SIPSorcery.Net
                                 string[] ownerFields = sdpLineTrimmed.Substring(2).Split(' ');
                                 sdp.Username = ownerFields[0];
                                 sdp.SessionId = ownerFields[1];
-                                Int32.TryParse(ownerFields[2], out sdp.AnnouncementVersion);
+                                UInt64.TryParse(ownerFields[2], out sdp.AnnouncementVersion);
                                 sdp.NetworkType = ownerFields[3];
                                 sdp.AddressType = ownerFields[4];
                                 sdp.AddressOrHost = ownerFields[5];


### PR DESCRIPTION
Using a signed 32-bit integer was ignoring large values seen in the wild such as from RTPEngine (64bit populated by SSL_random) and NTP timestamps which are 64-bit and recommended by the SDP RFC.