### PR TITLE
Reduce Memory allocations

### DIFF
--- a/src/net/DtlsSrtp/DtlsSrtpTransport.cs
+++ b/src/net/DtlsSrtp/DtlsSrtpTransport.cs
@@ -19,6 +19,7 @@
 using System;
 using System.Buffers;
 using System.Collections.Concurrent;
+using System.Linq;
 using Microsoft.Extensions.Logging;
 using Org.BouncyCastle.Crypto.Tls;
 using Org.BouncyCastle.Security;
@@ -398,6 +399,21 @@ namespace SIPSorcery.Net
             return 0; //No Errors
         }
 
+        public byte[] ProtectRTP(byte[] packet, int offset, int length)
+        {
+            var buffer=ArrayPool<byte>.Shared.Rent(packet.Length * 2);
+            try
+            {
+                var resultLength = ProtectRTP(packet, offset, length, buffer, packet.Length * 2);
+                var segment=new ArraySegment<byte>(buffer, 0, resultLength);
+                return segment.ToArray();
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(buffer);
+            }
+
+        }
         public int ProtectRTP(byte[] packet, int offset, int length,byte[] buffer,int bufferLength)
         {
             lock (this.srtpEncoder)
@@ -454,6 +470,20 @@ namespace SIPSorcery.Net
             return 0; //No Errors
         }
 
+        public byte[] ProtectRTCP(byte[] packet, int offset, int length)
+        {
+            var buffer=ArrayPool<byte>.Shared.Rent(packet.Length * 2);
+            try
+            {
+                var resultLength = ProtectRTCP(packet, offset, length, buffer, packet.Length * 2);
+                var segment=new ArraySegment<byte>(buffer, 0, resultLength);
+                return segment.ToArray();
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(buffer);
+            }
+        }
         public int ProtectRTCP(byte[] packet, int offset, int length,byte[] buffer,int bufferLength)
         {
             lock (this.srtcpEncoder)

--- a/src/net/DtlsSrtp/DtlsSrtpTransport.cs
+++ b/src/net/DtlsSrtp/DtlsSrtpTransport.cs
@@ -17,6 +17,7 @@
 //-----------------------------------------------------------------------------
 
 using System;
+using System.Buffers;
 using System.Collections.Concurrent;
 using Microsoft.Extensions.Logging;
 using Org.BouncyCastle.Crypto.Tls;
@@ -397,28 +398,37 @@ namespace SIPSorcery.Net
             return 0; //No Errors
         }
 
-        public byte[] ProtectRTP(byte[] packet, int offset, int length)
+        public int ProtectRTP(byte[] packet, int offset, int length,byte[] buffer,int bufferLength)
         {
             lock (this.srtpEncoder)
             {
-                return this.srtpEncoder.Transform(packet, offset, length);
+                return this.srtpEncoder.Transform(packet, offset, length,buffer,bufferLength);
             }
         }
 
         public int ProtectRTP(byte[] payload, int length, out int outLength)
         {
-            var result = ProtectRTP(payload, 0, length);
-
-            if (result == null)
+            var resultBuf=ArrayPool<byte>.Shared.Rent(length * 2);
+            try
             {
-                outLength = 0;
-                return -1;
+                var resultSize = ProtectRTP(payload, 0, length,resultBuf,length * 2);
+
+                if (resultSize <1)
+                {
+                    outLength = 0;
+                    return -1;
+                }
+
+                System.Buffer.BlockCopy(resultBuf, 0, payload, 0, resultSize);
+                outLength = resultSize;
+
+                return 0; //No Errors
             }
-
-            System.Buffer.BlockCopy(result, 0, payload, 0, result.Length);
-            outLength = result.Length;
-
-            return 0; //No Errors
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(resultBuf);
+            }
+           
         }
 
         public byte[] UnprotectRTCP(byte[] packet, int offset, int length)
@@ -444,27 +454,36 @@ namespace SIPSorcery.Net
             return 0; //No Errors
         }
 
