### PR TITLE
Rename and reimplement the Unix time conversion function

### DIFF
--- a/src/sys/TypeExtensions.cs
+++ b/src/sys/TypeExtensions.cs
@@ -75,10 +75,7 @@ namespace SIPSorcery.Sys
 
         public static long GetEpoch(this DateTime dateTime)
         {
-            var unixTime = dateTime.ToUniversalTime() -
-                new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
-
-            return Convert.ToInt64(unixTime.TotalSeconds);
+            return new DateTimeOffset(dateTime.ToUniversalTime()).ToUnixTimeSeconds();
         }
 
         /// <summary>

--- a/src/sys/TypeExtensions.cs
+++ b/src/sys/TypeExtensions.cs
@@ -73,7 +73,7 @@ namespace SIPSorcery.Sys
             return true;
         }
 
-        public static long GetEpoch(this DateTime dateTime)
+        public static long ToUnixTime(this DateTime dateTime)
         {
             return new DateTimeOffset(dateTime.ToUniversalTime()).ToUnixTimeSeconds();
         }

--- a/test/unit/sys/TypeExtensionsUnitTest.cs
+++ b/test/unit/sys/TypeExtensionsUnitTest.cs
@@ -69,6 +69,20 @@ namespace SIPSorcery.Sys.UnitTests
         }
 
         [Fact]
+        public void GetEpochTest()
+        {
+            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+
+            var dateTime = new DateTime(2025, 2, 12, 23, 39, 0);
+            var unixTime = dateTime.GetEpoch();
+
+            logger.LogDebug("Unix time: {unixTime}.", unixTime);
+
+            Assert.Equal(1739399940L, unixTime);
+        }
+
+        [Fact]
         public void ParseHexStrTest()
         {
             logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);

--- a/test/unit/sys/TypeExtensionsUnitTest.cs
+++ b/test/unit/sys/TypeExtensionsUnitTest.cs
@@ -69,17 +69,31 @@ namespace SIPSorcery.Sys.UnitTests
         }
 
         [Fact]
-        public void GetEpochTest()
+        public void ToUnixTimeTest()
         {
             logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
             logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
 
             var dateTime = new DateTime(2025, 2, 12, 23, 39, 0);
-            var unixTime = dateTime.GetEpoch();
+            var unixTime = dateTime.ToUnixTime();
 
             logger.LogDebug("Unix time: {unixTime}.", unixTime);
 
             Assert.Equal(1739399940L, unixTime);
+        }
+
+        [Fact]
+        public void ToUnixTimeAfter2038Test()
+        {
+            logger.LogDebug("--> {MethodName}", System.Reflection.MethodBase.GetCurrentMethod().Name);
+            logger.BeginScope(System.Reflection.MethodBase.GetCurrentMethod().Name);
+
+            var dateTime = new DateTime(2060, 2, 13, 22, 54, 54);
+            var unixTime = dateTime.ToUnixTime();
+
+            logger.LogDebug("Unix time: {unixTime}.", unixTime);
+
+            Assert.Equal(2843934894L, unixTime);
         }
 
         [Fact]


### PR DESCRIPTION
* Use a more idiomatic approach to convert a DateTime to Unix time, and add a unit test.
* Rename the function GetEpoch() to ToUnixTime(), as is this function doesn't
return the epoch, but the number of seconds since the epoch.
* Also add a unit test to make sure this implementation is not subject to the year
2038 problem.