### PR TITLE
Keep the local track's RTP event capability when setting remote description on an RTP session (Fix issue-1164)

### DIFF
--- a/src/net/RTP/MediaStream.cs
+++ b/src/net/RTP/MediaStream.cs
@@ -169,14 +169,7 @@ namespace SIPSorcery.net.RTP
                         if (m_localTrack.Capabilities != null && !m_localTrack.NoDtmfSupport &&
                             !m_localTrack.Capabilities.Any(x => x.ID == RTPSession.DTMF_EVENT_PAYLOAD_ID))
                         {
-                            SDPAudioVideoMediaFormat rtpEventFormat = new SDPAudioVideoMediaFormat(
-                                SDPMediaTypesEnum.audio,
-                                RTPSession.DTMF_EVENT_PAYLOAD_ID,
-                                SDP.TELEPHONE_EVENT_ATTRIBUTE,
-                                RTPSession.DEFAULT_AUDIO_CLOCK_RATE,
-                                SDPAudioVideoMediaFormat.DEFAULT_AUDIO_CHANNEL_COUNT,
-                                "0-16");
-                            m_localTrack.Capabilities.Add(rtpEventFormat);
+                            m_localTrack.Capabilities.Add(DefaultRTPEventFormat);
                         }
                     }
                 }
@@ -202,6 +195,23 @@ namespace SIPSorcery.net.RTP
         /// The remote RTP control end point this stream is sending to RTCP reports for the media stream to.
         /// </summary>
         public IPEndPoint ControlDestinationEndPoint { get; set; }
+
+        /// <summary>
+        /// Default RTP event format that we support.
+        /// </summary>
+        public static SDPAudioVideoMediaFormat DefaultRTPEventFormat
+        {
+            get
+            {
+                return new SDPAudioVideoMediaFormat(
+                                SDPMediaTypesEnum.audio,
+                                RTPSession.DTMF_EVENT_PAYLOAD_ID,
+                                SDP.TELEPHONE_EVENT_ATTRIBUTE,
+                                RTPSession.DEFAULT_AUDIO_CLOCK_RATE,
+                                SDPAudioVideoMediaFormat.DEFAULT_AUDIO_CHANNEL_COUNT,
+                                "0-16");
+            }
+        }
 
         #endregion PROPERTIES
 

--- a/src/net/RTP/RTPSession.cs
+++ b/src/net/RTP/RTPSession.cs
@@ -1031,16 +1031,17 @@ namespace SIPSorcery.Net
                         currentMediaStream.RemoteTrack.Capabilities = capabilities;
 
                         // Keep the local track's RTP event capability
+                        var currentLocalTrackCapabilities = currentMediaStream.LocalTrack.Capabilities;
                         SDPAudioVideoMediaFormat localRTPEventCapabilities;
-                        try
+                        if (currentLocalTrackCapabilities.Any(x => x.Name().ToLower() == SDP.TELEPHONE_EVENT_ATTRIBUTE))
                         {
-                            localRTPEventCapabilities = currentMediaStream.LocalTrack.Capabilities.First(x => x.Name().ToLower() == SDP.TELEPHONE_EVENT_ATTRIBUTE);
+                            localRTPEventCapabilities = currentLocalTrackCapabilities.First(x => x.Name().ToLower() == SDP.TELEPHONE_EVENT_ATTRIBUTE);
                         }
-                        catch
+                        else
                         {
                             localRTPEventCapabilities = MediaStream.DefaultRTPEventFormat;
                         }
-                        
+
                         currentMediaStream.LocalTrack.Capabilities = capabilities.Where(x => x.Name().ToLower() != SDP.TELEPHONE_EVENT_ATTRIBUTE).ToList();
                         currentMediaStream.LocalTrack.Capabilities.Add(localRTPEventCapabilities);
 

--- a/src/net/RTP/RTPSession.cs
+++ b/src/net/RTP/RTPSession.cs
@@ -1029,7 +1029,20 @@ namespace SIPSorcery.Net
                         SDPAudioVideoMediaFormat.SortMediaCapability(capabilities, currentMediaStream.LocalTrack?.Capabilities);
 
                         currentMediaStream.RemoteTrack.Capabilities = capabilities;
-                        currentMediaStream.LocalTrack.Capabilities = capabilities;
+
+                        // Keep the local track's RTP event capability
+                        SDPAudioVideoMediaFormat localRTPEventCapabilities;
+                        try
+                        {
+                            localRTPEventCapabilities = currentMediaStream.LocalTrack.Capabilities.First(x => x.Name().ToLower() == SDP.TELEPHONE_EVENT_ATTRIBUTE);
+                        }
+                        catch
+                        {
+                            localRTPEventCapabilities = MediaStream.DefaultRTPEventFormat;
+                        }
+                        
+                        currentMediaStream.LocalTrack.Capabilities = capabilities.Where(x => x.Name().ToLower() != SDP.TELEPHONE_EVENT_ATTRIBUTE).ToList();
+                        currentMediaStream.LocalTrack.Capabilities.Add(localRTPEventCapabilities);
 
                         if (currentMediaStream.MediaType == SDPMediaTypesEnum.audio)
                         {


### PR DESCRIPTION
Keep the local track's RTP event capability when setting remote description on an RTP session