### PR TITLE
SIP Messages are discarded to send when we try to send succesive SIP INFO messages

### DIFF
--- a/src/core/SIP/SIPTransport.cs
+++ b/src/core/SIP/SIPTransport.cs
@@ -1028,9 +1028,9 @@ namespace SIPSorcery.SIP
                                             }
                                         }
                                         else if (m_transactionEngine != null && sipRequest.Method == SIPMethodsEnum.CANCEL &&
-                                            GetTransaction(SIPTransaction.GetRequestTransactionId(sipRequest.Header.Vias.TopViaHeader.Branch, SIPMethodsEnum.INVITE)) != null)
+                                            GetTransaction(SIPTransaction.GetRequestTransactionId(sipRequest.Header.Vias.TopViaHeader.Branch, SIPMethodsEnum.INVITE, sipRequest.Header.CSeq)) != null)
                                         {
-                                            UASInviteTransaction inviteTransaction = (UASInviteTransaction)GetTransaction(SIPTransaction.GetRequestTransactionId(sipRequest.Header.Vias.TopViaHeader.Branch, SIPMethodsEnum.INVITE));
+                                            UASInviteTransaction inviteTransaction = (UASInviteTransaction)GetTransaction(SIPTransaction.GetRequestTransactionId(sipRequest.Header.Vias.TopViaHeader.Branch, SIPMethodsEnum.INVITE, sipRequest.Header.CSeq));
                                             if (inviteTransaction != null)
                                             {
                                                 // Note: this will generate the INVITE request response.

--- a/src/core/SIPTransactions/SIPTransaction.cs
+++ b/src/core/SIPTransactions/SIPTransaction.cs
@@ -256,7 +256,7 @@ namespace SIPSorcery.SIP
                 }
 
                 m_sipTransport = sipTransport;
-                m_transactionId = GetRequestTransactionId(transactionRequest.Header.Vias.TopViaHeader.Branch, transactionRequest.Header.CSeqMethod);
+                m_transactionId = GetRequestTransactionId(transactionRequest.Header.Vias.TopViaHeader.Branch, transactionRequest.Header.CSeqMethod, transactionRequest.Header.CSeq);
                 HasTimedOut = false;
 
                 m_transactionRequest = transactionRequest;
@@ -278,9 +278,9 @@ namespace SIPSorcery.SIP
             }
         }
 
-        public static string GetRequestTransactionId(string branchId, SIPMethodsEnum method)
+        public static string GetRequestTransactionId(string branchId, SIPMethodsEnum method, int cseq)
         {
-            return Crypto.GetSHAHashAsString(branchId + method.ToString());
+            return Crypto.GetSHAHashAsString(branchId + method.ToString() + cseq.ToString());
         }
 
         public Task<SocketError> GotResponse(SIPEndPoint localSIPEndPoint, SIPEndPoint remoteEndPoint, SIPResponse sipResponse)

--- a/src/core/SIPTransactions/SIPTransactionEngine.cs
+++ b/src/core/SIPTransactions/SIPTransactionEngine.cs
@@ -147,7 +147,7 @@ namespace SIPSorcery.SIP
             }
 
             SIPMethodsEnum transactionMethod = (sipRequest.Method != SIPMethodsEnum.ACK) ? sipRequest.Method : SIPMethodsEnum.INVITE;
-            string transactionId = SIPTransaction.GetRequestTransactionId(sipRequest.Header.Vias.TopViaHeader.Branch, transactionMethod);
+            string transactionId = SIPTransaction.GetRequestTransactionId(sipRequest.Header.Vias.TopViaHeader.Branch, transactionMethod, sipRequest.Header.CSeq);
 
             lock (m_pendingTransactions)
             {
@@ -237,7 +237,7 @@ namespace SIPSorcery.SIP
             }
             else
             {
-                string transactionId = SIPTransaction.GetRequestTransactionId(sipResponse.Header.Vias.TopViaHeader.Branch, sipResponse.Header.CSeqMethod);
+                string transactionId = SIPTransaction.GetRequestTransactionId(sipResponse.Header.Vias.TopViaHeader.Branch, sipResponse.Header.CSeqMethod, sipResponse.Header.CSeq);
 
                 m_pendingTransactions.TryGetValue(transactionId, out var transaction);
                 return transaction;


### PR DESCRIPTION
When we want to successively send SIP INFO (DTMF) messages, the first message is sent but those who continue are missed,

The reason is that the TransactionID (`SIPTransaction.GetRequestTransactionId`)  is calculated from `Branch` and `CSeqMethod`, therefor the successive SIP INFO messages are discarded.

Our Proposal is to add Header.Cseq into `SIPTransaction.GetRequestTransactionId` calculation.

