### PR TITLE
Improved tel: URI handling

### DIFF
--- a/src/core/SIP/SIPURI.cs
+++ b/src/core/SIP/SIPURI.cs
@@ -127,10 +127,11 @@ namespace SIPSorcery.SIP
                 string canonicalAddress = Scheme + ":";
                 canonicalAddress += !String.IsNullOrEmpty(User) ? User + "@" : null;
 
-                // First expression is for IPv6 addresses with a port.
+                // First expression is for IPv6 addresses with a port and tel: URIs.
                 // Second expression is for IPv4 addresses and hostnames with a port.
                 if (Host.Contains("]:") ||
-                    (Host.IndexOf(':') != -1 && Host.IndexOf(':') == Host.LastIndexOf(':')))
+                    (Host.IndexOf(':') != -1 && Host.IndexOf(':') == Host.LastIndexOf(':')) ||
+                    Scheme == SIPSchemesEnum.tel)
                 {
                     canonicalAddress += Host;
                 }
@@ -551,7 +552,7 @@ namespace SIPSorcery.SIP
         /// <returns>A string representing the address of record for the URI.</returns>
         public string ToAOR()
         {
-            return User + USER_HOST_SEPARATOR + Host;
+            return Scheme == SIPSchemesEnum.tel ? Host : User + USER_HOST_SEPARATOR + Host;
         }
 
         public SIPEndPoint ToSIPEndPoint()

--- a/test/unit/core/SIP/SIPURIUnitTest.cs
+++ b/test/unit/core/SIP/SIPURIUnitTest.cs
@@ -972,5 +972,28 @@ namespace SIPSorcery.SIP.UnitTests
 
             logger.LogDebug("-----------------------------------------");
         }
+
+        /// <summary>
+        /// Tests that a SIP URI with a tel: scheme is correctly recognised.
+        /// </summary>
+        [Fact]
+        public void ParseTelSchemeURIUnitTest()
+        {
+            logger.LogDebug("--> " + System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+
+            var telStr = "tel:+1-(201) 555 0123;phone-context=example.com";
+            SIPURI sipURI = SIPURI.ParseSIPURI(telStr);
+
+            Assert.Equal(null, sipURI.User);
+            Assert.Equal("+1-(201) 555 0123", sipURI.Host);
+            Assert.Equal("tel:+1-(201) 555 0123", sipURI.CanonicalAddress);
+            Assert.True(sipURI.Parameters.Has("phone-context"), "The tel: URI parameters were not parsed correctly.");
+            Assert.Equal("example.com", sipURI.Parameters.Get("phone-context"));
+            Assert.Equal(telStr, sipURI.ToString());
+            Assert.Equal("+1-(201) 555 0123", sipURI.ToAOR());
+
+            logger.LogDebug("-----------------------------------------");
+        }
     }
 }


### PR DESCRIPTION
This PR tweaks `CanonicalAddress` and `ToAOR` behaviour so that tel: URIs can be used similarly to how sip: URIs are.