-        public byte[] ProtectRTCP(byte[] packet, int offset, int length)
+        public int ProtectRTCP(byte[] packet, int offset, int length,byte[] buffer,int bufferLength)
         {
             lock (this.srtcpEncoder)
             {
-                return this.srtcpEncoder.Transform(packet, offset, length);
+                return this.srtcpEncoder.Transform(packet, offset, length,buffer,bufferLength);
             }
         }
 
         public int ProtectRTCP(byte[] payload, int length, out int outLength)
         {
-            var result = ProtectRTCP(payload, 0, length);
-            if (result == null)
+            var buff=ArrayPool<byte>.Shared.Rent(length * 2);
+            try
             {
-                outLength = 0;
-                return -1;
+                var resultSize = ProtectRTCP(payload, 0, length,buff,length * 2);
+                if (resultSize<0)
+                {
+                    outLength = 0;
+                    return -1;
+                }
+
+                System.Buffer.BlockCopy(buff, 0, payload, 0, resultSize);
+                outLength = resultSize;
+
+                return 0; //No Errors
             }
-
-            System.Buffer.BlockCopy(result, 0, payload, 0, result.Length);
-            outLength = result.Length;
-
-            return 0; //No Errors
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(buff);
+            }
+           
         }
 
         /// <summary>

--- a/src/net/DtlsSrtp/SrtpHandler.cs
+++ b/src/net/DtlsSrtp/SrtpHandler.cs
@@ -190,8 +190,23 @@ namespace SIPSorcery.Net
 
             return 0; //No Errors
         }
