### PR TITLE
Added code two new public Func AdjustCancel and AdjustBye to allow th…

### DIFF
--- a/src/app/SIPUserAgents/ISIPClientUserAgent.cs
+++ b/src/app/SIPUserAgents/ISIPClientUserAgent.cs
@@ -38,6 +38,6 @@ namespace SIPSorcery.SIP.App
         SIPRequest Call(SIPCallDescriptor sipCallDescriptor);
         SIPRequest Call(SIPCallDescriptor sipCallDescriptor, SIPEndPoint serverEndPoint);
         void AckAnswer(SIPResponse sipResponse, string content, string contentType);
-        void Cancel();
+        void Cancel(string? reason = null);
     }
 }

--- a/src/app/SIPUserAgents/SIPB2BUserAgent.cs
+++ b/src/app/SIPUserAgents/SIPB2BUserAgent.cs
@@ -83,7 +83,7 @@ namespace SIPSorcery.SIP.App
         public void Cancel(string? reason = null)
         {
             logger.LogDebug("SIPB2BUserAgent Cancel.");
-            m_uac.Cancel();
+            m_uac.Cancel(reason);
 
             var busyResp = SIPResponse.GetResponse(m_uasTransaction.TransactionRequest, SIPResponseStatusCodesEnum.BusyHere, null);
             m_uasTransaction.SendFinalResponse(busyResp);

--- a/src/app/SIPUserAgents/SIPB2BUserAgent.cs
+++ b/src/app/SIPUserAgents/SIPB2BUserAgent.cs
@@ -80,7 +80,7 @@ namespace SIPSorcery.SIP.App
             m_uac.AckAnswer(sipResponse, content, contentType);
         }
 
-        public void Cancel()
+        public void Cancel(string? reason = null)
         {
             logger.LogDebug("SIPB2BUserAgent Cancel.");
             m_uac.Cancel();

--- a/src/app/SIPUserAgents/SIPClientUserAgent.cs
+++ b/src/app/SIPUserAgents/SIPClientUserAgent.cs
@@ -52,6 +52,10 @@ namespace SIPSorcery.SIP.App
 
         public Func<SIPRequest, SIPRequest> AdjustInvite;
 
+        public Func<SIPRequest, SIPRequest> AdjustBye;
+
+        public Func<SIPRequest, SIPRequest> AdjustCancel;
+
         public UACInviteTransaction ServerTransaction
         {
             get { return m_serverTransaction; }
@@ -614,6 +618,11 @@ namespace SIPSorcery.SIP.App
             cancelHeader.ProxySendFrom = inviteHeader.ProxySendFrom;
             cancelHeader.Vias = inviteHeader.Vias;
 
+            if (AdjustCancel != null)
+            {
+                cancelRequest = AdjustCancel(cancelRequest);
+            }
+
             return cancelRequest;
         }
 
@@ -632,6 +641,11 @@ namespace SIPSorcery.SIP.App
             byeRequest.Header = byeHeader;
             byeRequest.Header.Routes = (inviteResponse.Header.RecordRoutes != null) ? inviteResponse.Header.RecordRoutes.Reversed() : null;
             byeRequest.Header.Vias.PushViaHeader(SIPViaHeader.GetDefaultSIPViaHeader());
+
+            if (AdjustBye != null)
+            {
+                byeRequest = AdjustBye(byeRequest);
+            }
 
             return byeRequest;
         }

--- a/src/app/SIPUserAgents/SIPClientUserAgent.cs
+++ b/src/app/SIPUserAgents/SIPClientUserAgent.cs
@@ -300,7 +300,7 @@ namespace SIPSorcery.SIP.App
                         if (!string.IsNullOrEmpty(reason))
                         {
                             // The REASON header gets pre-appended automatically in the SIPHeader class as "Reason: " when ToString() is called on the SIP Header class.
-                            cancelRequest.Header.Reason = $"SIP;cause=487;text=\"{reason}\"";
+                            cancelRequest.Header.Reason = reason;
                         }
                     }
 
@@ -336,7 +336,7 @@ namespace SIPSorcery.SIP.App
                 if (!string.IsNullOrEmpty(reason))
                 {
                     // The REASON header gets pre-appended automatically in the SIPHeader class as "Reason: " when ToString() is called on the SIP Header class.
-                    byeRequest.Header.Reason = $"Q.850;cause=16;text=\"{reason}\"";
+                    byeRequest.Header.Reason = reason;
                 }
 
                 m_byeTransaction = new SIPNonInviteTransaction(m_sipTransport, byeRequest, m_outboundProxy);


### PR DESCRIPTION
I need access to modify the SIP BYE and CANCEL headers before it is sent. I have added Funcs to allow modifying the request outside of this class.

I could change the name AdjustInvite to AdjustSIPRequest which can then be reused for handling BYE and CANCEL request, however the user would need to perform a SIPRequest.Method check to determine which sip request BYE, CANCEL, or INVITE is being adjusted. I did not want to affect current library users so I made 2 new funcs instead.

I NEED THIS CHANGE in SIPSORCERY v6.2.4, what needs to happen so I can get this change in v6.2.4?