### PR TITLE
Add missing "text" SDP media type

### DIFF
--- a/src/net/SDP/SDPTypes.cs
+++ b/src/net/SDP/SDPTypes.cs
@@ -30,7 +30,8 @@ namespace SIPSorcery.Net
         data = 4,
         control = 5,
         image = 6,
-        message = 7
+        message = 7,
+        text = 8
     }
 
     public class SDPMediaTypes


### PR DESCRIPTION
The `text` media type is valid per RFC 4566 and is present in the [media registry](https://www.iana.org/assignments/sdp-parameters/sdp-parameters.xhtml#sdp-parameters-1), however, if a message using `m=text` is encountered, an exception is thrown from `SDPMediaTypes.GetSDPMediaType` due to the unrecognized enum field being used.