-
-       public int ProtectRTP(byte[] packet, int offset, int length,byte[] buffer,int bufferLength)
+        
+        public byte[] ProtectRTP(byte[] packet, int offset, int length)
+        {
+            var buffer=ArrayPool<byte>.Shared.Rent(packet.Length * 2);
+            try
+            {
+                var resultLength = ProtectRTP(packet, offset, length, buffer, packet.Length * 2);
+                var segment=new ArraySegment<byte>(buffer, 0, resultLength);
+                return segment.ToArray();
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(buffer);
+            }
+        }
+       
+        public int ProtectRTP(byte[] packet, int offset, int length,byte[] buffer,int bufferLength)
         {
             lock (this.SrtpEncoder)
             {
@@ -247,6 +262,20 @@ namespace SIPSorcery.Net
             return 0; //No Errors
         }
 
+        public byte[] ProtectRTCP(byte[] packet, int offset, int length)
+        {
+            var buffer=ArrayPool<byte>.Shared.Rent(packet.Length * 2);
+            try
+            {
+                var resultLength = ProtectRTCP(packet, offset, length, buffer, packet.Length * 2);
+                var segment=new ArraySegment<byte>(buffer, 0, resultLength);
+                return segment.ToArray();
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(buffer);
+            }
+        }
         public int ProtectRTCP(byte[] packet, int offset, int length, byte[] buffer,int bufferLength)
         {
             lock (SrtcpEncoder)

--- a/src/net/DtlsSrtp/Transform/IPackerTransformer.cs
+++ b/src/net/DtlsSrtp/Transform/IPackerTransformer.cs
@@ -30,6 +30,7 @@ namespace SIPSorcery.Net
          *            the packet to be transformed
          * @return The transformed packet. Returns null if the packet cannot be transformed.
          */
+        byte[] Transform(byte[] pkt);
         int Transform(byte[] pkt,byte[] resultBuffer,int resultBufferLength);
 
         /**
@@ -44,6 +45,8 @@ namespace SIPSorcery.Net
          * @return The transformed packet. Returns null if the packet cannot be
          *         transformed.
          */
+        
+        byte[] Transform(byte[] pkt, int offset, int length);
         int Transform(byte[] pkt, int offset, int length,byte[] resultBuffer,int resultBufferLength);
 
         /**

--- a/src/net/DtlsSrtp/Transform/IPackerTransformer.cs
+++ b/src/net/DtlsSrtp/Transform/IPackerTransformer.cs
@@ -30,7 +30,7 @@ namespace SIPSorcery.Net
          *            the packet to be transformed
          * @return The transformed packet. Returns null if the packet cannot be transformed.
          */
-        byte[] Transform(byte[] pkt);
+        int Transform(byte[] pkt,byte[] resultBuffer,int resultBufferLength);
 
         /**
          * Transforms a specific non-secure packet.
@@ -44,7 +44,7 @@ namespace SIPSorcery.Net
          * @return The transformed packet. Returns null if the packet cannot be
          *         transformed.
          */
-        byte[] Transform(byte[] pkt, int offset, int length);
+        int Transform(byte[] pkt, int offset, int length,byte[] resultBuffer,int resultBufferLength);
 
         /**
          * Reverse-transforms a specific packet (i.e. transforms a transformed

--- a/src/net/DtlsSrtp/Transform/RawPacket.cs
+++ b/src/net/DtlsSrtp/Transform/RawPacket.cs
@@ -95,13 +95,33 @@ namespace SIPSorcery.Net
             this.buffer.SetLength(length - offset);
             this.buffer.Position = 0;
         }
-
-        public byte[] GetData()
+        public int GetDataIntoBuffer(byte[] resultBuffer,int bufferLength)
         {
+         
+            if (bufferLength < this.buffer.Length)
+            {
+                throw new InvalidDataException("Buffer is too small");
+            }
             this.buffer.Position = 0;
-            byte[] data = new byte[this.buffer.Length];
-            this.buffer.Read(data, 0, data.Length);
-            return data;
+            
+            this.buffer.Read(resultBuffer, 0, (int)this.buffer.Length);
+            return (int)this.buffer.Length;
+        }
+        public byte[] GetData(byte[] resultBuffer=null)
+        {
+            if (resultBuffer == null)
+            {
+                resultBuffer= new byte[this.buffer.Length];
+            }
+
+            if (resultBuffer.Length < this.buffer.Length)
+            {
+                throw new InvalidDataException("Buffer is too small");
+            }
+            this.buffer.Position = 0;
+            
+            this.buffer.Read(resultBuffer, 0, (int)this.buffer.Length);
+            return resultBuffer;
         }
 
         /**

--- a/src/net/DtlsSrtp/Transform/SrtcpTransformer.cs
+++ b/src/net/DtlsSrtp/Transform/SrtcpTransformer.cs
@@ -59,9 +59,49 @@ namespace SIPSorcery.Net
         /// </summary>
         /// <param name="pkt">plain SRTCP packet to be encrypted.</param>
         /// <returns>encrypted SRTCP packet.</returns>
+        public byte[] Transform(byte[] pkt)
+        {
+            return Transform(pkt, 0, pkt.Length);
+        }
+
+        
         public int Transform(byte[] pkt,byte[] resultBuffer,int resultBufferLength)
         {
             return Transform(pkt, 0, pkt.Length, resultBuffer, resultBufferLength);
+        }
+
+        public byte[] Transform(byte[] pkt, int offset, int length)
+        {
+            var isLocked = Interlocked.CompareExchange(ref _isLocked, 1, 0) != 0;
+            try
+            {
+                // Wrap the data into raw packet for readable format
+                var packet = !isLocked ? this.packet : new RawPacket();
+                packet.Wrap(pkt, offset, length);
+
+                // Associate the packet with its encryption context
+                long ssrc = packet.GetRTCPSSRC();
+                SrtcpCryptoContext context = null;
+                contexts.TryGetValue(ssrc, out context);
+
+                if (context == null)
+                {
+                    context = forwardEngine.GetDefaultContextControl().DeriveContext(ssrc);
+                    context.DeriveSrtcpKeys();
+                    contexts.AddOrUpdate(ssrc, context, (a, b) => context);
+                }
+
+                // Secure packet into SRTCP format
+                context.TransformPacket(packet);
+                return packet.GetData();
+              
+            }
+            finally
+            {
+                //Unlock
+                if (!isLocked)
+                    Interlocked.CompareExchange(ref _isLocked, 0, 1);
+            }
         }
 
         public int Transform(byte[] pkt, int offset, int length,byte[] resultBuffer,int resultBufferLength)

--- a/src/net/DtlsSrtp/Transform/SrtcpTransformer.cs
+++ b/src/net/DtlsSrtp/Transform/SrtcpTransformer.cs
@@ -59,12 +59,12 @@ namespace SIPSorcery.Net
         /// </summary>
         /// <param name="pkt">plain SRTCP packet to be encrypted.</param>
         /// <returns>encrypted SRTCP packet.</returns>
-        public byte[] Transform(byte[] pkt)
+        public int Transform(byte[] pkt,byte[] resultBuffer,int resultBufferLength)
         {
-            return Transform(pkt, 0, pkt.Length);
+            return Transform(pkt, 0, pkt.Length, resultBuffer, resultBufferLength);
         }
 
-        public byte[] Transform(byte[] pkt, int offset, int length)
+        public int Transform(byte[] pkt, int offset, int length,byte[] resultBuffer,int resultBufferLength)
         {
             var isLocked = Interlocked.CompareExchange(ref _isLocked, 1, 0) != 0;
             try
@@ -87,9 +87,8 @@ namespace SIPSorcery.Net
 
                 // Secure packet into SRTCP format
                 context.TransformPacket(packet);
-                byte[] result = packet.GetData();
-
-                return result;
+                return packet.GetDataIntoBuffer(resultBuffer,resultBufferLength);
+              
             }
             finally
             {

--- a/src/net/DtlsSrtp/Transform/SrtpTransformer.cs
+++ b/src/net/DtlsSrtp/Transform/SrtpTransformer.cs
@@ -70,12 +70,12 @@ namespace SIPSorcery.Net
             this.rawPacket = new RawPacket();
         }
 
-        public byte[] Transform(byte[] pkt)
+        public int Transform(byte[] pkt,byte[] outputBuffer,int outputBufferSize)
         {
-            return Transform(pkt, 0, pkt.Length);
+            return Transform(pkt, 0, pkt.Length,outputBuffer,outputBufferSize);
         }
 
-        public byte[] Transform(byte[] pkt, int offset, int length)
+        public int Transform(byte[] pkt, int offset, int length,byte[] outputBuffer,int outputBufferSize)
         {
             var isLocked = Interlocked.CompareExchange(ref _isLocked, 1, 0) != 0;
 
@@ -99,9 +99,8 @@ namespace SIPSorcery.Net
 
                 // Transform RTP packet into SRTP
                 context.TransformPacket(rawPacket);
-                byte[] result = rawPacket.GetData();
+                return rawPacket.GetDataIntoBuffer(outputBuffer,outputBufferSize);
 
-                return result;
             }
             finally
             {

--- a/src/net/ICE/RtpIceChannel.cs
+++ b/src/net/ICE/RtpIceChannel.cs
@@ -2615,11 +2615,16 @@ namespace SIPSorcery.Net
         /// <param name="buffer">The data to send to the peer.</param>
         /// <param name="relayEndPoint">The TURN server end point to send the relayed request to.</param>
         /// <returns></returns>
-        private SocketError SendRelay(ProtocolType protocol, IPEndPoint dstEndPoint, byte[] buffer, IPEndPoint relayEndPoint, IceServer iceServer)
+        private SocketError SendRelay(ProtocolType protocol, IPEndPoint dstEndPoint, byte[] buffer, IPEndPoint relayEndPoint, IceServer iceServer,int bufferLength=-1)
         {
+            if (bufferLength < 0)
+            {
+                bufferLength = buffer.Length;
+            }
+            
             STUNMessage sendReq = new STUNMessage(STUNMessageTypesEnum.SendIndication);
             sendReq.AddXORPeerAddressAttribute(dstEndPoint.Address, dstEndPoint.Port);
-            sendReq.Attributes.Add(new STUNAttribute(STUNAttributeTypesEnum.Data, buffer));
+            sendReq.Attributes.Add(new STUNAttribute(STUNAttributeTypesEnum.Data, buffer.Take(bufferLength).ToArray()));
 
             var request = sendReq.ToByteBuffer(null, false);
             var sendResult = protocol == ProtocolType.Tcp ?
@@ -2692,7 +2697,7 @@ namespace SIPSorcery.Net
         /// <param name="buffer">The data to send.</param>
         /// <returns>The result of initiating the send. This result does not reflect anything about
         /// whether the remote party received the packet or not.</returns>
-        public override SocketError Send(RTPChannelSocketsEnum sendOn, IPEndPoint dstEndPoint, byte[] buffer)
+        public override SocketError Send(RTPChannelSocketsEnum sendOn, IPEndPoint dstEndPoint, byte[] buffer, int bufferLength=-1)
         {
             if (NominatedEntry != null && NominatedEntry.LocalCandidate.type == RTCIceCandidateType.relay &&
                 NominatedEntry.LocalCandidate.IceServer != null &&
@@ -2706,7 +2711,7 @@ namespace SIPSorcery.Net
             }
             else
             {
-                return base.Send(sendOn, dstEndPoint, buffer);
+                return base.Send(sendOn, dstEndPoint, buffer, bufferLength);
             }
         }
     }

--- a/src/net/RTP/Packetisation/H264Packetiser.cs
+++ b/src/net/RTP/Packetisation/H264Packetiser.cs
@@ -41,17 +41,20 @@ namespace SIPSorcery.Net
 
         public struct H264Nal
         {
-            public byte[] NAL { get; }
+            public readonly int Start;
+            public readonly int Length;
+
             public bool IsLast { get; }
 
-            public H264Nal(byte[] nal, bool isLast)
+            public H264Nal(int start, int length, bool isLast)
             {
-                NAL = nal;
+                Start = start;
+                Length = length;
                 IsLast = isLast;
             }
         }
 
-        public static IEnumerable<H264Nal> ParseNals(byte[] accessUnit)
+        public static IEnumerable<H264Nal> ParseNals(byte[] accessUnit, int start, int end)
         {
             int zeroes = 0;
 
@@ -74,7 +77,7 @@ namespace SIPSorcery.Net
                         int nalSize = endPosn - currPosn;
                         bool isLast = currPosn + nalSize == accessUnit.Length;
 
-                        yield return new H264Nal(accessUnit.Skip(currPosn).Take(nalSize).ToArray(), isLast);
+                        yield return new H264Nal(currPosn, nalSize, isLast);
                     }
 
                     currPosn = nalStart;
@@ -87,7 +90,7 @@ namespace SIPSorcery.Net
 
             if (currPosn < accessUnit.Length)
             {
-                yield return new H264Nal(accessUnit.Skip(currPosn).ToArray(), true);
+                yield return new H264Nal(currPosn, accessUnit.Length - currPosn, true);
             }
         }
 

--- a/src/net/RTP/Packetisation/H264Packetiser.cs
+++ b/src/net/RTP/Packetisation/H264Packetiser.cs
@@ -54,20 +54,20 @@ namespace SIPSorcery.Net
             }
         }
 
-        public static IEnumerable<H264Nal> ParseNals(byte[] accessUnit, int start, int end)
+        public static IEnumerable<H264Nal> ParseNals(byte[] accessUnit, int start, int length)
         {
             int zeroes = 0;
 
             // Parse NALs from H264 access unit, encoded as an Annex B bitstream.
             // NALs are delimited by 0x000001 or 0x00000001.
             int currPosn = 0;
-            for (int i = 0; i < accessUnit.Length; i++)
+            for (int i = 0; i < length; i++)
             {
-                if (accessUnit[i] == 0x00)
+                if (accessUnit[start+i] == 0x00)
                 {
                     zeroes++;
                 }
-                else if (accessUnit[i] == 0x01 && zeroes >= 2)
+                else if (accessUnit[start+i] == 0x01 && zeroes >= 2)
                 {
                     // This is a NAL start sequence.
                     int nalStart = i + 1;
@@ -77,7 +77,7 @@ namespace SIPSorcery.Net
                         int nalSize = endPosn - currPosn;
                         bool isLast = currPosn + nalSize == accessUnit.Length;
 
-                        yield return new H264Nal(currPosn, nalSize, isLast);
+                        yield return new H264Nal(start+currPosn, nalSize, isLast);
                     }
 
                     currPosn = nalStart;
@@ -88,9 +88,9 @@ namespace SIPSorcery.Net
                 }
             }
 
-            if (currPosn < accessUnit.Length)
+            if (currPosn < length)
             {
-                yield return new H264Nal(currPosn, accessUnit.Length - currPosn, true);
+                yield return new H264Nal(start+currPosn, length - currPosn, true);
             }
         }
 

--- a/src/net/RTP/RTPChannel.cs
+++ b/src/net/RTP/RTPChannel.cs
@@ -462,8 +462,13 @@ namespace SIPSorcery.Net
         /// <param name="buffer">The data to send.</param>
         /// <returns>The result of initiating the send. This result does not reflect anything about
         /// whether the remote party received the packet or not.</returns>
-        public virtual SocketError Send(RTPChannelSocketsEnum sendOn, IPEndPoint dstEndPoint, byte[] buffer)
+        public virtual SocketError Send(RTPChannelSocketsEnum sendOn, IPEndPoint dstEndPoint, byte[] buffer,int bufferLength=-1)
         {
+            if (bufferLength == -1)
+            {
+                bufferLength=buffer.Length;
+            }
+                
             if (m_isClosed)
             {
                 return SocketError.Disconnecting;
@@ -472,7 +477,7 @@ namespace SIPSorcery.Net
             {
                 throw new ArgumentException("dstEndPoint", "An empty destination was specified to Send in RTPChannel.");
             }
-            else if (buffer == null || buffer.Length == 0)
+            else if (buffer == null || bufferLength == 0)
             {
                 throw new ArgumentException("buffer", "The buffer must be set and non empty for Send in RTPChannel.");
             }
@@ -515,7 +520,7 @@ namespace SIPSorcery.Net
                         m_rtpReceiver.BeginReceiveFrom();
                     }
 
-                    sendSocket.BeginSendTo(buffer, 0, buffer.Length, SocketFlags.None, dstEndPoint, EndSendTo, sendSocket);
+                    sendSocket.BeginSendTo(buffer, 0, bufferLength, SocketFlags.None, dstEndPoint, EndSendTo, sendSocket);
                     return SocketError.Success;
                 }
                 catch (ObjectDisposedException) // Thrown when socket is closed. Can be safely ignored.

--- a/src/net/RTP/RTPPacket.cs
+++ b/src/net/RTP/RTPPacket.cs
@@ -48,7 +48,7 @@ namespace SIPSorcery.Net
         {
             Header = new RTPHeader(packet);
             Payload = new byte[Header.PayloadSize];
-            Array.Copy(packet, Header.Length, Payload, 0, packet.Length);
+            Array.Copy(packet, Header.Length, Payload, 0, Payload.Length);
             this.PayloadSize = packet.Length;
         }
 

--- a/src/net/RTP/RTPPacket.cs
+++ b/src/net/RTP/RTPPacket.cs
@@ -15,39 +15,67 @@
 //-----------------------------------------------------------------------------
 
 using System;
+using System.IO;
 
 namespace SIPSorcery.Net
 {
     public class RTPPacket
     {
         public RTPHeader Header;
-        public byte[] Payload;
-
+        public byte[] Payload { get; private set; }
+        public int PayloadSize = -1;
         public RTPPacket()
         {
             Header = new RTPHeader();
         }
 
+        
         public RTPPacket(int payloadSize)
         {
             Header = new RTPHeader();
             Payload = new byte[payloadSize];
+            this.PayloadSize = payloadSize;
+        }
+        
+        public RTPPacket(byte[] payloadBuffer, int payloadSize)
+        {
+            Header = new RTPHeader();
+            Payload = payloadBuffer;
+            this.PayloadSize = payloadSize;
         }
 
         public RTPPacket(byte[] packet)
         {
             Header = new RTPHeader(packet);
             Payload = new byte[Header.PayloadSize];
-            Array.Copy(packet, Header.Length, Payload, 0, Payload.Length);
+            Array.Copy(packet, Header.Length, Payload, 0, packet.Length);
+            this.PayloadSize = packet.Length;
         }
 
+
+        public int CalculatedSize()
+        {
+            return Header.Length + PayloadSize;
+        }
+
+        public int GetBytes(byte[] buffer)
+        {
+            if (buffer.Length < CalculatedSize())
+            {
+                throw new InvalidDataException("buffer is too small");
+            }
+
+            Header.GetBytes(buffer);
+            Array.Copy(Payload, 0, buffer, Header.Length, PayloadSize);
+            return Header.Length+PayloadSize;
+        }
         public byte[] GetBytes()
         {
             byte[] header = Header.GetBytes();
             byte[] packet = new byte[header.Length + Payload.Length];
 
             Array.Copy(header, packet, header.Length);
-            Array.Copy(Payload, 0, packet, header.Length, Payload.Length);
+            Array.Copy(Payload, 0, packet, header.Length, PayloadSize);
 
             return packet;
         }

--- a/src/net/RTP/VideoStream.cs
+++ b/src/net/RTP/VideoStream.cs
@@ -133,8 +133,17 @@ namespace SIPSorcery.net.RTP
         /// See <see href="https://www.itu.int/rec/dologin_pub.asp?lang=e&amp;id=T-REC-H.264-201602-S!!PDF-E&amp;type=items" /> Annex B for byte stream specification.
         /// </remarks>
         // The same URL without XML escape sequences: https://www.itu.int/rec/dologin_pub.asp?lang=e&id=T-REC-H.264-201602-S!!PDF-E&type=items
-        public void SendH264Frame(uint duration, int payloadTypeID, byte[] accessUnit,int index,int length)
+        public void SendH264Frame(uint duration, int payloadTypeID, byte[] accessUnit, int index=-1, int length=-1)
         {
+            if (index < 0)
+            {
+                index = 0;
+            }
+
+            if (length < 0)
+            {
+                length = accessUnit.Length;
+            }
             if (CheckIfCanSendRtpRaw())
             {
                 foreach (var nal in H264Packetiser.ParseNals(accessUnit,index,length))

--- a/src/net/RTP/VideoStream.cs
+++ b/src/net/RTP/VideoStream.cs
@@ -15,6 +15,7 @@
 //-----------------------------------------------------------------------------
 
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
@@ -132,13 +133,13 @@ namespace SIPSorcery.net.RTP
         /// See <see href="https://www.itu.int/rec/dologin_pub.asp?lang=e&amp;id=T-REC-H.264-201602-S!!PDF-E&amp;type=items" /> Annex B for byte stream specification.
         /// </remarks>
         // The same URL without XML escape sequences: https://www.itu.int/rec/dologin_pub.asp?lang=e&id=T-REC-H.264-201602-S!!PDF-E&type=items
-        public void SendH264Frame(uint duration, int payloadTypeID, byte[] accessUnit)
+        public void SendH264Frame(uint duration, int payloadTypeID, byte[] accessUnit,int index,int length)
         {
             if (CheckIfCanSendRtpRaw())
             {
-                foreach (var nal in H264Packetiser.ParseNals(accessUnit))
+                foreach (var nal in H264Packetiser.ParseNals(accessUnit,index,length))
                 {
-                    SendH264Nal(duration, payloadTypeID, nal.NAL, nal.IsLast);
+                    SendH264Nal(duration, payloadTypeID, accessUnit, nal.IsLast,nal.Start,nal.Length);
                 }
             }
         }
@@ -151,19 +152,19 @@ namespace SIPSorcery.net.RTP
         /// <param name="nal">The buffer containing the NAL to send.</param>
         /// <param name="isLastNal">Should be set for the last NAL in the H264 access unit. Determines when the markbit gets set 
         /// and the timestamp incremented.</param>
-        private void SendH264Nal(uint duration, int payloadTypeID, byte[] nal, bool isLastNal)
+        private void SendH264Nal(uint duration, int payloadTypeID, byte[] nal, bool isLastNal,int arrIndex,int length)
         {
             //logger.LogDebug($"Send NAL {nal.Length}, is last {isLastNal}, timestamp {videoTrack.Timestamp}.");
             //logger.LogDebug($"nri {nalNri:X2}, type {nalType:X2}.");
 
-            byte nal0 = nal[0];
+            byte nal0 = nal[arrIndex+0];
 
-            if (nal.Length <= RTPSession.RTP_MAX_PAYLOAD)
+            if (length <= RTPSession.RTP_MAX_PAYLOAD)
             {
                 // Send as Single-Time Aggregation Packet (STAP-A).
-                byte[] payload = new byte[nal.Length];
+                byte[] payload = new byte[length];
                 int markerBit = isLastNal ? 1 : 0;   // There is only ever one packet in a STAP-A.
-                Buffer.BlockCopy(nal, 0, payload, 0, nal.Length);
+                Buffer.BlockCopy(nal, arrIndex, payload, 0, length);
 
                 SendRtpRaw(payload, LocalTrack.Timestamp, markerBit, payloadTypeID, true);
                 //logger.LogDebug($"send H264 {videoChannel.RTPLocalEndPoint}->{dstEndPoint} timestamp {videoTrack.Timestamp}, payload length {payload.Length}, seqnum {videoTrack.SeqNum}, marker {markerBit}.");
@@ -171,25 +172,29 @@ namespace SIPSorcery.net.RTP
             }
             else
             {
-                nal = nal.Skip(1).ToArray();
+                arrIndex++;
+                length--;
+                //nal = nal.Skip(1).ToArray();
 
                 // Send as Fragmentation Unit A (FU-A):
-                for (int index = 0; index * RTPSession.RTP_MAX_PAYLOAD < nal.Length; index++)
+                for (int index = 0; index * RTPSession.RTP_MAX_PAYLOAD <length; index++)
                 {
                     int offset = index * RTPSession.RTP_MAX_PAYLOAD;
-                    int payloadLength = ((index + 1) * RTPSession.RTP_MAX_PAYLOAD < nal.Length) ? RTPSession.RTP_MAX_PAYLOAD : nal.Length - index * RTPSession.RTP_MAX_PAYLOAD;
+                    int payloadLength = ((index + 1) * RTPSession.RTP_MAX_PAYLOAD < length) ? RTPSession.RTP_MAX_PAYLOAD : length - index * RTPSession.RTP_MAX_PAYLOAD;
 
                     bool isFirstPacket = index == 0;
-                    bool isFinalPacket = (index + 1) * RTPSession.RTP_MAX_PAYLOAD >= nal.Length;
+                    bool isFinalPacket = (index + 1) * RTPSession.RTP_MAX_PAYLOAD >= length;
                     int markerBit = (isLastNal && isFinalPacket) ? 1 : 0;
 
                     byte[] h264RtpHdr = H264Packetiser.GetH264RtpHeader(nal0, isFirstPacket, isFinalPacket);
 
-                    byte[] payload = new byte[payloadLength + h264RtpHdr.Length];
+                    byte[] payload = ArrayPool<byte>.Shared.Rent(payloadLength + h264RtpHdr.Length);
+                    //byte[] payload = new byte[payloadLength + h264RtpHdr.Length];
                     Buffer.BlockCopy(h264RtpHdr, 0, payload, 0, h264RtpHdr.Length);
-                    Buffer.BlockCopy(nal, offset, payload, h264RtpHdr.Length, payloadLength);
+                    Buffer.BlockCopy(nal, offset+arrIndex, payload, h264RtpHdr.Length, payloadLength);
 
-                    SendRtpRaw(payload, LocalTrack.Timestamp, markerBit, payloadTypeID, true);
+                    SendRtpRaw(payload, LocalTrack.Timestamp, markerBit, payloadTypeID, true,dataLength:payloadLength + h264RtpHdr.Length);
+                    ArrayPool<byte>.Shared.Return(payload);
                     //logger.LogDebug($"send H264 {videoChannel.RTPLocalEndPoint}->{dstEndPoint} timestamp {videoTrack.Timestamp}, FU-A {h264RtpHdr.HexStr()}, payload length {payloadLength}, seqnum {videoTrack.SeqNum}, marker {markerBit}.");
                 }
             }
@@ -255,7 +260,7 @@ namespace SIPSorcery.net.RTP
                     SendVp8Frame(durationRtpUnits, payloadID, sample);
                     break;
                 case "H264":
-                    SendH264Frame(durationRtpUnits, payloadID, sample);
+                    SendH264Frame(durationRtpUnits, payloadID, sample,0,sample.Length);
                     break;
                 default:
                     throw new ApplicationException($"Unsupported video format selected {videoSendingFormat.Name()}.");

--- a/src/sys/Crypto/Crypto.cs
+++ b/src/sys/Crypto/Crypto.cs
@@ -15,6 +15,7 @@
 //-----------------------------------------------------------------------------
 
 using System;
+using System.Buffers;
 using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
@@ -218,31 +219,52 @@ namespace SIPSorcery.Sys
 
         public static UInt16 GetRandomUInt16()
         {
-            byte[] uint16Buffer = new byte[2];
-            m_randomProvider.GetBytes(uint16Buffer);
-            return BitConverter.ToUInt16(uint16Buffer, 0);
+            byte[] uint16Buffer = ArrayPool<byte>.Shared.Rent(2);
+            try
+            {
+                m_randomProvider.GetBytes(uint16Buffer);
+                return BitConverter.ToUInt16(uint16Buffer, 0);
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(uint16Buffer);
+            }
         }
 
         public static UInt32 GetRandomUInt(bool noZero = false)
         {
-            byte[] uint32Buffer = new byte[4];
-            m_randomProvider.GetBytes(uint32Buffer);
-            var randomUint = BitConverter.ToUInt32(uint32Buffer, 0);
-
-            if(noZero && randomUint == 0)
+            byte[] uint32Buffer = ArrayPool<byte>.Shared.Rent(4);
+            try
             {
                 m_randomProvider.GetBytes(uint32Buffer);
-                randomUint = BitConverter.ToUInt32(uint32Buffer, 0);
-            }
+                var randomUint = BitConverter.ToUInt32(uint32Buffer, 0);
 
-            return randomUint;
+                if (noZero && randomUint == 0)
+                {
+                    m_randomProvider.GetBytes(uint32Buffer);
+                    randomUint = BitConverter.ToUInt32(uint32Buffer, 0);
+                }
+
+                return randomUint;
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(uint32Buffer);
+            }
         }
 
         public static UInt64 GetRandomULong()
         {
-            byte[] uint64Buffer = new byte[8];
-            m_randomProvider.GetBytes(uint64Buffer);
-            return BitConverter.ToUInt64(uint64Buffer, 0);
+            byte[] uint64Buffer = ArrayPool<byte>.Shared.Rent(8);
+            try
+            {
+                m_randomProvider.GetBytes(uint64Buffer);
+                return BitConverter.ToUInt64(uint64Buffer, 0);
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(uint64Buffer);
+            }
         }
 
         public static byte[] createRandomSalt(int length)


### PR DESCRIPTION
Reduce Memory allocations on H264 Sender HotPath by reusing byte[] and using ArrayPool<byte>