### PR TITLE
Fix HEVC NAL parsing and RTP de/packetization

### DIFF
--- a/src/net/RTP/Packetisation/H265Depacketiser.cs
+++ b/src/net/RTP/Packetisation/H265Depacketiser.cs
@@ -189,18 +189,17 @@ namespace SIPSorcery.Net
                     byte fuHeader = payload[2];
                     int fu_startOfNal = (fuHeader >> 7) & 0x01;  // start marker
                     int fu_endOfNal = (fuHeader >> 6) & 0x01;  // end marker
-                    int fu_type = (fuHeader >> 1) & 0x3F; // FU Type
+                    int fu_type = fuHeader & 0x3F; // fragmented NAL Type
                     if (fu_startOfNal == 1)
                     {
                         byte nalHeader1 = payload[0];
                         byte nalHeader2 = payload[1];
-                        int nal_header_f_bit = (nalHeader1 >> 7) & 0x01;
-                        int nuhLayerId = ((nalHeader1 & 0x01) << 5) | ((nalHeader2 >> 3) & 0x1F);
-                        int nuhTemporalIdPlus1 = nalHeader2 & 0x07;
-                        var fu_nalHeader1 = (byte)((nal_header_f_bit << 7) + (fu_type << 2) + (nuhLayerId >> 7));
-                        var fu_nalHeader2 = (byte)((nuhLayerId << 1) + (nuhTemporalIdPlus1));
-                        fuNal.WriteByte(fu_nalHeader1);
-                        fuNal.WriteByte(fu_nalHeader2);
+
+                        nalHeader1 &= 0x81; // clear the NAL type bits
+                        nalHeader1 |= (byte)((fu_type & 0x3F) << 1); // set the inner NAL type bits
+
+                        fuNal.WriteByte(nalHeader1);
+                        fuNal.WriteByte(nalHeader2);
                     }
 
                     if (fuNal.Length == 0 && fu_startOfNal != 1)

--- a/src/net/RTP/VideoStream.cs
+++ b/src/net/RTP/VideoStream.cs
@@ -152,6 +152,9 @@ namespace SIPSorcery.Net
 
             if (nal.Length <= RTPSession.RTP_MAX_PAYLOAD)
             {
+                //var naltype = naluHeader[0] >> 1 & 0x3F;
+                //logger.LogTrace("Sending NALtype {type}", naltype);
+
                 // Send as Single-Time Aggregation Packet (STAP-A).
                 byte[] payload = new byte[nal.Length];
                 int markerBit = isLastNal ? 1 : 0;   // There is only ever one packet in a STAP-A.
@@ -167,6 +170,7 @@ namespace SIPSorcery.Net
             else
             {
                 nal = nal.Skip(naluHeaderSize).ToArray();
+                //logger.LogTrace("Fragmenting");
 
                 // Send as Fragmentation Unit A (FU-A):
                 for (int index = 0; index * RTPSession.RTP_MAX_PAYLOAD < nal.Length; index++)
@@ -203,9 +207,19 @@ namespace SIPSorcery.Net
             if(CheckIfCanSendRtpRaw())
             {
                 var nals = H265Packetiser.ParseNals(sample);
-                var aggregatedNals = H265Packetiser.CreateAggregated(nals, RTPSession.RTP_MAX_PAYLOAD);
-                foreach (var nal in aggregatedNals)
+
+                // aggregation is only on 2 or more small nals
+                if (nals.Where(x => x.NAL.Length < RTPSession.RTP_MAX_PAYLOAD).Count() > 1)
                 {
+                    //logger.LogTrace("(ou) Trying aggregating {nals} nals", nals.Count());
+                    nals = H265Packetiser.CreateAggregated(nals, RTPSession.RTP_MAX_PAYLOAD);
+                }
+
+                //var i = 1;
+                foreach (var nal in nals)
+                {
+                    _pktCounter++;
+                    //logger.LogTrace("(out) SEND {bits}({of}/{all})", nal.NAL.Length, i++, nals.Count());
                     SendH26XNal(durationRtpUnits, payloadID, nal.NAL, nal.IsLast, true);
                 }
             }

--- a/src/net/RTP/VideoStream.cs
+++ b/src/net/RTP/VideoStream.cs
@@ -218,7 +218,6 @@ namespace SIPSorcery.Net
                 //var i = 1;
                 foreach (var nal in nals)
                 {
-                    _pktCounter++;
                     //logger.LogTrace("(out) SEND {bits}({of}/{all})", nal.NAL.Length, i++, nals.Count());
                     SendH26XNal(durationRtpUnits, payloadID, nal.NAL, nal.IsLast, true);
                 }


### PR DESCRIPTION
I read a bit [RFC 7798 Section 4.4](https://datatracker.ietf.org/doc/html/rfc7798#section-4.4)

Summary:
- The NAL parser forgot to set `zeroes` back to 0,
- The aggregator forgot to return aggregated NALs,
- Use a semantically readable fragmentation NAL (FU) handling

fixes #1392 
forwards https://github.com/sipsorcery-org/SIPSorceryMedia.FFmpeg/pull/97