### PR TITLE
Use "N" formatting option in Guid.ToString() instead of replacing characters

### DIFF
--- a/src/core/CallProperties.cs
+++ b/src/core/CallProperties.cs
@@ -14,7 +14,6 @@
 //-----------------------------------------------------------------------------
 
 using System;
-using System.Text.RegularExpressions;
 using SIPSorcery.Sys;
 
 namespace SIPSorcery.SIP
@@ -23,11 +22,7 @@ namespace SIPSorcery.SIP
     {
         public static string CreateNewCallId()
         {
-            Guid callIdGuid = Guid.NewGuid();
-
-            string callIdStr = Regex.Replace(callIdGuid.ToString(), "-", "");
-
-            return callIdStr;
+            return Guid.NewGuid().ToString("N");
         }
 
         public static string CreateNewTag()
@@ -59,7 +54,7 @@ namespace SIPSorcery.SIP
 
         public static string CreateBranchId()
         {
-            return SIPConstants.SIP_BRANCH_MAGICCOOKIE + Regex.Replace(Guid.NewGuid().ToString(), "-", "");
+            return SIPConstants.SIP_BRANCH_MAGICCOOKIE + Guid.NewGuid().ToString("N");
         }
     }
 }


### PR DESCRIPTION
There is already the format option "N" in the ToString() method of type Guid to perfom this kind of formatting. This makes the code lighter, and is more performant as it saves string allocations and manipulations.