### PR TITLE
Check authentication scheme case-insensitively

### DIFF
--- a/src/core/SIP/SIPHeader.cs
+++ b/src/core/SIP/SIPHeader.cs
@@ -856,7 +856,7 @@ namespace SIPSorcery.SIP
                 {
                     Value = headerValue
                 };
-                if (headerValue.StartsWith(SIPAuthorisationDigest.METHOD))
+                if (headerValue.StartsWith(SIPAuthorisationDigest.METHOD, StringComparison.OrdinalIgnoreCase))
                 {
                     authHeader.SIPDigest = SIPAuthorisationDigest.ParseAuthorisationDigest(authorizationType, headerValue);
                 }


### PR DESCRIPTION
Resolves #1339.

The authentication scheme should be checked case-insensitively, as per the following sources (mostly related to HTTP, but the same should apply for SIP):

- [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/WWW-Authenticate)
- [Related Rails issue](https://github.com/rails/rails/issues/21199)
- [RFC 2617](https://datatracker.ietf.org/doc/html/rfc2617#section-1.2) ("It uses an extensible, **case-insensitive** token to identify the authentication scheme") (emphasis mine)