### PR TITLE
Allow customizable timeouts for RTP sessions

### DIFF
--- a/src/net/RTCP/RTCPSession.cs
+++ b/src/net/RTCP/RTCPSession.cs
@@ -59,8 +59,7 @@ namespace SIPSorcery.Net
         private const float RTCP_INTERVAL_LOW_RANDOMISATION_FACTOR = 0.5F;
         private const float RTCP_INTERVAL_HIGH_RANDOMISATION_FACTOR = 1.5F;
         private const int NO_ACTIVITY_TIMEOUT_FACTOR = 6;
-        private const int NO_ACTIVITY_TIMEOUT_MILLISECONDS = NO_ACTIVITY_TIMEOUT_FACTOR * RTCP_MINIMUM_REPORT_PERIOD_MILLISECONDS;
-
+        
         private static ILogger logger = Log.Logger;
 
         private static DateTime UtcEpoch2036 = new DateTime(2036, 2, 7, 6, 28, 16, DateTimeKind.Utc);
@@ -91,6 +90,14 @@ namespace SIPSorcery.Net
         /// </summary>
         public DateTime LastActivityAt { get; private set; } = DateTime.MinValue;
 
+        /// <summary>
+        /// Sets the timeout threshold for this session. If no RTP or RTCP packets are received
+        /// in this time period, a hangup is invoked.  It's checked every 5 seconds so the timeout
+        /// is best set to an integer multiple of that.
+        /// </summary>
+        public int NoActivityTimeoutMilliseconds { get; set; } = NO_ACTIVITY_TIMEOUT_FACTOR * RTCP_MINIMUM_REPORT_PERIOD_MILLISECONDS;
+
+        
         /// <summary>
         /// Indicates whether the session is currently in a timed out state. This
         /// occurs if no RTP or RTCP packets have been received during an expected
@@ -332,12 +339,12 @@ namespace SIPSorcery.Net
                 {
                     lock (m_rtcpReportTimer)
                     {
-                        if ((LastActivityAt != DateTime.MinValue && DateTime.Now.Subtract(LastActivityAt).TotalMilliseconds > NO_ACTIVITY_TIMEOUT_MILLISECONDS) ||
-                            (LastActivityAt == DateTime.MinValue && DateTime.Now.Subtract(CreatedAt).TotalMilliseconds > NO_ACTIVITY_TIMEOUT_MILLISECONDS))
+                        if ((LastActivityAt != DateTime.MinValue && DateTime.Now.Subtract(LastActivityAt).TotalMilliseconds > NoActivityTimeoutMilliseconds) ||
+                            (LastActivityAt == DateTime.MinValue && DateTime.Now.Subtract(CreatedAt).TotalMilliseconds > NoActivityTimeoutMilliseconds))
                         {
                             if (!IsTimedOut)
                             {
-                                logger.LogWarning($"RTCP session for local ssrc {Ssrc} has not had any activity for over {NO_ACTIVITY_TIMEOUT_MILLISECONDS / 1000} seconds.");
+                                logger.LogWarning($"RTCP session for local ssrc {Ssrc} has not had any activity for over {NoActivityTimeoutMilliseconds / 1000} seconds.");
                                 IsTimedOut = true;
 
                                 OnTimeout?.Invoke(MediaType);


### PR DESCRIPTION
Changed a constant to a publically mutable property so timeouts can be customized for RTP sessions.  This is useful in cases where the VOIP system doesn't send packets if there's silence in the audio stream.