### PR TITLE
RTP Header Extensions

### DIFF
--- a/src/net/RTP/MediaStream.cs
+++ b/src/net/RTP/MediaStream.cs
@@ -396,18 +396,21 @@ namespace SIPSorcery.net.RTP
                          */
                 // https://datatracker.ietf.org/doc/html/rfc5285#section-4.2
 
-                foreach (var ext in RemoteTrack.HeaderExtensions.Values)
+                if (RemoteTrack?.HeaderExtensions?.Values != null)
                 {
-                    // TODO - must manage multiple extensions - here it's a shorcut to just take into account AbsSendTime
-                    // How to manage RTPHeader with different extensio profile ?
-                    // Need to increase ExtensionLength and update ExtensionPayload for each extensions
-                    if (ext.Uri == AbsSendTimeExtension.RTP_HEADER_EXTENSION_URI)
+                    foreach (var ext in RemoteTrack.HeaderExtensions.Values)
                     {
-                        rtpPacket.Header.HeaderExtensionFlag = 1;
-                        rtpPacket.Header.ExtensionProfile = RTPHeader.ONE_BYTE_EXTENSION_PROFILE;
-                        rtpPacket.Header.ExtensionLength = 1; // only abs-send-time for now
-                        rtpPacket.Header.ExtensionPayload = ext.WriteHeader();
-                        break;
+                        // TODO - must manage multiple extensions - here it's a shorcut to just take into account AbsSendTime
+                        // How to manage RTPHeader with different extensio profile ?
+                        // Need to increase ExtensionLength and update ExtensionPayload for each extensions
+                        if (ext.Uri == AbsSendTimeExtension.RTP_HEADER_EXTENSION_URI)
+                        {
+                            rtpPacket.Header.HeaderExtensionFlag = 1;
+                            rtpPacket.Header.ExtensionProfile = RTPHeader.ONE_BYTE_EXTENSION_PROFILE;
+                            rtpPacket.Header.ExtensionLength = 1; // only abs-send-time for now
+                            rtpPacket.Header.ExtensionPayload = ext.WriteHeader();
+                            break;
+                        }
                     }
                 }
 
@@ -883,7 +886,7 @@ namespace SIPSorcery.net.RTP
             header.GetHeaderExtensions().ToList().ForEach(rtpHeaderExtensionData =>
             {
                 // We want to store LastAbsoluteCaptureTimestamp in RemoteTrack using AbsSendTimeExtension
-                if(RemoteTrack?.HeaderExtensions.TryGetValue(rtpHeaderExtensionData.Id, out RTPHeaderExtension rtpHeaderExtension) == true)
+                if(RemoteTrack?.HeaderExtensions?.TryGetValue(rtpHeaderExtensionData.Id, out RTPHeaderExtension rtpHeaderExtension) == true)
                 {
                     rtpHeaderExtension?.ReadHeader(ref m_localTrack, ref m_remoteTrack, header, rtpHeaderExtensionData.Data);
                 }

--- a/src/net/RTP/MediaStreamTrack.cs
+++ b/src/net/RTP/MediaStreamTrack.cs
@@ -83,7 +83,7 @@ namespace SIPSorcery.Net
         /// <summary>
         ///  a=extmap - Mapping for RTP header extensions
         /// </summary>
-        public Dictionary<int, RTPHeaderExtension> HeaderExtensions { get; }
+        public Dictionary<int, RTPHeaderExtension> HeaderExtensions { get; internal set; }
 
         /// <summary>
         /// Represents the original and default stream status for the track. This is set

--- a/src/net/RTP/RTPHeader.cs
+++ b/src/net/RTP/RTPHeader.cs
@@ -28,7 +28,7 @@ namespace SIPSorcery.Net
         public const int MIN_HEADER_LEN = 12;
 
         public const int RTP_VERSION = 2;
-        private const int ONE_BYTE_EXTENSION_PROFILE = 0xBEDE;
+        public const int ONE_BYTE_EXTENSION_PROFILE = 0xBEDE;
 
         public int Version = RTP_VERSION;                       // 2 bits.
         public int PaddingFlag = 0;                             // 1 bit.
@@ -325,55 +325,5 @@ namespace SIPSorcery.Net
             return header.PayloadSize>=0;
         }
 
-        // DateTimeOffset.UnixEpoch only available in newer target frameworks
-        private static readonly DateTimeOffset UnixEpoch = new DateTimeOffset(1970, 1, 1, 0, 0, 0, TimeSpan.Zero);
-
-        // inspired by https://github.com/pion/rtp/blob/master/abssendtimeextension.go
-        internal static byte[] AbsSendTime(DateTimeOffset now)
-        {
-            ulong unixNanoseconds = (ulong)((now - UnixEpoch).Ticks * 100L);
-            var seconds = unixNanoseconds / (ulong)1e9;
-            seconds += 0x83AA7E80UL; // offset in seconds between unix epoch and ntp epoch
-            var f = unixNanoseconds % (ulong)1e9;
-            f <<= 32;
-            f /= (ulong)1e9;
-            seconds <<= 32;
-            var ntp = seconds | f;
-            var abs = ntp >> 14;
-            var length = 2; // extension length (3-1)
-
-            return new[]
-            {
-                (byte)((RTCPeerConnection.RTP_HEADER_EXTENSION_ID_ABS_SEND_TIME << 4) | length),
-                (byte)((abs & 0xff0000UL) >> 16),
-                (byte)((abs & 0xff00UL) >> 8),
-                (byte)(abs & 0xffUL) 
-            };
-        }
-
-        /*
-           An example header extension, with three extension elements, some
-           padding, and including the required RTP fields, follows:
-           
-           0                   1                   2                   3
-           0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
-           +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-           |       0xBE    |    0xDE       |           length=3            |
-           +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-           |  ID   | L=0   |     data      |  ID   |  L=1  |   data...     |
-           +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-           |     ...data   |    0 (pad)    |    0 (pad)    |  ID   | L=3   |
-           +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-           |                          data                                 |
-           +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-         */
-        // https://datatracker.ietf.org/doc/html/rfc5285#section-4.2
-        public void AddAbsSendTimeExtension()
-        {
-            HeaderExtensionFlag = 1;
-            ExtensionProfile = ONE_BYTE_EXTENSION_PROFILE;
-            ExtensionLength = 1; // only abs-send-time for now
-            ExtensionPayload = AbsSendTime(DateTimeOffset.Now);
-        }
     }
 }

