### PR TITLE
Update TopViaHeader for CANCEL:OK possible fix for Issue 1169

### DIFF
--- a/src/core/SIP/SIPTransport.cs
+++ b/src/core/SIP/SIPTransport.cs
@@ -1039,6 +1039,8 @@ namespace SIPSorcery.SIP
                                                 // Note: this will generate the CANCEL request response.
                                                 SIPResponse okResponse = SIPResponse.GetResponse(sipRequest, SIPResponseStatusCodesEnum.Ok, null);
                                                 okResponse.Header.To.ToTag = inviteTransaction.LocalTag;
+                                                // Only update response here, as INVITE requests header is already set correctly from prior responses
+                                                okResponse.Header.Vias.UpateTopViaHeader(remoteEndPoint.GetIPEndPoint());
                                                 return SendResponseAsync(okResponse);
                                             }
                                             else


### PR DESCRIPTION
Possible solution for #1169 

Update TopViaHeader for a SIP-Cancel:Ok to assure correct routing of the response back to it's originating socket.

If not done the set via header will be used which might not be correctly routable.