### PR TITLE
uac-use fromTag if provided while making call

### DIFF
--- a/src/app/SIPUserAgents/SIPCallDescriptor.cs
+++ b/src/app/SIPUserAgents/SIPCallDescriptor.cs
@@ -240,6 +240,10 @@ namespace SIPSorcery.SIP.App
             MangleIPAddress = mangleIPAddress;
         }
 
+        public SIPCallDescriptor()
+        {
+        }
+
         public SIPFromHeader GetFromHeader()
         {
             SIPFromHeader fromHeader = SIPFromHeader.ParseFromHeader(From);

--- a/src/app/SIPUserAgents/SIPClientUserAgent.cs
+++ b/src/app/SIPUserAgents/SIPClientUserAgent.cs
@@ -553,7 +553,10 @@ namespace SIPSorcery.SIP.App
 
             SIPHeader inviteHeader = new SIPHeader(sipCallDescriptor.GetFromHeader(), SIPToHeader.ParseToHeader(sipCallDescriptor.To), 1, callId);
 
-            inviteHeader.From.FromTag = CallProperties.CreateNewTag();
+            if (inviteHeader.From.FromTag.IsNullOrBlank())
+            {
+                inviteHeader.From.FromTag = CallProperties.CreateNewTag();
+            }
 
             inviteHeader.Contact = new List<SIPContactHeader>() { SIPContactHeader.GetDefaultSIPContactHeader(inviteRequest.URI.Scheme) };
             inviteHeader.Contact[0].ContactURI.User = sipCallDescriptor.Username;


### PR DESCRIPTION
UseCase:  
In a scenerio while we need to make a Re-Invite we need to send the same from/to Tag of the original call

Previous behaviour:  
Even if we have provided a `FromTag` during `SIPClientUserAgent.Call(`, the fromTag is replaced with a new one.

This pull Request enhancement:   
We keep the `FromTag` of the From SIPHeader provided to `SIPClientUserAgent.Call(`