--- a/src/net/RTP/RTPHeaderExtension.cs
+++ b/src/net/RTP/RTPHeaderExtension.cs
@@ -45,6 +45,13 @@ namespace SIPSorcery.net.RTP
             return result;
         }
 
+        /// <summary>
+        /// To create a RTP Header Extension
+        /// </summary>
+        /// <param name="id"><see cref="int"/> Id / extmap</param>
+        /// <param name="uri"><see cref="String"/>uri</param>
+        /// <param name="type"><see cref="RTPHeaderExtension"/>type (one or two bytes)</param>
+        /// <param name="medias"><see cref="SDPMediaTypesEnum"/>media(s) supportef by this extension - set null/empty if all medias are supported</param>
         public RTPHeaderExtension(int id, string uri, RTPHeaderExtensionType type, params SDPMediaTypesEnum[] medias )
         {
             Id = id;
@@ -67,10 +74,7 @@ namespace SIPSorcery.net.RTP
         // Uri
         public string Uri { get; }
 
-        // Data read of the RTPHeaderExtension
-        public byte[] Data { get; set;  }
-
-        // Medias supported by this extension - if null all media are supported
+        // Medias supported by this extension - if null/empty all medias are supported
         public List<SDPMediaTypesEnum> Medias { get;}
 
         // Type (one or two bytes)
@@ -93,24 +97,6 @@ namespace SIPSorcery.net.RTP
         public abstract void ReadHeader(ref MediaStreamTrack localTrack, ref MediaStreamTrack remoteTrack, RTPHeader header, byte[] data);
     }
 
-    public class RTPHeaderExtensionUri
-    {
-        public enum Type{
-            Unknown,
-            AbsCaptureTime
-        }
-
-        private static Dictionary<string, Type> Types { get; } = new Dictionary<string, Type>() {{"http://www.webrtc.org/experiments/rtp-hdrext/abs-capture-time", Type.AbsCaptureTime}};
-
-        public static Type? GetType(string uri) {
-            if (!Types.ContainsKey(uri)) {
-                return Type.Unknown;
-            }
-
-            return Types[uri];
-        }
-    }
-    
     public enum RTPHeaderExtensionType
     {
         OneByte,

--- a/src/net/RTP/RTPHeaderExtension.cs
+++ b/src/net/RTP/RTPHeaderExtension.cs
@@ -67,7 +67,7 @@ namespace SIPSorcery.net.RTP
         }
 
         // Id / "extmap"
-        public int Id { get; }
+        public int Id { get; internal set; }
 
         // Uri
         public string Uri { get; }

--- a/src/net/RTP/RTPHeaderExtension.cs
+++ b/src/net/RTP/RTPHeaderExtension.cs
@@ -1,23 +1,96 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
+using SIPSorcery.net.RTP.RTPHeaderExtensions;
 using SIPSorcery.Net;
