### PR TITLE
WebRTC IPv6 support for TURN (along with REQUESTED-ADDRESS-FAMILY)

### DIFF
--- a/src/net/ICE/RtpIceChannel.cs
+++ b/src/net/ICE/RtpIceChannel.cs
@@ -2316,6 +2316,11 @@ namespace SIPSorcery.Net
             STUNAttributeConstants.TcpTransportType :
             STUNAttributeConstants.UdpTransportType));*/
 
+            allocateRequest.Attributes.Add(
+                new STUNAttribute(STUNAttributeTypesEnum.RequestedAddressFamily,
+                iceServer.ServerEndPoint.AddressFamily == AddressFamily.InterNetwork ?
+                STUNAttributeConstants.IPv4AddressFamily : STUNAttributeConstants.IPv6AddressFamily));
+
             byte[] allocateReqBytes = null;
 
             if (iceServer.Nonce != null && iceServer.Realm != null && iceServer._username != null && iceServer._password != null)

--- a/src/net/ICE/RtpIceChannel.cs
+++ b/src/net/ICE/RtpIceChannel.cs
@@ -2364,6 +2364,11 @@ namespace SIPSorcery.Net
             //allocateRequest.Attributes.Add(new STUNAttribute(STUNAttributeTypesEnum.Lifetime, 3600));
             allocateRequest.Attributes.Add(new STUNAttribute(STUNAttributeTypesEnum.Lifetime, ALLOCATION_TIME_TO_EXPIRY_VALUE));
 
+            allocateRequest.Attributes.Add(
+                new STUNAttribute(STUNAttributeTypesEnum.RequestedAddressFamily,
+                iceServer.ServerEndPoint.AddressFamily == AddressFamily.InterNetwork ?
+                STUNAttributeConstants.IPv4AddressFamily : STUNAttributeConstants.IPv6AddressFamily));
+
             byte[] allocateReqBytes = null;
 
             if (iceServer.Nonce != null && iceServer.Realm != null && iceServer._username != null && iceServer._password != null)

