### PR TITLE
fix stream retrieval bug

### DIFF
--- a/src/net/RTP/RTPSession.cs
+++ b/src/net/RTP/RTPSession.cs
@@ -1,4 +1,4 @@
-//-----------------------------------------------------------------------------
+﻿//-----------------------------------------------------------------------------
 // Filename: RTPSession.cs
 //
 // Description: Represents an RTP session constituted of a single media stream. The session
@@ -2318,13 +2318,12 @@ namespace SIPSorcery.Net
                     return AudioStream;
                 }
             }
-            else
+            
+            if (HasVideo)
             {
-                if (HasVideo)
-                {
-                    return VideoStream;
-                }
+                return VideoStream;
             }
+            
 
             return null;
         }


### PR DESCRIPTION
After setting up logging i noticed a repeating error finding a media stream - not sure why the id is not matching but this logic looked a bit dodgy and the change resolved it with no side effects i could find.