-using SIPSorcery.Sys;
 
 namespace SIPSorcery.net.RTP
 {
-    public class RTPHeaderExtension
+    public abstract class RTPHeaderExtension
     {
-        public RTPHeaderExtension(int id, string uri)
+        /// <summary>
+        /// Create an RTPHeaderExtension (<see cref="AbsSendTimeExtension"/>, <see cref="CVOExtension"/>, etc ...) based on the URI provided
+        /// If found, id permits to store the "extmap" value related to this extension
+        /// It not found returns null
+        /// </summary>
+        /// <param name="id">extmap value</param>
+        /// <param name="uri">URI of the extension - for example: "http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time" or "urn:3gpp:video-orientation" </param>
+        /// <returns>A Specific RTPHeaderExtension</returns>
+        public static RTPHeaderExtension GetRTPHeaderExtension(int id, String uri)
+        {
+            switch (uri)
+            {
+                case AbsSendTimeExtension.RTP_HEADER_EXTENSION_URI:
+                    return new AbsSendTimeExtension(id);
+
+                case CVOExtension.RTP_HEADER_EXTENSION_URI:
+                    return new CVOExtension(id);
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// To get a list of all RT
+        /// </summary>
+        /// <returns></returns>
+        public static Dictionary<int, RTPHeaderExtension> GetRTPHeaderExtensions()
+        {
+            int index = 1;
+            var result = new Dictionary<int, RTPHeaderExtension>
+            {
+                { index, new AbsSendTimeExtension(index++) },
+                { index, new CVOExtension(index++) }
+            };
+
+            return result;
+        }
+
+        public RTPHeaderExtension(int id, string uri, RTPHeaderExtensionType type, params SDPMediaTypesEnum[] medias )
         {
             Id = id;
             Uri = uri;
+            Type = type;
+
+            if (medias != null)
+            {
+                Medias = medias.ToList();
+            }
+            else
+            {
+                Medias = new List<SDPMediaTypesEnum>();
+            }
         }
+
+        // Id / "extmap"
         public int Id { get; }
+
+        // Uri
         public string Uri { get; }
 
-        public RTPHeaderExtensionUri.Type? Type => RTPHeaderExtensionUri.GetType(Uri);
+        // Data read of the RTPHeaderExtension
+        public byte[] Data { get; set;  }
+
+        // Medias supported by this extension - if null all media are supported
+        public List<SDPMediaTypesEnum> Medias { get;}
+
+        // Type (one or two bytes)
+        public RTPHeaderExtensionType Type { get; }
+
+        public Boolean IsMediaSupported(SDPMediaTypesEnum media)
+        {
+            if (Medias.Count == 0)
+            {
+                return true;
+            }
+
+            return Medias.Contains(media);
+        }
+
+        // Function to call to get the payload when writting the RTP header
+        public abstract byte[] WriteHeader();
+
+        // Function to call when reading the RTP header
+        public abstract void ReadHeader(ref MediaStreamTrack localTrack, ref MediaStreamTrack remoteTrack, RTPHeader header, byte[] data);
     }
 
     public class RTPHeaderExtensionUri
@@ -55,29 +128,5 @@ namespace SIPSorcery.net.RTP
         public int Id { get; }
         public byte[] Data { get; }
         public RTPHeaderExtensionType Type { get; }
-
-        public RTPHeaderExtensionUri.Type? GetUriType(Dictionary<int, RTPHeaderExtension> map) {
-            return !map.ContainsKey(Id) ? null : map[Id].Type;
-        }
-
-
-        public ulong? GetNtpTimestamp(Dictionary<int, RTPHeaderExtension> extensions){
-            var extensionType = GetUriType(extensions);
-            if (extensionType != RTPHeaderExtensionUri.Type.AbsCaptureTime) {
-                return null;
-            }
-
-            return GetUlong(0);
-        }
-
-        public ulong? GetUlong(int offset) {
-            if (offset + sizeof(ulong) - 1 >= Data.Length) {
-                return null;
-            }
-
-            return BitConverter.IsLittleEndian ? 
-                NetConvert.DoReverseEndian(BitConverter.ToUInt64(Data, offset)) : 
-                BitConverter.ToUInt64(Data, offset);
-        }
     }
 }

--- a/src/net/RTP/RTPHeaderExtension.cs
+++ b/src/net/RTP/RTPHeaderExtension.cs
@@ -52,10 +52,11 @@ namespace SIPSorcery.net.RTP
         /// <param name="uri"><see cref="String"/>uri</param>
         /// <param name="type"><see cref="RTPHeaderExtension"/>type (one or two bytes)</param>
         /// <param name="medias"><see cref="SDPMediaTypesEnum"/>media(s) supportef by this extension - set null/empty if all medias are supported</param>
-        public RTPHeaderExtension(int id, string uri, RTPHeaderExtensionType type, params SDPMediaTypesEnum[] medias )
+        public RTPHeaderExtension(int id, string uri, int extensionSize, RTPHeaderExtensionType type, params SDPMediaTypesEnum[] medias )
         {
             Id = id;
             Uri = uri;
+            ExtensionSize = extensionSize;
             Type = type;
 
             if (medias != null)
@@ -74,6 +75,8 @@ namespace SIPSorcery.net.RTP
         // Uri
         public string Uri { get; }
 
+        public int ExtensionSize { get; }
+
         // Medias supported by this extension - if null/empty all medias are supported
         public List<SDPMediaTypesEnum> Medias { get;}
 
@@ -91,10 +94,10 @@ namespace SIPSorcery.net.RTP
         }
 
         // Function to call to get the payload when writting the RTP header
-        public abstract byte[] WriteHeader();
+        public abstract byte[] Marshal();
 
         // Function to call when reading the RTP header
-        public abstract void ReadHeader(ref MediaStreamTrack localTrack, ref MediaStreamTrack remoteTrack, RTPHeader header, byte[] data);
+        public abstract void Unmarshal(ref MediaStreamTrack localTrack, ref MediaStreamTrack remoteTrack, RTPHeader header, byte[] data);
     }
 
     public enum RTPHeaderExtensionType

--- a/src/net/RTP/RTPHeaderExtension.cs
+++ b/src/net/RTP/RTPHeaderExtension.cs
@@ -25,6 +25,9 @@ namespace SIPSorcery.net.RTP
 
                 case CVOExtension.RTP_HEADER_EXTENSION_URI:
                     return new CVOExtension(id);
+
+                case AudioLevelExtension.RTP_HEADER_EXTENSION_URI:
+                    return new AudioLevelExtension(id);
             }
             return null;
         }
@@ -39,7 +42,8 @@ namespace SIPSorcery.net.RTP
             var result = new Dictionary<int, RTPHeaderExtension>
             {
                 { index, new AbsSendTimeExtension(index++) },
-                { index, new CVOExtension(index++) }
+                { index, new CVOExtension(index++) },
+                { index, new AudioLevelExtension(index++) }
             };
 
             return result;

--- a/src/net/RTP/RTPHeaderExtension.cs
+++ b/src/net/RTP/RTPHeaderExtension.cs
@@ -16,37 +16,30 @@ namespace SIPSorcery.net.RTP
         /// <param name="id">extmap value</param>
         /// <param name="uri">URI of the extension - for example: "http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time" or "urn:3gpp:video-orientation" </param>
         /// <returns>A Specific RTPHeaderExtension</returns>
-        public static RTPHeaderExtension GetRTPHeaderExtension(int id, String uri)
+        public static RTPHeaderExtension GetRTPHeaderExtension(int id, String uri, SDPMediaTypesEnum media)
         {
+            RTPHeaderExtension result = null;
             switch (uri)
             {
                 case AbsSendTimeExtension.RTP_HEADER_EXTENSION_URI:
-                    return new AbsSendTimeExtension(id);
+                    result = new AbsSendTimeExtension(id);
+                    break;
 
                 case CVOExtension.RTP_HEADER_EXTENSION_URI:
-                    return new CVOExtension(id);
+                    result = new CVOExtension(id);
+                    break;
 
                 case AudioLevelExtension.RTP_HEADER_EXTENSION_URI:
-                    return new AudioLevelExtension(id);
+                    result = new AudioLevelExtension(id);
+                    break;
             }
-            return null;
-        }
 
-        /// <summary>
-        /// To get a list of all RT
-        /// </summary>
-        /// <returns></returns>
-        public static Dictionary<int, RTPHeaderExtension> GetRTPHeaderExtensions()
-        {
-            int index = 1;
-            var result = new Dictionary<int, RTPHeaderExtension>
+            if ( (result != null) &&  result.IsMediaSupported(media) )
             {
-                { index, new AbsSendTimeExtension(index++) },
-                { index, new CVOExtension(index++) },
-                { index, new AudioLevelExtension(index++) }
-            };
+                return result;
+            }
 
-            return result;
+            return null;
         }
 
         /// <summary>
@@ -97,11 +90,14 @@ namespace SIPSorcery.net.RTP
             return Medias.Contains(media);
         }
 
+        // Function to call to set a new value to this extension
+        public abstract void Set(Object obj);
+
         // Function to call to get the payload when writting the RTP header
         public abstract byte[] Marshal();
 
         // Function to call when reading the RTP header
