### PR TITLE
To parse enums, use TryParse() instead of Parse() in a try block.

### DIFF
--- a/src/core/SIP/SIPConstants.cs
+++ b/src/core/SIP/SIPConstants.cs
@@ -159,17 +159,9 @@ namespace SIPSorcery.SIP
 
         public static bool IsAllowedScheme(string schemeType)
         {
-            try
-            {
-                Enum.Parse(typeof(SIPSchemesEnum), schemeType, true);
-                return true;
+            return Enum.TryParse<SIPSchemesEnum>(schemeType, true, out _);
             }
-            catch
-            {
-                return false;
             }
-        }
-    }
 
     /// <summary>
     /// A list of the transport layer protocols that are supported (the network layers
@@ -213,16 +205,8 @@ namespace SIPSorcery.SIP
 
         public static bool IsAllowedProtocol(string protocol)
         {
-            try
-            {
-                Enum.Parse(typeof(SIPProtocolsEnum), protocol, true);
-                return true;
+            return Enum.TryParse<SIPProtocolsEnum>(protocol, true, out _);
             }
-            catch
-            {
-                return false;
-            }
-        }
 
         /// <summary>
         /// Returns true for connectionless transport protocols, such as UDP, and false for
@@ -392,15 +376,12 @@ namespace SIPSorcery.SIP
     {
         public static SIPMethodsEnum GetMethod(string method)
         {
-            SIPMethodsEnum sipMethod = SIPMethodsEnum.UNKNOWN;
-
-            try
+            if (Enum.TryParse<SIPMethodsEnum>(method, true, out var sipMethod))
             {
-                sipMethod = (SIPMethodsEnum)Enum.Parse(typeof(SIPMethodsEnum), method, true);
+                return sipMethod;
             }
-            catch { }
 
-            return sipMethod;
+            return SIPMethodsEnum.UNKNOWN;
         }
     }
 

--- a/src/net/RTSP/RTSPContants.cs
+++ b/src/net/RTSP/RTSPContants.cs
@@ -61,15 +61,12 @@ namespace SIPSorcery.Net
     {
         public static RTSPMethodsEnum GetMethod(string method)
         {
-            RTSPMethodsEnum rtspMethod = RTSPMethodsEnum.UNKNOWN;
-
-            try
+            if (Enum.TryParse<RTSPMethodsEnum>(method, true, out var parsed))
             {
-                rtspMethod = (RTSPMethodsEnum)Enum.Parse(typeof(RTSPMethodsEnum), method, true);
+                return parsed;
             }
-            catch { }
 
-            return rtspMethod;
+            return RTSPMethodsEnum.UNKNOWN;
         }
     }
 

--- a/src/sys/StorageTypes.cs
+++ b/src/sys/StorageTypes.cs
@@ -48,7 +48,7 @@ namespace SIPSorcery.Sys
 
             logger.LogError("StorageTypesConverter {StorageType} unknown.", storageType);
 
-                return StorageTypes.Unknown;
-            }
+            return StorageTypes.Unknown;
         }
     }
+}

--- a/src/sys/StorageTypes.cs
+++ b/src/sys/StorageTypes.cs
@@ -41,15 +41,14 @@ namespace SIPSorcery.Sys
 
         public static StorageTypes GetStorageType(string storageType)
         {
-            try
+            if (Enum.TryParse<StorageTypes>(storageType, true, out var result))
             {
-                return (StorageTypes)Enum.Parse(typeof(StorageTypes), storageType, true);
+                return result;
             }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "StorageTypesConverter {StorageType} unknown.", storageType);
+
+            logger.LogError("StorageTypesConverter {StorageType} unknown.", storageType);
+
                 return StorageTypes.Unknown;
             }
         }
     }
-}


### PR DESCRIPTION
To parse enums, it is recommended to use TryParse(). This is more C# idiomatic, and it avoids declaring a try/catch block, which has a performance cost.