### PR TITLE
Fix the audio encoder to cope with two channel OPUS samples.

### DIFF
--- a/examples/OpenAIExamples/WebRTCOpenAI/Program.cs
+++ b/examples/OpenAIExamples/WebRTCOpenAI/Program.cs
@@ -98,11 +98,13 @@ class Program
             return;
         }
 
+        var openAIKey = args[0];
+
         var flow = await Prelude.Right<Error, Unit>(default)
             .BindAsync(_ =>
             {
                 logger.LogInformation("STEP 1: Get ephemeral key from OpenAI.");
-                return OpenAIRealtimeRestClient.CreateEphemeralKeyAsync(OPENAI_REALTIME_SESSIONS_URL, args[0], OPENAI_MODEL, OPENAI_VOICE);
+                return OpenAIRealtimeRestClient.CreateEphemeralKeyAsync(OPENAI_REALTIME_SESSIONS_URL, openAIKey, OPENAI_MODEL, OPENAI_VOICE);
             })
             .BindAsync(async ephemeralKey =>
             {

--- a/src/app/Media/Codecs/AudioEncoder.cs
+++ b/src/app/Media/Codecs/AudioEncoder.cs
@@ -27,7 +27,7 @@ namespace SIPSorcery.Media
         private const int G722_BIT_RATE = 64000;              // G722 sampling rate is 16KHz with bits per sample of 16.
         private const int OPUS_SAMPLE_RATE = 48000;           // Opus codec sampling rate, 48KHz.
         private const int OPUS_CHANNELS = 2;                  // Opus codec number of channels.
-        private const int OPUS_MAXIMUM_DECODE_BUFFER_LENGTH = 5760;
+        private const int OPUS_MAXIMUM_FRAME_SIZE = 5760;
 
         private G722Codec _g722Codec;
         private G722CodecState _g722CodecState;
@@ -214,18 +214,43 @@ namespace SIPSorcery.Media
                     _opusDecoder = OpusCodecFactory.CreateDecoder(format.ClockRate, format.ChannelCount);
                 }
 
-                float[] decodedPcmFloat = new float[OPUS_MAXIMUM_DECODE_BUFFER_LENGTH];
-                int decodedLength = _opusDecoder.Decode(encodedSample, decodedPcmFloat, decodedPcmFloat.Length, false);
+                //float[] decodedPcmFloat = new float[OPUS_MAXIMUM_DECODE_BUFFER_LENGTH];
+                //int decodedLength = _opusDecoder.Decode(encodedSample, decodedPcmFloat, decodedPcmFloat.Length, false);
 
-                // Convert float PCM to short PCM
-                short[] decodedPcm = new short[decodedLength];
-                for (int i = 0; i < decodedLength; i++)
+                //// Convert float PCM to short PCM
+                //short[] decodedPcm = new short[decodedLength];
+                //for (int i = 0; i < decodedLength; i++)
+                //{
+                //    // Clamp the value to the valid range of -32768 to 32767
+                //    decodedPcm[i] = ClampToShort(decodedPcmFloat[i] * 32767);
+                //}
+
+                //return decodedPcm;
+
+                // worst-case max frame size (in samples per channel) * channels
+                int maxSamples = OPUS_MAXIMUM_FRAME_SIZE * format.ChannelCount;
+                float[] floatBuf = new float[maxSamples];
+
+                // decode returns the number of samples *per channel*
+                int samplesPerChannel = _opusDecoder.Decode(
+                    encodedSample,
+                    floatBuf,
+                    floatBuf.Length,
+                    false);
+
+                // total decoded floats = samplesPerChannel * channels
+                int totalFloats = samplesPerChannel * format.ChannelCount;
+
+                // convert to 16-bit interleaved PCM
+                short[] pcm16 = new short[totalFloats];
+                for (int i = 0; i < totalFloats; i++)
                 {
-                    // Clamp the value to the valid range of -32768 to 32767
-                    decodedPcm[i] = ClampToShort(decodedPcmFloat[i] * 32767);
+                    // clamp to [-1,1]
+                    var f = ClampToFloat(floatBuf[i], -1.0f, 1.0f);
+                    pcm16[i] = (short)(f * 32767);
                 }
 
-                return decodedPcm;
+                return pcm16;
             }
             else
             {
@@ -250,6 +275,13 @@ namespace SIPSorcery.Media
                 return short.MinValue;
             }
             return (short)value;
+        }
+
+        private float ClampToFloat(float value, float min, float max)
+        {
+            if (value < min) { return min; }
+            if (value > max) { return max; }
+            return value;
         }
     }
 }

--- a/src/app/Media/Codecs/AudioEncoder.cs
+++ b/src/app/Media/Codecs/AudioEncoder.cs
@@ -214,38 +214,22 @@ namespace SIPSorcery.Media
                     _opusDecoder = OpusCodecFactory.CreateDecoder(format.ClockRate, format.ChannelCount);
                 }
 
-                //float[] decodedPcmFloat = new float[OPUS_MAXIMUM_DECODE_BUFFER_LENGTH];
-                //int decodedLength = _opusDecoder.Decode(encodedSample, decodedPcmFloat, decodedPcmFloat.Length, false);
-
-                //// Convert float PCM to short PCM
-                //short[] decodedPcm = new short[decodedLength];
-                //for (int i = 0; i < decodedLength; i++)
-                //{
-                //    // Clamp the value to the valid range of -32768 to 32767
-                //    decodedPcm[i] = ClampToShort(decodedPcmFloat[i] * 32767);
-                //}
-
-                //return decodedPcm;
-
-                // worst-case max frame size (in samples per channel) * channels
                 int maxSamples = OPUS_MAXIMUM_FRAME_SIZE * format.ChannelCount;
                 float[] floatBuf = new float[maxSamples];
 
-                // decode returns the number of samples *per channel*
+                // Decode returns the number of samples per channel.
                 int samplesPerChannel = _opusDecoder.Decode(
                     encodedSample,
                     floatBuf,
                     floatBuf.Length,
                     false);
 
-                // total decoded floats = samplesPerChannel * channels
                 int totalFloats = samplesPerChannel * format.ChannelCount;
 
-                // convert to 16-bit interleaved PCM
+                // Convert to 16-bit interleaved PCM.
                 short[] pcm16 = new short[totalFloats];
                 for (int i = 0; i < totalFloats; i++)
                 {
-                    // clamp to [-1,1]
                     var f = ClampToFloat(floatBuf[i], -1.0f, 1.0f);
                     pcm16[i] = (short)(f * 32767);
                 }


### PR DESCRIPTION
Partially resolves #1399 (update to SIPSorceryMedia.Windows also required).