-        public abstract void Unmarshal(ref MediaStreamTrack localTrack, ref MediaStreamTrack remoteTrack, RTPHeader header, byte[] data);
+        public abstract Object Unmarshal(RTPHeader header, byte[] data);
     }
 
     public enum RTPHeaderExtensionType

--- a/src/net/RTP/RTPHeaderExtensions/AbsSendTimeExtension.cs
+++ b/src/net/RTP/RTPHeaderExtensions/AbsSendTimeExtension.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 using SIPSorcery.Net;
 
 namespace SIPSorcery.net.RTP.RTPHeaderExtensions
@@ -11,19 +9,37 @@ namespace SIPSorcery.net.RTP.RTPHeaderExtensions
     public class AbsSendTimeExtension: RTPHeaderExtension
     {
         public const string RTP_HEADER_EXTENSION_URI    = "http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time";
+        public const int RTP_HEADER_EXTENSION_SIZE = 3;
 
-        public AbsSendTimeExtension(int id): base(id, RTP_HEADER_EXTENSION_URI, RTPHeaderExtensionType.OneByte)
+        public AbsSendTimeExtension(int id): base(id, RTP_HEADER_EXTENSION_URI, RTP_HEADER_EXTENSION_SIZE, RTPHeaderExtensionType.OneByte)
         {
         }
 
-        public override byte[] WriteHeader()
+        public override byte[] Marshal()
         {
-            return AbsSendTimePayload(Id, DateTimeOffset.Now);
+            // inspired by https://github.com/pion/rtp/blob/master/abssendtimeextension.go
+            ulong unixNanoseconds = (ulong)((DateTimeOffset.Now - UnixEpoch).Ticks * 100L);
+            var seconds = unixNanoseconds / (ulong)1e9;
+            seconds += 0x83AA7E80UL; // offset in seconds between unix epoch and ntp epoch
+            var f = unixNanoseconds % (ulong)1e9;
+            f <<= 32;
+            f /= (ulong)1e9;
+            seconds <<= 32;
+            var ntp = seconds | f;
+            var abs = ntp >> 14;
+
+            return new[]
+            {
+                (byte)((Id << 4) | ExtensionSize - 1),
+                (byte)((abs & 0xff0000UL) >> 16),
+                (byte)((abs & 0xff00UL) >> 8),
+                (byte)(abs & 0xffUL)
+            };
         }
 
-        public override void ReadHeader(ref MediaStreamTrack localTrack, ref MediaStreamTrack remoteTrack, RTPHeader header, byte[] data)
+        public override void Unmarshal(ref MediaStreamTrack localTrack, ref MediaStreamTrack remoteTrack, RTPHeader header, byte[] data)
         {
-            var ntpTimestamp = GetUlong(data, 0);
+            var ntpTimestamp = GetUlong(data);
             if (ntpTimestamp.HasValue)
             {
                 remoteTrack.LastAbsoluteCaptureTimestamp = new TimestampPair() { NtpTimestamp = ntpTimestamp.Value, RtpTimestamp = header.Timestamp };
@@ -33,39 +49,16 @@ namespace SIPSorcery.net.RTP.RTPHeaderExtensions
         // DateTimeOffset.UnixEpoch only available in newer target frameworks
         private static readonly DateTimeOffset UnixEpoch = new DateTimeOffset(1970, 1, 1, 0, 0, 0, TimeSpan.Zero);
 
-        // inspired by https://github.com/pion/rtp/blob/master/abssendtimeextension.go
-        private static byte[] AbsSendTimePayload(int id, DateTimeOffset now)
+        private ulong? GetUlong(byte[] data)
         {
-            ulong unixNanoseconds = (ulong)((now - UnixEpoch).Ticks * 100L);
-            var seconds = unixNanoseconds / (ulong)1e9;
-            seconds += 0x83AA7E80UL; // offset in seconds between unix epoch and ntp epoch
-            var f = unixNanoseconds % (ulong)1e9;
-            f <<= 32;
-            f /= (ulong)1e9;
-            seconds <<= 32;
-            var ntp = seconds | f;
-            var abs = ntp >> 14;
-            var length = 2; // extension length (3-1)
-
-            return new[]
-            {
-                (byte)((id << 4) | length),
-                (byte)((abs & 0xff0000UL) >> 16),
-                (byte)((abs & 0xff00UL) >> 8),
-                (byte)(abs & 0xffUL)
-            };
-        }
-
-        private static ulong? GetUlong(byte[] data, int offset)
-        {
-            if (offset + sizeof(ulong) - 1 >= data.Length)
+            if (data.Length != ExtensionSize)
             {
                 return null;
             }
 
             return BitConverter.IsLittleEndian ?
-                SIPSorcery.Sys.NetConvert.DoReverseEndian(BitConverter.ToUInt64(data, offset)) :
-                BitConverter.ToUInt64(data, offset);
+                SIPSorcery.Sys.NetConvert.DoReverseEndian(BitConverter.ToUInt64(data, 0)) :
+                BitConverter.ToUInt64(data, 0);
         }
     }
 }

--- a/src/net/RTP/RTPHeaderExtensions/AbsSendTimeExtension.cs
+++ b/src/net/RTP/RTPHeaderExtensions/AbsSendTimeExtension.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using SIPSorcery.Net;
+
+namespace SIPSorcery.net.RTP.RTPHeaderExtensions
+{
+    // AbsSendTimeExtension is a extension payload format in
+    // http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time
+    // Code refrence: https://chromium.googlesource.com/external/webrtc/+/e2a017725570ead5946a4ca8235af27470ca0df9/webrtc/modules/rtp_rtcp/source/rtp_header_extensions.cc#49
+    public class AbsSendTimeExtension: RTPHeaderExtension
+    {
+        public const string RTP_HEADER_EXTENSION_URI    = "http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time";
+
+        public AbsSendTimeExtension(int id): base(id, RTP_HEADER_EXTENSION_URI, RTPHeaderExtensionType.OneByte)
+        {
+        }
+
+        public override byte[] WriteHeader()
+        {
+            return AbsSendTimePayload(Id, DateTimeOffset.Now);
+        }
+
+        public override void ReadHeader(ref MediaStreamTrack localTrack, ref MediaStreamTrack remoteTrack, RTPHeader header, byte[] data)
+        {
+            var ntpTimestamp = GetUlong(data, 0);
+            if (ntpTimestamp.HasValue)
+            {
+                remoteTrack.LastAbsoluteCaptureTimestamp = new TimestampPair() { NtpTimestamp = ntpTimestamp.Value, RtpTimestamp = header.Timestamp };
+            }
+        }
+
+        // DateTimeOffset.UnixEpoch only available in newer target frameworks
+        private static readonly DateTimeOffset UnixEpoch = new DateTimeOffset(1970, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+        // inspired by https://github.com/pion/rtp/blob/master/abssendtimeextension.go
+        private static byte[] AbsSendTimePayload(int id, DateTimeOffset now)
+        {
+            ulong unixNanoseconds = (ulong)((now - UnixEpoch).Ticks * 100L);
+            var seconds = unixNanoseconds / (ulong)1e9;
+            seconds += 0x83AA7E80UL; // offset in seconds between unix epoch and ntp epoch
+            var f = unixNanoseconds % (ulong)1e9;
+            f <<= 32;
+            f /= (ulong)1e9;
+            seconds <<= 32;
+            var ntp = seconds | f;
+            var abs = ntp >> 14;
+            var length = 2; // extension length (3-1)
+
+            return new[]
+            {
+                (byte)((id << 4) | length),
+                (byte)((abs & 0xff0000UL) >> 16),
+                (byte)((abs & 0xff00UL) >> 8),
+                (byte)(abs & 0xffUL)
+            };
+        }
+
+        /*
+           An example header extension, with three extension elements, some
+           padding, and including the required RTP fields, follows:
+           
+           0                   1                   2                   3
+           0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+           +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+           |       0xBE    |    0xDE       |           length=3            |
+           +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+           |  ID   | L=0   |     data      |  ID   |  L=1  |   data...     |
+           +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+           |     ...data   |    0 (pad)    |    0 (pad)    |  ID   | L=3   |
+           +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+           |                          data                                 |
+           +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+         */
+        // https://datatracker.ietf.org/doc/html/rfc5285#section-4.2
+        private RTPHeader WriteAbsSendTimeHeader(RTPHeader rtpHeader)
+        {
+            rtpHeader.HeaderExtensionFlag = 1;
+            rtpHeader.ExtensionProfile = RTPHeader.ONE_BYTE_EXTENSION_PROFILE;
+            rtpHeader.ExtensionLength = 1; // only abs-send-time for now
+            rtpHeader.ExtensionPayload = AbsSendTimePayload(Id, DateTimeOffset.Now);
+            return rtpHeader;
+        }
+
+        private static ulong? GetUlong(byte[] data, int offset)
+        {
+            if (offset + sizeof(ulong) - 1 >= data.Length)
+            {
+                return null;
+            }
+
+            return BitConverter.IsLittleEndian ?
+                SIPSorcery.Sys.NetConvert.DoReverseEndian(BitConverter.ToUInt64(data, offset)) :
+                BitConverter.ToUInt64(data, offset);
+        }
+    }
+}

--- a/src/net/RTP/RTPHeaderExtensions/AbsSendTimeExtension.cs
+++ b/src/net/RTP/RTPHeaderExtensions/AbsSendTimeExtension.cs
@@ -56,32 +56,6 @@ namespace SIPSorcery.net.RTP.RTPHeaderExtensions
             };
         }
 
