### PR TITLE
Use object.ReferenceEquals for reference type equality comparison

### DIFF
--- a/src/core/SIP/SIPEndPoint.cs
+++ b/src/core/SIP/SIPEndPoint.cs
@@ -244,7 +244,7 @@ namespace SIPSorcery.SIP
 
         public static bool operator ==(SIPEndPoint endPoint1, SIPEndPoint endPoint2)
         {
-            if ((object)endPoint1 == null && (object)endPoint2 == null)
+            if (object.ReferenceEquals(endPoint1, endPoint2))
             {
                 return true;
             }

--- a/src/core/SIP/SIPParameters.cs
+++ b/src/core/SIP/SIPParameters.cs
@@ -1,4 +1,4 @@
-//-----------------------------------------------------------------------------
+﻿//-----------------------------------------------------------------------------
 // Filename: SIPParameters.cs
 //
 // Description: SIP parameters as used in Contact, To, From and Via SIP headers.
@@ -16,6 +16,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Runtime.Serialization;
 using Microsoft.Extensions.Logging;
 using SIPSorcery.Sys;
@@ -337,7 +338,7 @@ namespace SIPSorcery.SIP
         /// </summary>
         public static bool operator ==(SIPParameters x, SIPParameters y)
         {
-            if (x is null && y is null)
+            if (object.ReferenceEquals(x, y))
             {
                 return true;
             }

--- a/src/core/SIP/SIPURI.cs
+++ b/src/core/SIP/SIPURI.cs
@@ -1,4 +1,4 @@
-//-----------------------------------------------------------------------------
+﻿//-----------------------------------------------------------------------------
 // Filename: SIPURI.cs
 //
 // Description: SIP URI.
@@ -605,7 +605,7 @@ namespace SIPSorcery.SIP
 
         public static bool operator ==(SIPURI uri1, SIPURI uri2)
         {
-            if (uri1 is null && uri2 is null)
+            if (object.ReferenceEquals(uri1, uri2))
             {
                 return true;
             }

--- a/src/net/STUN/STUNUri.cs
+++ b/src/net/STUN/STUNUri.cs
@@ -268,7 +268,7 @@ namespace SIPSorcery.Net
 
         public static bool operator ==(STUNUri uri1, STUNUri uri2)
         {
-            if (uri1 is null && uri2 is null)
+            if (object.ReferenceEquals(uri1, uri2))
             {
                 return true;
             }


### PR DESCRIPTION
Use [Object.ReferenceEquals(Object, Object) Method](https://learn.microsoft.com/dotnet/api/system.object.referenceequals) to compare for both parameters being `null` references or referencing the same instance:

This includes the existing comparison (`x is null && y is null`), and short-circuits if `x` and `y` are the same reference.