--- a/src/net/ICE/RtpIceChannel.cs
+++ b/src/net/ICE/RtpIceChannel.cs
@@ -2404,7 +2404,7 @@ namespace SIPSorcery.Net
         {
             STUNMessage permissionsRequest = new STUNMessage(STUNMessageTypesEnum.CreatePermission);
             permissionsRequest.Header.TransactionId = Encoding.ASCII.GetBytes(transactionID);
-            permissionsRequest.Attributes.Add(new STUNXORAddressAttribute(STUNAttributeTypesEnum.XORPeerAddress, peerEndPoint.Port, peerEndPoint.Address));
+            permissionsRequest.Attributes.Add(new STUNXORAddressAttribute(STUNAttributeTypesEnum.XORPeerAddress, peerEndPoint.Port, peerEndPoint.Address, permissionsRequest.Header.TransactionId));
 
             byte[] createPermissionReqBytes = null;
 

--- a/src/net/STUN/STUNAttributes/STUNAddressAttribute.cs
+++ b/src/net/STUN/STUNAttributes/STUNAddressAttribute.cs
@@ -19,20 +19,17 @@ using SIPSorcery.Sys;
 
 namespace SIPSorcery.Net
 {
-    public class STUNAddressAttribute : STUNAttribute
+    [Obsolete("Provided for backward compatibility with RFC3489 clients.")]
     public class STUNAddressAttribute : STUNAddressAttributeBase
     {
-        public const UInt16 ADDRESS_ATTRIBUTE_LENGTH = 8;
-
-        public int Family = 1;      // Ipv4 = 1, IPv6 = 2.
-        public int Port;
-        public IPAddress Address;
-
-        public override UInt16 PaddedLength
-        {
-            get { return ADDRESS_ATTRIBUTE_LENGTH; }
-        }
-
+        /// <summary>
+        /// Obsolete.
+        /// <br/> For IPv6 support, please parse using
+        /// <br/> <see cref="STUNXORAddressAttribute(STUNAttributeTypesEnum, byte[], byte[])"/>
+        /// <br/> <br/>
+        /// Parses an IPv4 Address attribute.
+        /// </summary>
+        [Obsolete("Provided for backward compatibility with RFC3489 clients.")]
         public STUNAddressAttribute(byte[] attributeValue)
             : base(STUNAttributeTypesEnum.MappedAddress, attributeValue)
         {
@@ -48,6 +45,14 @@ namespace SIPSorcery.Net
             Address = new IPAddress(new byte[] { attributeValue[4], attributeValue[5], attributeValue[6], attributeValue[7] });
         }
 
+        /// <summary>
+        /// Obsolete.
+        /// <br/> For IPv6 support, please parse using
+        /// <br/> <see cref="STUNXORAddressAttribute(STUNAttributeTypesEnum, byte[], byte[])"/>
+        /// <br/> <br/>
+        /// Parses an IPv4 Address attribute.
+        /// </summary>
+        [Obsolete("Provided for backward compatibility with RFC3489 clients.")]
         public STUNAddressAttribute(STUNAttributeTypesEnum attributeType, byte[] attributeValue)
             : base(attributeType, attributeValue)
         {
@@ -63,6 +68,14 @@ namespace SIPSorcery.Net
             Address = new IPAddress(new byte[] { attributeValue[4], attributeValue[5], attributeValue[6], attributeValue[7] });
         }
 
+        /// <summary>
+        /// Obsolete.
+        /// <br/> For IPv6 support, please parse using
+        /// <br/> <see cref="STUNXORAddressAttribute(STUNAttributeTypesEnum, byte[], byte[])"/>
+        /// <br/> <br/>
+        /// Parses an IPv4 Address attribute.
+        /// </summary>
+        [Obsolete("Provided for backward compatibility with RFC3489 clients.")]
         public STUNAddressAttribute(STUNAttributeTypesEnum attributeType, int port, IPAddress address)
             : base(attributeType, null)
         {

--- a/src/net/STUN/STUNAttributes/STUNAddressAttribute.cs
+++ b/src/net/STUN/STUNAttributes/STUNAddressAttribute.cs
@@ -20,6 +20,7 @@ using SIPSorcery.Sys;
 namespace SIPSorcery.Net
 {
     public class STUNAddressAttribute : STUNAttribute
+    public class STUNAddressAttribute : STUNAddressAttributeBase
     {
         public const UInt16 ADDRESS_ATTRIBUTE_LENGTH = 8;
 

--- a/src/net/STUN/STUNAttributes/STUNAddressAttributeBase.cs
+++ b/src/net/STUN/STUNAttributes/STUNAddressAttributeBase.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Text;
+
+namespace SIPSorcery.Net
+{
+    public abstract class STUNAddressAttributeBase : STUNAttribute
+    {
+        /// <summary>
+        /// Obsolete.
+        /// <br/> Please use <see cref="ADDRESS_ATTRIBUTE_IPV4_LENGTH"/> or <see cref="ADDRESS_ATTRIBUTE_IPV6_LENGTH"/> instead.
+        /// <br/> <br/>
+        /// </summary>
+        [Obsolete("Default attribute length for IPv4 only.")]
+        public const UInt16 ADDRESS_ATTRIBUTE_LENGTH = 8;
+
+        public const UInt16 ADDRESS_ATTRIBUTE_IPV4_LENGTH = 8;
+        public const UInt16 ADDRESS_ATTRIBUTE_IPV6_LENGTH = 20;
+
+        protected UInt16 AddressAttributeLength = ADDRESS_ATTRIBUTE_IPV4_LENGTH;
+        protected byte[] TransactionId;
+
+        /// <summary>
+        /// Defaults to IPv4 (0x01 // 1)
+        /// </summary>
+        public int Family = 1;      // Ipv4 = 1, IPv6 = 2.
+        public int Port;
+        public IPAddress Address;
+
+        public override UInt16 PaddedLength
+        {
+            get => AddressAttributeLength;
+        }
+
+        public STUNAddressAttributeBase(STUNAttributeTypesEnum attributeType, byte[] value)
+            : base(attributeType, value)
+        {
+        }
+    }
+}

--- a/src/net/STUN/STUNAttributes/STUNAttribute.cs
+++ b/src/net/STUN/STUNAttributes/STUNAttribute.cs
@@ -59,6 +59,7 @@ namespace SIPSorcery.Net
         ReflectedFrom = 0x000B,         // Not used in RFC5389.
         Realm = 0x0014,
         Nonce = 0x0015,
+        RequestedAddressFamily = 0x0017,// Added in RFC6156.
         XORMappedAddress = 0x0020,
 
         Software = 0x8022,              // Added in RFC5389.
@@ -97,6 +98,15 @@ namespace SIPSorcery.Net
     {
         public static readonly byte[] UdpTransportType = new byte[] { 0x11, 0x00, 0x00, 0x00 };     // The payload type for UDP in a RequestedTransport type attribute.
         public static readonly byte[] TcpTransportType = new byte[] { 0x06, 0x00, 0x00, 0x00 };     // The payload type for TCP in a RequestedTransport type attribute.
+
+        /// <summary>
+        /// The requested TURN relay ip address is IPv4 (RFC5389, Section 15.1)
+        /// </summary>
+        public static readonly byte[] IPv4AddressFamily = new byte[] { 0x01, 0x00, 0x00, 0x00 };
+        /// <summary>
+        /// The requested TURN relay ip address is IPv6 (RFC5389, Section 15.1)
+        /// </summary>
+        public static readonly byte[] IPv6AddressFamily = new byte[] { 0x02, 0x00, 0x00, 0x00 };
     }
 
     public class STUNAttribute

--- a/src/net/STUN/STUNAttributes/STUNAttribute.cs
+++ b/src/net/STUN/STUNAttributes/STUNAttribute.cs
@@ -1,4 +1,4 @@
-//-----------------------------------------------------------------------------
+﻿//-----------------------------------------------------------------------------
 // Filename: STUNAttribute.cs
 //
 // Description: Implements STUN message attributes as defined in RFC5389.
@@ -157,7 +157,9 @@ namespace SIPSorcery.Net
             Value = NetConvert.GetBytes(value);
         }
 
-        public static List<STUNAttribute> ParseMessageAttributes(byte[] buffer, int startIndex, int endIndex)
+        public static List<STUNAttribute> ParseMessageAttributes(byte[] buffer, int startIndex, int endIndex) => ParseMessageAttributes(buffer, startIndex, endIndex, null);
+
+        public static List<STUNAttribute> ParseMessageAttributes(byte[] buffer, int startIndex, int endIndex, STUNHeader header)
         {
             if (buffer != null && buffer.Length > startIndex && buffer.Length >= endIndex)
             {
@@ -204,7 +206,7 @@ namespace SIPSorcery.Net
                     }
                     else if (attributeType == STUNAttributeTypesEnum.XORMappedAddress || attributeType == STUNAttributeTypesEnum.XORPeerAddress || attributeType == STUNAttributeTypesEnum.XORRelayedAddress)
                     {
-                        attribute = new STUNXORAddressAttribute(attributeType, stunAttributeValue);
+                        attribute = new STUNXORAddressAttribute(attributeType, stunAttributeValue, header);
                     }
                     else if(attributeType == STUNAttributeTypesEnum.ConnectionId)
                     {

--- a/src/net/STUN/STUNAttributes/STUNAttribute.cs
+++ b/src/net/STUN/STUNAttributes/STUNAttribute.cs
@@ -206,7 +206,7 @@ namespace SIPSorcery.Net
                     }
                     else if (attributeType == STUNAttributeTypesEnum.XORMappedAddress || attributeType == STUNAttributeTypesEnum.XORPeerAddress || attributeType == STUNAttributeTypesEnum.XORRelayedAddress)
                     {
-                        attribute = new STUNXORAddressAttribute(attributeType, stunAttributeValue, header);
+                        attribute = new STUNXORAddressAttribute(attributeType, stunAttributeValue, header.TransactionId);
                     }
                     else if(attributeType == STUNAttributeTypesEnum.ConnectionId)
                     {

--- a/src/net/STUN/STUNAttributes/STUNXORAddressAttribute.cs
+++ b/src/net/STUN/STUNAttributes/STUNXORAddressAttribute.cs
@@ -26,17 +26,14 @@ namespace SIPSorcery.Net
     /// </summary>
     public class STUNXORAddressAttribute : STUNAddressAttributeBase
     {
-        public const UInt16 ADDRESS_ATTRIBUTE_LENGTH = 8;
-
-        public int Family = 1;      // Ipv4 = 1, IPv6 = 2.
-        public int Port;
-        public IPAddress Address;
-
-        public override UInt16 PaddedLength
-        {
-            get { return ADDRESS_ATTRIBUTE_LENGTH; }
-        }
-
+        /// <summary>
+        /// Obsolete.
+        /// <br/> For IPv6 support, please parse using
+        /// <br/> <see cref="STUNXORAddressAttribute(STUNAttributeTypesEnum, byte[], byte[])"/>
+        /// <br/> <br/>
+        /// Parses an XOR-d (encoded) IPv4 Address attribute.
+        /// </summary>
+        [Obsolete("Provided for backward compatibility with RFC3489 clients.")]
         public STUNXORAddressAttribute(STUNAttributeTypesEnum attributeType, byte[] attributeValue)
             : this(attributeType, attributeValue, null)
         {
@@ -69,6 +66,13 @@ namespace SIPSorcery.Net
             Address = new IPAddress(address);
         }
 
+        /// <summary>
+        /// Obsolete.
+        /// <br/> For IPv6 support, please create using <see cref="STUNXORAddressAttribute(STUNAttributeTypesEnum, int, IPAddress, byte[])"/>
+        /// <br/> <br/>
+        /// Creates an XOR-d (encoded) IPv4 Address attribute.
+        /// </summary>
+        [Obsolete("Provided for backward compatibility with RFC3489 clients.")]
         public STUNXORAddressAttribute(STUNAttributeTypesEnum attributeType, int port, IPAddress address)
             : base(attributeType, null)
         {

--- a/src/net/STUN/STUNAttributes/STUNXORAddressAttribute.cs
+++ b/src/net/STUN/STUNAttributes/STUNXORAddressAttribute.cs
@@ -24,7 +24,7 @@ namespace SIPSorcery.Net
     /// This attribute is the same as the mapped address attribute except the address details are XOR'ed with the STUN magic cookie. 
     /// THe reason for this is to stop NAT application layer gateways from doing string replacements of private IP addresses and ports.
     /// </summary>
-    public class STUNXORAddressAttribute : STUNAttribute
+    public class STUNXORAddressAttribute : STUNAddressAttributeBase
     {
         public const UInt16 ADDRESS_ATTRIBUTE_LENGTH = 8;
 

--- a/src/net/STUN/STUNMessage.cs
+++ b/src/net/STUN/STUNMessage.cs
@@ -1,4 +1,4 @@
-//-----------------------------------------------------------------------------
+﻿//-----------------------------------------------------------------------------
 // Filename: STUNMessage.cs
 //
 // Description: Implements STUN Message as defined in RFC5389.
@@ -100,7 +100,7 @@ namespace SIPSorcery.Net
 
                 if (stunMessage.Header.MessageLength > 0)
                 {
-                    stunMessage.Attributes = STUNAttribute.ParseMessageAttributes(buffer, STUNHeader.STUN_HEADER_LENGTH, bufferLength);
+                    stunMessage.Attributes = STUNAttribute.ParseMessageAttributes(buffer, STUNHeader.STUN_HEADER_LENGTH, bufferLength, stunMessage.Header);
                 }
 
                 if (stunMessage.Attributes.Count > 0 && stunMessage.Attributes.Last().AttributeType == STUNAttributeTypesEnum.FingerPrint)

--- a/src/net/STUN/STUNMessage.cs
+++ b/src/net/STUN/STUNMessage.cs
@@ -86,7 +86,7 @@ namespace SIPSorcery.Net
 
         public void AddXORAddressAttribute(STUNAttributeTypesEnum addressType, IPAddress remoteAddress, int remotePort)
         {
-            STUNXORAddressAttribute xorAddressAttribute = new STUNXORAddressAttribute(addressType, remotePort, remoteAddress);
+            STUNXORAddressAttribute xorAddressAttribute = new STUNXORAddressAttribute(addressType, remotePort, remoteAddress, Header.TransactionId);
             Attributes.Add(xorAddressAttribute);
         }
 


### PR DESCRIPTION
## This PR is for supporting IPv6. (and adding obsolescence warnings for [RFC 3489](https://datatracker.ietf.org/doc/html/rfc3489))

### Summary:
- [x] Added REQUESTED-ADDRESS-FAMILY attribute type for Allocation Request and Refresh Request according to [RFC 8656](https://datatracker.ietf.org/doc/html/rfc8656),
- [x] Added `STUNAddressAttributeBase` abstract class for better code management,
- [x] Added `IP AddressFamily` determination at creation and parsing time,
- [x] IPv6 support for XOR-d (encoded) IP Address according to [RFC 8489 (section 14.2)](https://datatracker.ietf.org/doc/html/rfc8489#section-14.2),
  - [x] Using `STUNHeader.TransactionId`,
  - [ ] **But I didn't add IPv6 support for RFC 3489 though...** as commented in [RFC 5389 (section 15.1)](https://datatracker.ietf.org/doc/html/rfc5389#section-15.1),
- [ ] Should work for both TURN client and TURN server modes (?) (not tested yet for turn server mode),
- [x] Added deprecated warnings for RFC 3489 MAPPED-ADDRESS `STUNAddressAttribute` attribute usage