-        /*
-           An example header extension, with three extension elements, some
-           padding, and including the required RTP fields, follows:
-           
-           0                   1                   2                   3
-           0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
-           +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-           |       0xBE    |    0xDE       |           length=3            |
-           +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-           |  ID   | L=0   |     data      |  ID   |  L=1  |   data...     |
-           +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-           |     ...data   |    0 (pad)    |    0 (pad)    |  ID   | L=3   |
-           +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-           |                          data                                 |
-           +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-         */
-        // https://datatracker.ietf.org/doc/html/rfc5285#section-4.2
-        private RTPHeader WriteAbsSendTimeHeader(RTPHeader rtpHeader)
-        {
-            rtpHeader.HeaderExtensionFlag = 1;
-            rtpHeader.ExtensionProfile = RTPHeader.ONE_BYTE_EXTENSION_PROFILE;
-            rtpHeader.ExtensionLength = 1; // only abs-send-time for now
-            rtpHeader.ExtensionPayload = AbsSendTimePayload(Id, DateTimeOffset.Now);
-            return rtpHeader;
-        }
-
         private static ulong? GetUlong(byte[] data, int offset)
         {
             if (offset + sizeof(ulong) - 1 >= data.Length)

--- a/src/net/RTP/RTPHeaderExtensions/AudioLevelExtension.cs
+++ b/src/net/RTP/RTPHeaderExtensions/AudioLevelExtension.cs
@@ -1,0 +1,69 @@
+﻿using SIPSorcery.Net;
+using System;
+
+namespace SIPSorcery.net.RTP.RTPHeaderExtensions
+{
+    public class AudioLevelExtension : RTPHeaderExtension
+    {
+        public const string RTP_HEADER_EXTENSION_URI = "urn:ietf:params:rtp-hdrext:ssrc-audio-level";
+        public const int RTP_HEADER_EXTENSION_SIZE = 1;
+
+        public event Action<Boolean> OnVoiceChange;
+        public event Action<ushort> OnLevelChange;
+
+        private Boolean _voice = false;
+        private ushort _level = 0;
+
+        public AudioLevelExtension(int id) : base(id, RTP_HEADER_EXTENSION_URI, RTP_HEADER_EXTENSION_SIZE, RTPHeaderExtensionType.OneByte, Net.SDPMediaTypesEnum.audio)
+        {
+        }
+
+        public void SetVoice(Boolean voice)
+        {
+            if(_voice != voice)
+            {
+                _voice = voice;
+                OnVoiceChange?.Invoke(voice);
+            }
+        }
+
+        public void SetLevel(ushort level)
+        {
+            if(level > 127)
+            {
+                return;
+            }
+
+            if (_level != level)
+            {
+                _level = level;
+                OnLevelChange?.Invoke(_level);
+            }
+        }
+
+        public override byte[] Marshal()
+        {
+            byte voice = 0;
+            if (_voice)
+            {
+                voice = 0x80;
+            };
+
+            return new[]
+            {
+                (byte)((Id << 4) | ExtensionSize - 1),
+                (byte)(voice | _level)
+            };
+        }
+
+        public override void Unmarshal(ref MediaStreamTrack localTrack, ref MediaStreamTrack remoteTrack, RTPHeader header, byte[] data)
+        {
+            if (data.Length == ExtensionSize)
+            {
+                SetLevel((ushort)(data[0] & 0x7F));
+                SetVoice((data[0] & 0x80) != 0);
+            }
+        }
+
+    }
+}

--- a/src/net/RTP/RTPHeaderExtensions/CVOExtension.cs
+++ b/src/net/RTP/RTPHeaderExtensions/CVOExtension.cs
@@ -1,0 +1,106 @@
+﻿using SIPSorcery.Net;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace SIPSorcery.net.RTP.RTPHeaderExtensions
+{
+    // CVO (Coordination of Video Orientation) is a extension payload format in  https://www.3gpp.org/ftp/Specs/archive/26_series/26.114/26114-i70.zip
+
+    // Code reference:
+    //  - https://chromium.googlesource.com/external/webrtc/+/e2a017725570ead5946a4ca8235af27470ca0df9/webrtc/modules/rtp_rtcp/source/rtp_header_extensions.cc#134
+    //  - https://chromium.googlesource.com/external/webrtc/+/e2a017725570ead5946a4ca8235af27470ca0df9/webrtc/modules/rtp_rtcp/include/rtp_cvo.h
+
+    public class CVOExtension: RTPHeaderExtension
+    {
+        public const string RTP_HEADER_EXTENSION_URI    = "urn:3gpp:video-orientation";
+
+        private VideoRotation rotation = VideoRotation.kVideoRotation_0;
+
+        public CVOExtension(int id) : base(id, RTP_HEADER_EXTENSION_URI, RTPHeaderExtensionType.OneByte, Net.SDPMediaTypesEnum.video)
+        {
+        }
+
+        public override byte[] WriteHeader()
+        {
+            return null;
+        }
+
+        public override void ReadHeader(ref MediaStreamTrack localTrack, ref MediaStreamTrack remoteTrack, RTPHeader header, byte[] data)
+        {
+            if ( (data != null) && data.Length > 0)
+            {
+                var currentRotation = ConvertCVOByteToVideoRotation((uint)data[0]);
+                if(currentRotation != rotation)
+                {
+                    rotation = currentRotation;
+                    // TODO - need to trigger event
+                }
+            }
+            
+        }
+
+        // enum for clockwise rotation.
+        public enum VideoRotation
+        {
+            kVideoRotation_0 = 0,
+            kVideoRotation_90 = 90,
+            kVideoRotation_180 = 180,
+            kVideoRotation_270 = 270
+        };
+
+        static uint ConvertVideoRotationToCVOByte(VideoRotation rotation)
+        {
+            switch (rotation)
+            {
+                case VideoRotation.kVideoRotation_0:
+                    return 0;
+                case VideoRotation.kVideoRotation_90:
+                    return 1;
+                case VideoRotation.kVideoRotation_180:
+                    return 2;
+                case VideoRotation.kVideoRotation_270:
+                    return 3;
+                default:
+                    return 0;
+            }
+        }
+
+        static VideoRotation ConvertCVOByteToVideoRotation(uint cvo_byte)
+        {
+            /* CVO byte: |0 0 0 0 C F R1 R0|
+                With the following definitions: 
+
+                C = Camera: indicates the direction of the camera used for this video stream. It can be used by the MTSI client in 
+                receiver to e.g. display the received video differently depending on the source camera. 
+                    0: Front-facing camera, facing the user. If camera direction is unknown by the sending MTSI client in the terminal then this is the default value used. 
+                    1: Back-facing camera, facing away from the user. 
+                
+                F = Flip: indicates a horizontal (left-right flip) mirror operation on the video as sent on the link. 
+                    0: No flip operation. If the sending MTSI client in terminal does not know if a horizontal mirror operation is necessary, then this is the default value used. 
+                    1: Horizontal flip operation 
+
+                R1, R0 = Rotation: indicates the rotation of the video as transmitted on the link.
+                    0, 0 =   0° rotation                            => needs   0° CW rotation
+                    0, 1 =  90° Counter Clockwise (CCW) rotation    => needs  90° CW rotation 
+                    1, 0 = 180° CCW rotation                        => needs 180° CW rotation
+                    1, 1 = 270° CCW rotation                        => needs 270° CW rotation
+             */
+
+            uint rotation_bits = cvo_byte & 0x3;
+            switch (rotation_bits)
+            {
+                case 0:
+                    return VideoRotation.kVideoRotation_0;
+                case 1:
+                    return VideoRotation.kVideoRotation_90;
+                case 2:
+                    return VideoRotation.kVideoRotation_180;
+                case 3:
+                    return VideoRotation.kVideoRotation_270;
+                default:
+                    return VideoRotation.kVideoRotation_0;
+            }
+        }
+    }
+}

--- a/src/net/RTP/RTPSession.cs
+++ b/src/net/RTP/RTPSession.cs
@@ -23,7 +23,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
-using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -466,6 +465,27 @@ namespace SIPSorcery.Net
         public event Action<int, IPEndPoint, SDPMediaTypesEnum, RTPPacket> OnRtpPacketReceivedByIndex;
 
         /// <summary>
+        /// Gets fired when an RTP Header packet is received from a remote party. (on the primary one)
+        /// Parameters are:
+        ///  - Remote endpoint packet was received from,
+        ///  - The media type the packet contains, will be audio or video,
+        ///  - The RTP Header extension URI,
+        ///  - Object/Value of the header
+        /// </summary>
+        public event Action< IPEndPoint, SDPMediaTypesEnum, String, Object> OnRtpHeaderReceived;
+
+        /// <summary>
+        /// Gets fired when an RTP Header packet is received from a remote party.
+        /// Parameters are:
+        ///  - index of the AudioStream or VideoStream
+        ///  - Remote endpoint packet was received from,
+        ///  - The media type the packet contains, will be audio or video,
+        ///  - The RTP Header extension URI,
+        ///  - Object/Value of the header
+        /// </summary>
+        public event Action<int, IPEndPoint, SDPMediaTypesEnum, String, Object> OnRtpHeaderReceivedByIndex;
+
+        /// <summary>
         /// Gets fired when an RTP event is detected on the remote call party's RTP stream (on the primary one).
         /// </summary>
         public event Action<IPEndPoint, RTPEvent, RTPHeader> OnRtpEvent;
@@ -635,6 +655,7 @@ namespace SIPSorcery.Net
                 mediaStream.OnSendReportByIndex += RaiseOnSendReport;
                 mediaStream.OnRtpEventByIndex += RaisedOnRtpEvent;
                 mediaStream.OnRtpPacketReceivedByIndex += RaisedOnRtpPacketReceived;
+                mediaStream.OnRtpHeaderReceivedByIndex += RaisedOnRtpHeaderReceived;
                 mediaStream.OnReceiveReportByIndex += RaisedOnOnReceiveReport;
 
                 if (mediaStream.MediaType == SDPMediaTypesEnum.audio)
@@ -724,6 +745,15 @@ namespace SIPSorcery.Net
                 OnRtpPacketReceived?.Invoke(ipEndPoint, media, rtpPacket);
             }
             OnRtpPacketReceivedByIndex?.Invoke(index, ipEndPoint, media, rtpPacket);
