### PR TITLE
Update TakeOffHold() to Task

### DIFF
--- a/src/app/Media/VoIPMediaSession.cs
+++ b/src/app/Media/VoIPMediaSession.cs
@@ -376,7 +376,7 @@ namespace SIPSorcery.Media
             }
         }
 
-        public async void TakeOffHold()
+        public async Task TakeOffHold()
         {
             if (HasAudio)
             {


### PR DESCRIPTION
I just experienced this scenario today so I replaced `async void` with `async Task` in `TakeOffHold()` to prevent silent failures and ensure exceptions can be awaited and handled correctly.

