### PR TITLE
uac and uas send NonInvite SIP Request

### DIFF
--- a/src/app/SIPUserAgents/SIPClientUserAgent.cs
+++ b/src/app/SIPUserAgents/SIPClientUserAgent.cs
@@ -485,6 +485,21 @@ namespace SIPSorcery.SIP.App
             }
         }
 
+        public Task<SocketError> SendNonInviteRequest(SIPRequest sipRequest)
+        {
+            try
+            {
+                SIPNonInviteTransaction nonInvteTransaction = new SIPNonInviteTransaction(m_sipTransport, sipRequest, m_outboundProxy);
+                nonInvteTransaction.SendRequest();
+                return Task.FromResult(SocketError.Success);
+            }
+            catch (Exception excp)
+            {
+                logger.LogError($"Exception SendNonInviteRequest. {excp.Message}");
+                return Task.FromResult(SocketError.Fault);
+            }
+        }
+        
         private Task<SocketError> ByeServerFinalResponseReceived(SIPEndPoint localSIPEndPoint, SIPEndPoint remoteEndPoint, SIPTransaction sipTransaction, SIPResponse sipResponse)
         {
             try

--- a/src/app/SIPUserAgents/SIPServerUserAgent.cs
+++ b/src/app/SIPUserAgents/SIPServerUserAgent.cs
@@ -384,6 +384,21 @@ namespace SIPSorcery.SIP.App
             }
         }
 
+        public Task<SocketError> SendNonInviteRequest(SIPRequest sipRequest)
+        {
+            try
+            {
+                SIPNonInviteTransaction nonInvteTransaction = new SIPNonInviteTransaction(m_sipTransport, sipRequest, m_outboundProxy);
+                nonInvteTransaction.SendRequest();
+                return Task.FromResult(SocketError.Success);
+            }
+            catch (Exception excp)
+            {
+                logger.LogError($"Exception SendNonInviteRequest. {excp.Message}");
+                return Task.FromResult(SocketError.Fault);
+            }
+        }
+        
         public void Redirect(SIPResponseStatusCodesEnum redirectCode, SIPURI redirectURI)
         {
             Redirect(redirectCode, redirectURI, null);


### PR DESCRIPTION
While using SIPClientUserAgent or SIPServerUserAgent, we might need to send Non Invite requests like SIP INFO or SIP NOTIFY
