### PR TITLE
Fix a potential IndexOutOfRangeException in BufferUtils.GetStringPosition()

### DIFF
--- a/src/sys/BufferUtils.cs
+++ b/src/sys/BufferUtils.cs
@@ -13,6 +13,7 @@
 // BSD 3-Clause "New" or "Revised" License, see included LICENSE.md file.
 //-----------------------------------------------------------------------------
 
+using System;
 using System.Text;
 
 namespace SIPSorcery.Sys
@@ -30,50 +31,48 @@ namespace SIPSorcery.Sys
         /// <returns>The start position in the buffer of the requested string or -1 if not found.</returns>
         public static int GetStringPosition(byte[] buffer, int startPosition, int endPosition, string find, string end)
         {
-            if (buffer == null || buffer.Length == 0 || find == null)
+            if (buffer == null || buffer.Length == 0 || find == null || find.Length == 0)
             {
                 return -1;
             }
-            else
+
+            byte[] findArray = Encoding.UTF8.GetBytes(find);
+            byte[] endArray = (end != null) ? Encoding.UTF8.GetBytes(end) : null;
+
+            int findPosn = 0;
+            int endPosn = 0;
+
+            for (int index = startPosition; index < endPosition && index < buffer.Length; index++)
             {
-                byte[] findArray = Encoding.UTF8.GetBytes(find);
-                byte[] endArray = (end != null) ? Encoding.UTF8.GetBytes(end) : null;
-
-                int findPosn = 0;
-                int endPosn = 0;
-
-                for (int index = startPosition; index < endPosition && index < buffer.Length; index++)
+                if (buffer[index] == findArray[findPosn])
                 {
-                    if (buffer[index] == findArray[findPosn])
-                    {
-                        findPosn++;
-                    }
-                    else
-                    {
-                        findPosn = 0;
-                    }
-
-                    if (endArray != null && buffer[index] == endArray[endPosn])
-                    {
-                        endPosn++;
-                    }
-                    else
-                    {
-                        endPosn = 0;
-                    }
-
-                    if (findPosn == findArray.Length)
-                    {
-                        return index - findArray.Length + 1;
-                    }
-                    else if (endArray != null && endPosn == endArray.Length)
-                    {
-                        return -1;
-                    }
+                    findPosn++;
+                }
+                else
+                {
+                    findPosn = 0;
                 }
 
-                return -1;
+                if (endArray != null && buffer[index] == endArray[endPosn])
+                {
+                    endPosn++;
+                }
+                else
+                {
+                    endPosn = 0;
+                }
+
+                if (findPosn == findArray.Length)
+                {
+                    return index - findArray.Length + 1;
+                }
+                else if (endArray != null && endPosn == endArray.Length)
+                {
+                    return -1;
+                }
             }
+
+            return -1;
         }
 
         public static bool HasString(byte[] buffer, int startPosition, int endPosition, string find, string end)

--- a/test/unit/sys/BufferUtilsUnitTest.cs
+++ b/test/unit/sys/BufferUtilsUnitTest.cs
@@ -53,6 +53,32 @@ namespace SIPSorcery.Sys.UnitTests
         }
 
         [Fact]
+        public void GetStringPositionWithEmptyFindUnitTest()
+        {
+            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+
+            string sipMsg =
+                "REGISTER sip:Blue Face SIP/2.0\r\n" +
+                "Via: SIP/2.0/UDP 127.0.0.1:1720;branch=z9hG4bKlgnUQcaywCOaPcXR\r\n" +
+                "Max-Forwards: 70\r\n" +
+                "User-Agent: PA168S\r\n" +
+                "From: \"user\" <sip:user@Blue Face>;tag=81swjAV7dHG1yjd5\r\n" +
+                "To: \"user\" <sip:user@Blue Face>\r\n" +
+                "Call-ID: DHZVs1HFuMoTQ6LO@82.114.95.1\r\n" +
+                "CSeq: 15754 REGISTER\r\n" +
+                "Contact: <sip:user@127.0.0.1:1720>\r\n" +
+                "Expires: 30\r\n" +
+                "Content-Length: 0\r\n\r\n";
+
+            byte[] sample = Encoding.ASCII.GetBytes(sipMsg);
+
+            int index = BufferUtils.GetStringPosition(sample, 0, Int32.MaxValue, string.Empty, null);
+
+            Assert.Equal(-1, index);
+        }
+
+        [Fact]
         public void GetStringIndexUnitTest()
         {
             logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);


### PR DESCRIPTION
Fix a potential IndexOutOfRangeException in BufferUtils.GetStringPosition()
when parameter "find" is an empty string.

If we don't check for the length of parameter "find", then the first indexing of "findArray" raises an IndexOutOfRangeException.