+        }
+
+        private void RaisedOnRtpHeaderReceived(int index, IPEndPoint ipEndPoint, SDPMediaTypesEnum media, String uri, Object value)
+        {
+            if (index == 0)
+            {
+                OnRtpHeaderReceived?.Invoke(ipEndPoint, media, uri, value);
+            }
+            OnRtpHeaderReceivedByIndex?.Invoke(index, ipEndPoint, media, uri, value);
         }
 
         private void RaisedOnOnReceiveReport(int index, IPEndPoint ipEndPoint, SDPMediaTypesEnum media, RTCPCompoundPacket report)
@@ -2442,6 +2472,7 @@ namespace SIPSorcery.Net
                 VideoStream?.SendRtpRaw(payload, timestamp, markerBit, payloadTypeID);
             }
         }
+
         /// <summary>
         /// Allows additional control for sending raw RTCP payloads (on the primary one).
         /// </summary>

--- a/src/net/SDP/SDP.cs
+++ b/src/net/SDP/SDP.cs
@@ -424,7 +424,12 @@ namespace SIPSorcery.Net
                                              var extensionId = formatAttributeMatch.Result("${id}");
                                              var uri = formatAttributeMatch.Result("${url}");
                                              if (Int32.TryParse(extensionId, out var id)) {
-                                                 activeAnnouncement.HeaderExtensions.Add(id, new RTPHeaderExtension(id, uri));
+
+                                                var rtpExtension = RTPHeaderExtension.GetRTPHeaderExtension(id, uri);
+                                                if ( (rtpExtension != null) && (rtpExtension.IsMediaSupported(activeAnnouncement.Media)))
+                                                {
+                                                    activeAnnouncement.HeaderExtensions.Add(id, rtpExtension);
+                                                }
                                              }
                                              else {
                                                  logger.LogWarning("Invalid id of header extension in " + SDPMediaAnnouncement.MEDIA_EXTENSION_MAP_ATTRIBUE_PREFIX);

--- a/src/net/SDP/SDP.cs
+++ b/src/net/SDP/SDP.cs
@@ -424,9 +424,8 @@ namespace SIPSorcery.Net
                                              var extensionId = formatAttributeMatch.Result("${id}");
                                              var uri = formatAttributeMatch.Result("${url}");
                                              if (Int32.TryParse(extensionId, out var id)) {
-
-                                                var rtpExtension = RTPHeaderExtension.GetRTPHeaderExtension(id, uri);
-                                                if ( (rtpExtension != null) && (rtpExtension.IsMediaSupported(activeAnnouncement.Media)))
+                                                var rtpExtension = RTPHeaderExtension.GetRTPHeaderExtension(id, uri, activeAnnouncement.Media);
+                                                if ( (rtpExtension != null) && !activeAnnouncement.HeaderExtensions.ContainsKey(id))
                                                 {
                                                     activeAnnouncement.HeaderExtensions.Add(id, rtpExtension);
                                                 }

--- a/src/net/WebRTC/RTCPeerConnection.cs
+++ b/src/net/WebRTC/RTCPeerConnection.cs
@@ -1075,7 +1075,7 @@ namespace SIPSorcery.Net
                         var remoteHeaderExtensions = VideoStreamList[indexVideoStream].RemoteTrack?.HeaderExtensions?.Values;
                         if (remoteHeaderExtensions != null)
                         {
-                            var localHeaderExtensions = VideoStreamList[indexAudioStream].LocalTrack?.HeaderExtensions?.Values;
+                            var localHeaderExtensions = VideoStreamList[indexVideoStream].LocalTrack?.HeaderExtensions?.Values;
                             localHeaderExtensions ??= new Dictionary<int, RTPHeaderExtension>().Values;
 
                             var newRemoteHeaderExtensions = new Dictionary<int, RTPHeaderExtension>();

--- a/src/net/WebRTC/RTCPeerConnection.cs
+++ b/src/net/WebRTC/RTCPeerConnection.cs
@@ -46,6 +46,7 @@ using SIPSorcery.net.RTP;
 using Org.BouncyCastle.Crypto.Tls;
 using SIPSorcery.SIP.App;
 using SIPSorcery.Sys;
+using SIPSorcery.net.RTP.RTPHeaderExtensions;
 
 namespace SIPSorcery.Net
 {
@@ -161,8 +162,6 @@ namespace SIPSorcery.Net
         private const string NORMAL_CLOSE_REASON = "normal";
         private const ushort SCTP_DEFAULT_PORT = 5000;
         private const string UNKNOWN_DATACHANNEL_ERROR = "unknown";
-        public const int RTP_HEADER_EXTENSION_ID_ABS_SEND_TIME = 2;
-        public const string RTP_HEADER_EXTENSION_URI_ABS_SEND_TIME = "http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time";
 
         /// <summary>
         /// The period to wait for the SCTP association to complete before giving up.
@@ -926,19 +925,24 @@ namespace SIPSorcery.Net
             bool excludeIceCandidates = options != null && options.X_ExcludeIceCandidates;
             var offerSdp = createBaseSdp(mediaStreamList, excludeIceCandidates);
 
-            foreach (var mediaStream in offerSdp.Media)
+            var extensions = RTPHeaderExtension.GetRTPHeaderExtensions();
+            foreach (var media in offerSdp.Media)
             {
-                // when creating offer, tell that we support abs-send-time
-                mediaStream.HeaderExtensions.Add(
-                    RTP_HEADER_EXTENSION_ID_ABS_SEND_TIME,
-                    new RTPHeaderExtension(
-                        RTP_HEADER_EXTENSION_ID_ABS_SEND_TIME, 
-                        RTP_HEADER_EXTENSION_URI_ABS_SEND_TIME));
-            }
+                // when creating offer, tell that we support several RTP extensions
+                foreach (var ext in extensions.Values)
+                {
+                    if (ext.IsMediaSupported(media.Media))
+                    {
+                        logger.LogDebug("[createOffer] - Add HeaderExtensions:[{Uri}]", ext.Uri);
+                        media.HeaderExtensions.Add(ext.Id, ext);
+                    }
+                    else
+                    {
+                        logger.LogDebug("[createOffer] - HeaderExtensions not added:[{Uri}] - Media:[{Media]}]", ext.Uri, media.Media);
+                    }
+                }
 
-            foreach (var ann in offerSdp.Media)
-            {
-                ann.IceRole = IceRole;
+                media.IceRole = IceRole;
             }
 
             RTCSessionDescriptionInit initDescription = new RTCSessionDescriptionInit
@@ -1019,14 +1023,13 @@ namespace SIPSorcery.Net
                 foreach (var media in answerSdp.Media)
                 {
                     var remoteMedia = remoteDescription.sdp.Media.FirstOrDefault(m => m.MediaID == media.MediaID);
-                    // when creating answer, copy abs-send-time ext only if the media in offer contained it
+
                     if (remoteMedia != null)
                     {
-                        foreach (var kv in 
-                                 remoteMedia.HeaderExtensions.Where(kv => 
-                                     kv.Value.Uri == RTP_HEADER_EXTENSION_URI_ABS_SEND_TIME))
+                        foreach (var ext in remoteMedia.HeaderExtensions.Values)
                         {
-                            media.HeaderExtensions.Add(kv.Key, kv.Value);
+                            logger.LogDebug("[createAnswer] - Add HeaderExtensions:[{Uri}]", ext.Uri);
+                            media.HeaderExtensions.Add(ext.Id, ext);
                         }
                     }
                 }


### PR DESCRIPTION
### Add support of RTP Header Extensions:

Three are actually supported:
- Abs Send Time - thanks to @[theimowski](https://github.com/theimowski) with https://github.com/sipsorcery-org/sipsorcery/pull/1084
- Coordination of Video Orientation (CVO)
- Audio Level 

### How to add support of a new extension

It's "easy" to add new RTP Header Extension:
- needs to inherit from RTPHeaderExtension
- needs to define an URI as public const string which define the extension in the SDP: for example "http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time" for the AbsSendTime extension

### How to use one of them

By default no extension is used. If you want to use one or more you have to define them when creating a **MediaStreamTrack** with the **headerExtensions** optional parameter.

Example:
```
static private Dictionary<int, RTPHeaderExtension> GetRTPHeaderExtensions(SDPMediaTypesEnum mediaType)
{
    Dictionary<int, RTPHeaderExtension> result = new();

    List<String> extensionsUri = new() { 
                                    AbsSendTimeExtension.RTP_HEADER_EXTENSION_URI,
                                    AudioLevelExtension.RTP_HEADER_EXTENSION_URI,
                                    CVOExtension.RTP_HEADER_EXTENSION_URI 
                                    } ;

    int id = 1;
    foreach (var extUri in extensionsUri)
    {
        var extension = RTPHeaderExtension.GetRTPHeaderExtension(id, extUri, mediaType);
        if(extension != null)
        {
            result.Add(extension.Id, extension);
        }
        id++;
    }
    return result;
}

var extensions = GetRTPHeaderExtensions(SDPMediaTypesEnum.video);

return new SIPSorcery.Net.MediaStreamTrack(SDPMediaTypesEnum.video, isRemote, videoFormatSDPListUsed, mediaStreamStatus, headerExtensions: extensions);

```

### How to receive info from extension 

Like we have **OnRtpPacketReceivedByIndex** event on **MediaStream**, we have now **OnRtpHeaderReceivedByIndex** event to have RTP header value; 
```
public event Action<int, IPEndPoint, SDPMediaTypesEnum, String, Object> OnRtpHeaderReceivedByIndex;

// With String the URI of the extension
// With Object, the data received which depends of the extension
// - for AudioLevelExtension it's an AudioLevel object
// - for CVOExtension it's a CVO object
```

### How to send info from extension 

Like we have **SendRtpRaw** method on **MediaStream**, we have now **SetRtpHeaderExtensionValue** method to set a new RTP header value; 
```
public void SetRtpHeaderExtensionValue(String uri, Object value)

// With String the URI of the extension
// With Object, the data to send which depends of the extension
// - for AudioLevelExtension it's an AudioLevel object
// - for CVOExtension it's a CVO object
```
When a value is set on an extension, it will be used for each RTP packet until a new value is set.


### Restrictions:

- Only ONE_BYTE_EXTENSION_PROFILE is supported - so only extmap from 1 to 14 are supported (I never see so much extensions). This restriction exists only because I didn't understand how to handle more when sending data - see "**protected void SendRtpRaw()**" in **MediaStream**. Perhaps someone can remove this restriction

- I have tested only in WebRTC use case. I don't use  SIP use case. I let the community to check them