### PR TITLE
Increase WAIT_DIALOG_TIMEOUT for ACK to T6

### DIFF
--- a/src/app/SIPUserAgents/SIPUserAgent.cs
+++ b/src/app/SIPUserAgents/SIPUserAgent.cs
@@ -49,7 +49,7 @@ namespace SIPSorcery.SIP.App
         private static readonly string m_sdpContentType = SDP.SDP_MIME_CONTENTTYPE;
         private static readonly string m_sipReferContentType = SIPMIMETypes.REFER_CONTENT_TYPE;
         private static int WAIT_ONHOLD_TIMEOUT = SIPTimings.T1;
-        private static int WAIT_DIALOG_TIMEOUT = SIPTimings.T2;
+        private static int WAIT_DIALOG_TIMEOUT = SIPTimings.T6;
         private readonly SemaphoreSlim m_semaphoreSlim = new SemaphoreSlim(1, 1);
 
         private static ILogger logger = Log.Logger;


### PR DESCRIPTION
There is an issue in the timeout for ACK responses, resulting in the error:
> The attempt to answer a call failed as the dialog was not created. The likely cause is the ACK not being received in time.

The timeout is set to be T2 (5 seconds), but according to the [RFC](https://www.ietf.org/rfc/rfc3261.txt), it should be higher:

>    layer for transmission.  The ACK MUST be sent to the same address,
>   port, and transport to which the original request was sent.  The
>   client transaction SHOULD start timer D when it enters the
>   "Completed" state, with a value of at least 32 seconds for unreliable

This pull request increases the timeout to T6, i.e. 32 seconds.