### PR TITLE
Fixed selecting the common format when no telephone event.

### DIFF
--- a/src/SIPSorcery.csproj
+++ b/src/SIPSorcery.csproj
@@ -27,6 +27,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.1;net462;net5.0;net6.0;net8.0</TargetFrameworks>
+    <LangVersion>10.0</LangVersion>
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
     <NoWarn>$(NoWarn);SYSLIB0050</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/app/Media/VoIPMediaSession.cs
+++ b/src/app/Media/VoIPMediaSession.cs
@@ -178,7 +178,8 @@ namespace SIPSorcery.Media
         {
             // IMPTORTANT NOTE: The audio sink format cannot be set here as it is not known until the first RTP packet
             // is received from the remote party. All we know at this stage is which audio formats are supported but NOT
-            // which one the remote party has chosen to use.
+            // which one the remote party has chosen to use. Generally it seems the sending and reciving formats should be the same but
+            // the standard is very fuzzy in that area. See https://datatracker.ietf.org/doc/html/rfc3264#section-7 and note the "SHOULD" in the text.
 
             var audioFormat = audoFormats.First();
             logger.LogDebug($"Setting audio source format to {audioFormat.FormatID}:{audioFormat.Codec} {audioFormat.ClockRate} (RTP clock rate {audioFormat.RtpClockRate}).");
@@ -190,7 +191,8 @@ namespace SIPSorcery.Media
         {
             // IMPTORTANT NOTE: The video sink format cannot be set here as it is not known until the first RTP packet
             // is received from the remote party. All we know at this stage is which audio formats are supported but NOT
-            // which one the remote party has chosen to use.
+            // which one the remote party has chosen to use. Generally it seems the sending and reciving formats should be the same but
+            // the standard is very fuzzy in that area. See https://datatracker.ietf.org/doc/html/rfc3264#section-7 and note the "SHOULD" in the text.
 
             var videoFormat = videoFormats.First();
             logger.LogDebug($"Setting video sink and source format to {videoFormat.FormatID}:{videoFormat.Codec}.");

--- a/src/net/SDP/SDPAudioVideoMediaFormat.cs
+++ b/src/net/SDP/SDPAudioVideoMediaFormat.cs
@@ -467,8 +467,8 @@ namespace SIPSorcery.Net
             else
             {
                 // Check if RTP events are supported and if required adjust the local format ID.
-                var aEventFormat = a.FirstOrDefault(x => x.Name()?.ToLower() == SDP.TELEPHONE_EVENT_ATTRIBUTE);
-                var bEventFormat = b.FirstOrDefault(x => x.Name()?.ToLower() == SDP.TELEPHONE_EVENT_ATTRIBUTE);
+                var aEventFormat = GetFormatForName(a, SDP.TELEPHONE_EVENT_ATTRIBUTE);
+                var bEventFormat = GetFormatForName(b, SDP.TELEPHONE_EVENT_ATTRIBUTE);
 
                 if (!aEventFormat.IsEmpty() && !bEventFormat.IsEmpty())
                 {
@@ -479,6 +479,26 @@ namespace SIPSorcery.Net
                 {
                     return Empty;
                 }
+            }
+        }
+
+        /// <summary>
+        /// Attempts to get a matching entry in a list of media formats for a specific format name.
+        /// </summary>
+        /// <param name="formats">The list of formats to search.</param>
+        /// <param name="formatName">The format name to search for.</param>
+        /// <returns>If found the matching format or the empty format if not.</returns>
+        public static SDPAudioVideoMediaFormat GetFormatForName(List<SDPAudioVideoMediaFormat> formats, string formatName)
+        {
+            if (formats == null || formats.Count == 0)
+            {
+                return Empty;
+            }
+            else
+            {
+                return formats.Any(x => x.Name()?.ToLower() == formatName?.ToLower()) ?
+                   formats.First(x => x.Name()?.ToLower() == formatName?.ToLower()) :
+                   Empty;
             }
         }
     }


### PR DESCRIPTION
A bug had been introduced when the default format, which was created when no match was found, was a normal looking format with an ID of 0. This was a big problem as 0 is PCMU. Added a dedicated method for looking up a format by name so that if no match an explicit empty format can be returned and avoid impersonating PCMU.