### PR TITLE
Enhance performance and memory efficiency

### DIFF
--- a/src/SIPSorcery.csproj
+++ b/src/SIPSorcery.csproj
@@ -29,6 +29,11 @@
     <!-- The packages below are transitive references included to overcome vulnerabilities in a top level package. -->
     <PackageReference Include="System.Net.Security" Version="4.3.2" /> <!-- Vuln version referenced by ystem.Net.WebSockets.Client. -->
   </ItemGroup>
+  
+  <ItemGroup Condition="'$(TargetFramework)' == 'net462' OR '$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Memory" Version="4.6.3" />
+    <PackageReference Include="Microsoft.Bcl.HashCode" Version="6.0.0" />
+  </ItemGroup>
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.1;net462;net5.0;net6.0;net8.0</TargetFrameworks>
@@ -87,6 +92,7 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <ContinuousIntegrationBuild Condition="'$(CI)' == 'true'">true</ContinuousIntegrationBuild>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
 </Project>

--- a/src/net/RTCP/RTCPBye.cs
+++ b/src/net/RTCP/RTCPBye.cs
@@ -1,4 +1,4 @@
-//-----------------------------------------------------------------------------
+﻿//-----------------------------------------------------------------------------
 // Filename: RTCPBye.cs
 //
 // Description: RTCP Goodbye packet as defined in RFC3550.
@@ -27,6 +27,9 @@
 //-----------------------------------------------------------------------------
 
 using System;
+using System.Buffers.Binary;
+using System.ComponentModel;
+using System.Diagnostics;
 using System.Text;
 using SIPSorcery.Sys;
 
@@ -73,7 +76,17 @@ namespace SIPSorcery.Net
         /// Create a new RTCP Goodbye packet from a serialised byte array.
         /// </summary>
         /// <param name="packet">The byte array holding the Goodbye packet.</param>
-        public RTCPBye(byte[] packet)
+        [Obsolete("Use RTCPBye(ReadOnlySpan<byte> packet) instead.", false)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public RTCPBye(byte[] packet) : this(new ReadOnlySpan<byte>(packet))
+        {
+        }
+
+        /// <summary>
+        /// Create a new RTCP Goodbye packet from a serialised byte array.
+        /// </summary>
+        /// <param name="packet">The byte array holding the Goodbye packet.</param>
+        public RTCPBye(ReadOnlySpan<byte> packet)
         {
             if (packet.Length < MIN_PACKET_SIZE)
             {
@@ -82,14 +95,7 @@ namespace SIPSorcery.Net
 
             Header = new RTCPHeader(packet);
 
-            if (BitConverter.IsLittleEndian)
-            {
-                SSRC = NetConvert.DoReverseEndian(BitConverter.ToUInt32(packet, 4));
-            }
-            else
-            {
-                SSRC = BitConverter.ToUInt32(packet, 4);
-            }
+            SSRC = BinaryPrimitives.ReadUInt32BigEndian(packet.Slice(4));
 
             if (packet.Length > MIN_PACKET_SIZE)
             {
@@ -97,10 +103,12 @@ namespace SIPSorcery.Net
 
                 if (packet.Length - MIN_PACKET_SIZE - 1 >= reasonLength)
                 {
-                    Reason = Encoding.UTF8.GetString(packet, 9, reasonLength);
+                    Reason = Encoding.UTF8.GetString(packet.Slice(9, reasonLength));
                 }
             }
         }
+
+        public int GetPacketSize() => RTCPHeader.HEADER_BYTES_LENGTH + GetPaddedLength(((Reason is not null) ? Encoding.UTF8.GetByteCount(Reason) : 0));
 
         /// <summary>
         /// Gets the raw bytes for the Goodbye packet.
@@ -108,30 +116,39 @@ namespace SIPSorcery.Net
         /// <returns>A byte array.</returns>
         public byte[] GetBytes()
         {
-            byte[] reasonBytes = (Reason != null) ? Encoding.UTF8.GetBytes(Reason) : null;
-            int reasonLength = (reasonBytes != null) ? reasonBytes.Length : 0;
-            byte[] buffer = new byte[RTCPHeader.HEADER_BYTES_LENGTH + GetPaddedLength(reasonLength)];
-            Header.SetLength((ushort)(buffer.Length / 4 - 1));
+            var buffer = new byte[GetPacketSize()];
 
-            Buffer.BlockCopy(Header.GetBytes(), 0, buffer, 0, RTCPHeader.HEADER_BYTES_LENGTH);
-            int payloadIndex = RTCPHeader.HEADER_BYTES_LENGTH;
-
-            if (BitConverter.IsLittleEndian)
-            {
-                Buffer.BlockCopy(BitConverter.GetBytes(NetConvert.DoReverseEndian(SSRC)), 0, buffer, payloadIndex, 4);
-            }
-            else
-            {
-                Buffer.BlockCopy(BitConverter.GetBytes(SSRC), 0, buffer, payloadIndex, 4);
-            }
-
-            if (reasonLength > 0)
-            {
-                buffer[payloadIndex + 4] = (byte)reasonLength;
-                Buffer.BlockCopy(reasonBytes, 0, buffer, payloadIndex + 5, reasonBytes.Length);
-            }
+            WriteBytesCore(buffer);
 
             return buffer;
+        }
+
+        public int WriteBytes(Span<byte> buffer)
+        {
+            var size = GetPacketSize();
+
+            if (buffer.Length < size)
+            {
+                throw new ArgumentOutOfRangeException($"The buffer should have at least {size} bytes and had only {buffer.Length}.");
+            }
+
+            WriteBytesCore(buffer.Slice(0, size));
+
+            return size;
+        }
+
+        private void WriteBytesCore(Span<byte> buffer)
+        {
+            Header.SetLength((ushort)(buffer.Length / 4 - 1));
+            _ = Header.WriteBytes(buffer);
+
+            BinaryPrimitives.WriteUInt32BigEndian(buffer.Slice(RTCPHeader.HEADER_BYTES_LENGTH), SSRC);
+
+            if (Reason is not null)
+            {
+                buffer[RTCPHeader.HEADER_BYTES_LENGTH + 4] =
+                    (byte)Encoding.UTF8.GetBytes(Reason.AsSpan(), buffer.Slice(RTCPHeader.HEADER_BYTES_LENGTH + 5));
+            }
         }
 
         /// <summary>

--- a/src/net/RTCP/RTCPCompoundPacket.cs
+++ b/src/net/RTCP/RTCPCompoundPacket.cs
@@ -62,9 +62,18 @@ namespace SIPSorcery.Net
         /// Creates a new RTCP compound packet from a serialised buffer.
         /// </summary>
         /// <param name="packet">The serialised RTCP compound packet to parse.</param>
-        public RTCPCompoundPacket(byte[] packet)
+        [Obsolete("Use RTCPCompoundPacket(ReadOnlySpan<byte> packet) instead.", false)]
+        public RTCPCompoundPacket(byte[] packet) : this(new ReadOnlySpan<byte>(packet))
         {
-            int offset = 0;
+        }
+
+        /// <summary>
+        /// Creates a new RTCP compound packet from a serialised buffer.
+        /// </summary>
+        /// <param name="packet">The serialised RTCP compound packet to parse.</param>
+        public RTCPCompoundPacket(ReadOnlySpan<byte> packet)
+        {
+            var offset = 0;
             while (offset < packet.Length)
             {
                 if (packet.Length - offset < RTCPHeader.HEADER_BYTES_LENGTH)
@@ -74,43 +83,44 @@ namespace SIPSorcery.Net
                 }
                 else
                 {
-                    var buffer = packet.Skip(offset).ToArray();
+                    var buffer = packet.Slice(offset);
 
                     // The payload type field is the second byte in the RTCP header.
-                    byte packetTypeID = buffer[1];
+                    var packetTypeID = buffer[1];
                     switch (packetTypeID)
                     {
                         case (byte)RTCPReportTypesEnum.SR:
                             SenderReport = new RTCPSenderReport(buffer);
-                            int srLength = (SenderReport != null) ? SenderReport.GetBytes().Length : Int32.MaxValue;
+                            var srLength = SenderReport.GetPacketSize();
                             offset += srLength;
                             break;
                         case (byte)RTCPReportTypesEnum.RR:
                             ReceiverReport = new RTCPReceiverReport(buffer);
-                            int rrLength = (ReceiverReport != null) ? ReceiverReport.GetBytes().Length : Int32.MaxValue;
+                            var rrLength = ReceiverReport.GetPacketSize();
                             offset += rrLength;
                             break;
                         case (byte)RTCPReportTypesEnum.SDES:
                             SDesReport = new RTCPSDesReport(buffer);
-                            int sdesLength = (SDesReport != null) ? SDesReport.GetBytes().Length : Int32.MaxValue;
+                            var sdesLength = SDesReport.GetPacketSize();
                             offset += sdesLength;
                             break;
                         case (byte)RTCPReportTypesEnum.BYE:
                             Bye = new RTCPBye(buffer);
-                            int byeLength = (Bye != null) ? Bye.GetBytes().Length : Int32.MaxValue;
+                            var byeLength = Bye.GetPacketSize();
                             offset += byeLength;
                             break;
                         case (byte)RTCPReportTypesEnum.RTPFB:
                             var typ = RTCPHeader.ParseFeedbackType(buffer);
-                            switch (typ) {
+                            switch (typ)
+                            {
                                 case RTCPFeedbackTypesEnum.TWCC:
                                     TWCCFeedback = new RTCPTWCCFeedback(buffer);
-                                    int twccFeedbackLength = (TWCCFeedback.Header.Length + 1) * 4;
+                                    var twccFeedbackLength = (TWCCFeedback.Header.Length + 1) * 4;
                                     offset += twccFeedbackLength;
                                     break;
                                 default:
                                     Feedback = new RTCPFeedback(buffer);
-                                    int rtpfbFeedbackLength = Feedback.GetBytes().Length;
+                                    var rtpfbFeedbackLength = Feedback.GetPacketSize();
                                     offset += rtpfbFeedbackLength;
                                     break;
                             }
@@ -118,7 +128,7 @@ namespace SIPSorcery.Net
                         case (byte)RTCPReportTypesEnum.PSFB:
                             // TODO: Interpret Payload specific feedback reports.
                             Feedback = new RTCPFeedback(buffer);
-                            int psfbFeedbackLength = (Feedback != null) ? Feedback.GetBytes().Length : Int32.MaxValue;
+                            var psfbFeedbackLength = Feedback.GetPacketSize();
                             offset += psfbFeedbackLength;
                             //var psfbHeader = new RTCPHeader(buffer);
                             //offset += psfbHeader.Length * 4 + 4;
@@ -132,31 +142,82 @@ namespace SIPSorcery.Net
             }
         }
 
+        // TODO: optimize this
+        public int GetPacketSize() =>
+            (SenderReport?.GetPacketSize()).GetValueOrDefault() +
+            (ReceiverReport?.GetPacketSize()).GetValueOrDefault() +
+            SDesReport.GetPacketSize() +
+            (Bye?.GetPacketSize()).GetValueOrDefault();
+
         /// <summary>
         /// Serialises a compound RTCP packet to a byte array ready for transmission.
         /// </summary>
         /// <returns>A byte array representing a serialised compound RTCP packet.</returns>
         public byte[] GetBytes()
         {
-            if (SenderReport == null && ReceiverReport == null)
+            if (SenderReport is null && ReceiverReport is null)
             {
-                throw new ApplicationException("An RTCP compound packet must have either a Sender or Receiver report set.");
+                throw new InvalidOperationException("An RTCP compound packet must have either a Sender or Receiver report set.");
             }
-            else if (SDesReport == null)
+            else if (SDesReport is null)
             {
-                throw new ApplicationException("An RTCP compound packet must have an SDES report set.");
+                throw new InvalidOperationException("An RTCP compound packet must have an SDES report set.");
             }
 
-            List<byte> compoundBuffer = new List<byte>();
-            compoundBuffer.AddRange((SenderReport != null) ? SenderReport.GetBytes() : ReceiverReport.GetBytes());
-            compoundBuffer.AddRange(SDesReport.GetBytes());
+            var size = GetPacketSize();
+
+            var buffer = new byte[size];
+
+            WriteBytesCore(buffer);
+
+            return buffer;
+        }
+
+        public int WriteBytes(Span<byte> buffer)
+        {
+            if (SenderReport is null && ReceiverReport is null)
+            {
+                throw new InvalidOperationException("An RTCP compound packet must have either a Sender or Receiver report set.");
+            }
+            else if (SDesReport is null)
+            {
+                throw new InvalidOperationException("An RTCP compound packet must have an SDES report set.");
+            }
+
+            var size = GetPacketSize();
+
+            if (buffer.Length < size)
+            {
+                throw new ArgumentOutOfRangeException($"The buffer should have at least {size} bytes and had only {buffer.Length}.");
+            }
+
+            WriteBytesCore(buffer.Slice(0, size));
+
+            return size;
+        }
+
+        private void WriteBytesCore(Span<byte> buffer)
+        {
+            if (SenderReport is not null)
+            {
+                var bytesWritten = SenderReport.WriteBytes(buffer);
+                buffer = buffer.Slice(bytesWritten);
+            }
+            else
+            {
+                var bytesWritten = ReceiverReport.WriteBytes(buffer);
+                buffer = buffer.Slice(bytesWritten);
+            }
+
+            {
+                var bytesWritten = SDesReport.WriteBytes(buffer);
+                buffer = buffer.Slice(bytesWritten);
+            }
 
             if (Bye != null)
             {
-                compoundBuffer.AddRange(Bye.GetBytes());
+                var bytesWritten = Bye.WriteBytes(buffer);
             }
-
-            return compoundBuffer.ToArray();
         }
 
         public string GetDebugSummary()
@@ -244,39 +305,40 @@ namespace SIPSorcery.Net
                     switch (packetTypeID)
                     {
                         case (byte)RTCPReportTypesEnum.SR:
-                            rtcpCompoundPacket.SenderReport = new RTCPSenderReport(buffer);
+                            // TODO: add parsing method that returns consumed bytes
+                            rtcpCompoundPacket.SenderReport = new RTCPSenderReport(buffer.AsSpan());
                             int srLength = (rtcpCompoundPacket.SenderReport != null) ? rtcpCompoundPacket.SenderReport.GetBytes().Length : Int32.MaxValue;
                             offset += srLength;
                             break;
                         case (byte)RTCPReportTypesEnum.RR:
-                            rtcpCompoundPacket.ReceiverReport = new RTCPReceiverReport(buffer);
+                            rtcpCompoundPacket.ReceiverReport = new RTCPReceiverReport(buffer.AsSpan());
                             int rrLength = (rtcpCompoundPacket.ReceiverReport != null) ? rtcpCompoundPacket.ReceiverReport.GetBytes().Length : Int32.MaxValue;
                             offset += rrLength;
                             break;
                         case (byte)RTCPReportTypesEnum.SDES:
-                            rtcpCompoundPacket.SDesReport = new RTCPSDesReport(buffer);
+                            rtcpCompoundPacket.SDesReport = new RTCPSDesReport(buffer.AsSpan());
                             int sdesLength = (rtcpCompoundPacket.SDesReport != null) ? rtcpCompoundPacket.SDesReport.GetBytes().Length : Int32.MaxValue;
                             offset += sdesLength;
                             break;
                         case (byte)RTCPReportTypesEnum.BYE:
-                            rtcpCompoundPacket.Bye = new RTCPBye(buffer);
+                            rtcpCompoundPacket.Bye = new RTCPBye(buffer.AsSpan());
                             int byeLength = (rtcpCompoundPacket.Bye != null) ? rtcpCompoundPacket.Bye.GetBytes().Length : Int32.MaxValue;
                             offset += byeLength;
                             break;
                         case (byte)RTCPReportTypesEnum.RTPFB:
-                            var typ = RTCPHeader.ParseFeedbackType(buffer);
+                            var typ = RTCPHeader.ParseFeedbackType(buffer.AsSpan());
                             switch (typ)
                             {
                                 default:
                                     {
-                                        rtcpCompoundPacket.Feedback = new RTCPFeedback(buffer);
+                                        rtcpCompoundPacket.Feedback = new RTCPFeedback(buffer.AsSpan());
                                         int rtpfbFeedbackLength = (rtcpCompoundPacket.Feedback != null) ? rtcpCompoundPacket.Feedback.GetBytes().Length : Int32.MaxValue;
                                         offset += rtpfbFeedbackLength;
                                     }
                                     break;
                                 case RTCPFeedbackTypesEnum.TWCC:
                                     {
-                                        rtcpCompoundPacket.TWCCFeedback = new RTCPTWCCFeedback(buffer);
+                                        rtcpCompoundPacket.TWCCFeedback = new RTCPTWCCFeedback(buffer.AsSpan());
                                         int twccFeedbackLength = (rtcpCompoundPacket.TWCCFeedback != null) ? rtcpCompoundPacket.TWCCFeedback.GetBytes().Length : Int32.MaxValue;
                                         offset += twccFeedbackLength;
                                     }
@@ -285,7 +347,7 @@ namespace SIPSorcery.Net
                             break;
                         case (byte)RTCPReportTypesEnum.PSFB:
                             // TODO: Interpret Payload specific feedback reports.
-                            rtcpCompoundPacket.Feedback = new RTCPFeedback(buffer);
+                            rtcpCompoundPacket.Feedback = new RTCPFeedback(buffer.AsSpan());
                             int psfbFeedbackLength = (rtcpCompoundPacket.Feedback != null) ? rtcpCompoundPacket.Feedback.GetBytes().Length : Int32.MaxValue;
                             offset += psfbFeedbackLength;
                             //var psfbHeader = new RTCPHeader(buffer);

--- a/src/net/RTCP/RTCPFeedback.cs
+++ b/src/net/RTCP/RTCPFeedback.cs
@@ -27,6 +27,10 @@
 //-----------------------------------------------------------------------------
 
 using System;
+using System;
+using System.Buffers.Binary;
+using System.ComponentModel;
+using System.Text;
 using Microsoft.Extensions.Logging;
 using SIPSorcery.Sys;
 
@@ -146,21 +150,23 @@ namespace SIPSorcery.Net
         /// Create a new RTCP Report from a serialised byte array.
         /// </summary>
         /// <param name="packet">The byte array holding the serialised feedback report.</param>
-        public RTCPFeedback(byte[] packet)
+        [Obsolete("Use RTCPFeedback(ReadOnlySpan<byte> packet) instead.", false)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public RTCPFeedback(byte[] packet) : this(new ReadOnlySpan<byte>(packet))
+        {
+        }
+
+        /// <summary>
+        /// Create a new RTCP Report from a serialised byte array.
+        /// </summary>
+        /// <param name="packet">The byte array holding the serialised feedback report.</param>
+        public RTCPFeedback(ReadOnlySpan<byte> packet)
         {
             Header = new RTCPHeader(packet);
 
-            int payloadIndex = RTCPHeader.HEADER_BYTES_LENGTH;
-            if (BitConverter.IsLittleEndian)
-            {
-                SenderSSRC = NetConvert.DoReverseEndian(BitConverter.ToUInt32(packet, payloadIndex));
-                MediaSSRC = NetConvert.DoReverseEndian(BitConverter.ToUInt32(packet, payloadIndex + 4));
-            }
-            else
-            {
-                SenderSSRC = BitConverter.ToUInt32(packet, payloadIndex);
-                MediaSSRC = BitConverter.ToUInt32(packet, payloadIndex + 4);
-            }
+            var payloadIndex = RTCPHeader.HEADER_BYTES_LENGTH;
+            SenderSSRC = BinaryPrimitives.ReadUInt32BigEndian(packet.Slice(payloadIndex));
+            MediaSSRC = BinaryPrimitives.ReadUInt32BigEndian(packet.Slice(payloadIndex + 4));
 
             switch (Header)
             {
@@ -170,16 +176,8 @@ namespace SIPSorcery.Net
                     break;
                 case var x when x.PacketType == RTCPReportTypesEnum.RTPFB:
                     SENDER_PAYLOAD_SIZE = 12;
-                    if (BitConverter.IsLittleEndian)
-                    {
-                        PID = NetConvert.DoReverseEndian(BitConverter.ToUInt16(packet, payloadIndex + 8));
-                        BLP = NetConvert.DoReverseEndian(BitConverter.ToUInt16(packet, payloadIndex + 10));
-                    }
-                    else
-                    {
-                        PID = BitConverter.ToUInt16(packet, payloadIndex + 8);
-                        BLP = BitConverter.ToUInt16(packet, payloadIndex + 10);
-                    }
+                    PID = BinaryPrimitives.ReadUInt16BigEndian(packet.Slice(payloadIndex + 8));
+                    BLP = BinaryPrimitives.ReadUInt16BigEndian(packet.Slice(payloadIndex + 10));
                     break;
 
                 case var x when x.PacketType == RTCPReportTypesEnum.PSFB && x.PayloadFeedbackMessageType == PSFBFeedbackTypesEnum.PLI:
@@ -202,10 +200,10 @@ namespace SIPSorcery.Net
                     SENDER_PAYLOAD_SIZE = 8 + 12; // 8 bytes from (SenderSSRC + MediaSSRC) + extra 12 bytes from REMB Definition
 
                     var currentCounter = payloadIndex + 8;
-                    UniqueID = System.Text.ASCIIEncoding.ASCII.GetString(packet, currentCounter, 4);
+                    UniqueID = Encoding.ASCII.GetString(packet.Slice(currentCounter, 4));
                     currentCounter += 4;
 
-                    if (string.Equals(UniqueID,"REMB", StringComparison.CurrentCultureIgnoreCase))
+                    if (string.Equals(UniqueID, "REMB", StringComparison.CurrentCultureIgnoreCase))
                     {
                         // Read first 8 bits
                         NumSsrcs = packet[currentCounter];
@@ -215,26 +213,12 @@ namespace SIPSorcery.Net
                         BitrateExp = (byte)(packet[currentCounter] >> 2);
 
                         // Now read next 18 bits
-                        var remaininMantissaBytes = new byte[] { (byte)0, (byte)(packet[currentCounter] & 3), packet[currentCounter + 1], packet[currentCounter + 2] };
-                        if (BitConverter.IsLittleEndian)
-                        {
-                            BitrateMantissa = NetConvert.DoReverseEndian(BitConverter.ToUInt32(remaininMantissaBytes, 0));
-                        }
-                        else
-                        {
-                            BitrateMantissa = BitConverter.ToUInt32(remaininMantissaBytes, 0);
-                        }
-                        
-                        currentCounter += 3;
+                        BitrateMantissa =
+                            ((((uint)packet[currentCounter++]) & 0b11U) << 16) |
+                            (((uint)packet[currentCounter++]) << 8) |
+                            ((uint)packet[currentCounter++]);
 
-                        if (BitConverter.IsLittleEndian)
-                        {
-                            FeedbackSSRC = NetConvert.DoReverseEndian(BitConverter.ToUInt32(packet, currentCounter));
-                        }
-                        else
-                        {
-                            FeedbackSSRC = BitConverter.ToUInt32(packet, currentCounter);
-                        }
+                        FeedbackSSRC = BinaryPrimitives.ReadUInt32BigEndian(packet.Slice(currentCounter));
                     }
 
                     break;
@@ -244,36 +228,50 @@ namespace SIPSorcery.Net
             }
         }
 
-       //0                   1                   2                   3
-       //0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
-       //+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-       //|V=2|P|   FMT   |       PT      |          length               |
-       //+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-       //|                  SSRC of packet sender                        |
-       //+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-       //|                  SSRC of media source                         |
-       //+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-       //:            Feedback Control Information(FCI)                  :
-       //:                                                               :
+        public int GetPacketSize() => RTCPHeader.HEADER_BYTES_LENGTH + SENDER_PAYLOAD_SIZE;
+
+        //0                   1                   2                   3
+        //0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+        //+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+        //|V=2|P|   FMT   |       PT      |          length               |
+        //+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+        //|                  SSRC of packet sender                        |
+        //+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+        //|                  SSRC of media source                         |
+        //+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+        //:            Feedback Control Information(FCI)                  :
+        //:                                                               :
         public byte[] GetBytes()
         {
-            byte[] buffer = new byte[RTCPHeader.HEADER_BYTES_LENGTH + SENDER_PAYLOAD_SIZE];
-            Header.SetLength((ushort)(buffer.Length / 4 - 1));
+            var buffer = new byte[GetPacketSize()];
 
-            Buffer.BlockCopy(Header.GetBytes(), 0, buffer, 0, RTCPHeader.HEADER_BYTES_LENGTH);
-            int payloadIndex = RTCPHeader.HEADER_BYTES_LENGTH;
+            WriteBytesCore(buffer);
+
+            return buffer;
+        }
+
+        public int WriteBytes(Span<byte> buffer)
+        {
+            var size = GetPacketSize();
+
+            if (buffer.Length < size)
+            {
+                throw new ArgumentOutOfRangeException($"The buffer should have at least {size} bytes and had only {buffer.Length}.");
+            }
+
+            WriteBytesCore(buffer.Slice(0, size));
+
+            return size;
+        }
+
+        private void WriteBytesCore(Span<byte> buffer)
+        {
+            Header.SetLength((ushort)(buffer.Length / 4 - 1));
+            _ = Header.WriteBytes(buffer);
 
             // All feedback packets require the Sender and Media SSRC's to be set.
-            if (BitConverter.IsLittleEndian)
-            {
-                Buffer.BlockCopy(BitConverter.GetBytes(NetConvert.DoReverseEndian(SenderSSRC)), 0, buffer, payloadIndex, 4);
-                Buffer.BlockCopy(BitConverter.GetBytes(NetConvert.DoReverseEndian(MediaSSRC)), 0, buffer, payloadIndex + 4, 4);
-            }
-            else
-            {
-                Buffer.BlockCopy(BitConverter.GetBytes(SenderSSRC), 0, buffer, payloadIndex, 4);
-                Buffer.BlockCopy(BitConverter.GetBytes(MediaSSRC), 0, buffer, payloadIndex + 4, 4);
-            }
+            BinaryPrimitives.WriteUInt32BigEndian(buffer.Slice(RTCPHeader.HEADER_BYTES_LENGTH), SenderSSRC);
+            BinaryPrimitives.WriteUInt32BigEndian(buffer.Slice(RTCPHeader.HEADER_BYTES_LENGTH + 4), MediaSSRC);
 
             switch (Header)
             {
@@ -281,16 +279,8 @@ namespace SIPSorcery.Net
                     // PLI feedback reports do no have any additional parameters.
                     break;
                 case var x when x.PacketType == RTCPReportTypesEnum.RTPFB:
-                    if (BitConverter.IsLittleEndian)
-                    {
-                        Buffer.BlockCopy(BitConverter.GetBytes(NetConvert.DoReverseEndian(PID)), 0, buffer, payloadIndex + 8, 2);
-                        Buffer.BlockCopy(BitConverter.GetBytes(NetConvert.DoReverseEndian(BLP)), 0, buffer, payloadIndex + 10, 2);
-                    }
-                    else
-                    {
-                        Buffer.BlockCopy(BitConverter.GetBytes(PID), 0, buffer, payloadIndex + 8, 2);
-                        Buffer.BlockCopy(BitConverter.GetBytes(BLP), 0, buffer, payloadIndex + 10, 2);
-                    }
+                    BinaryPrimitives.WriteUInt16BigEndian(buffer.Slice(RTCPHeader.HEADER_BYTES_LENGTH + 8), PID);
+                    BinaryPrimitives.WriteUInt16BigEndian(buffer.Slice(RTCPHeader.HEADER_BYTES_LENGTH + 10), BLP);
                     break;
 
                 case var x when x.PacketType == RTCPReportTypesEnum.PSFB && x.PayloadFeedbackMessageType == PSFBFeedbackTypesEnum.PLI:
@@ -308,51 +298,30 @@ namespace SIPSorcery.Net
                     //|  Num SSRC     | BR Exp    |  BR Mantissa                      |
                     //+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
                     //|   SSRC feedback                                               |
-                    var currentCounter = payloadIndex + 8;
 
                     //Fix UniqueID Size
-                    if(string.IsNullOrEmpty(UniqueID))
+                    if (string.IsNullOrEmpty(UniqueID))
                     {
-                        UniqueID = System.Text.ASCIIEncoding.ASCII.GetString(new byte[4]);
+                        UniqueID = new string('\0', 4);
                     }
                     while (UniqueID.Length < 4)
                     {
                         UniqueID += (char)0;
                     }
 
-                    Buffer.BlockCopy(System.Text.ASCIIEncoding.ASCII.GetBytes(UniqueID), 0, buffer, currentCounter, 4);
-                    currentCounter += 4;
+                    Encoding.ASCII.GetBytes(UniqueID.AsSpan(), buffer.Slice(RTCPHeader.HEADER_BYTES_LENGTH + 8));
 
-                    if (string.Equals(UniqueID, "REMB", StringComparison.CurrentCultureIgnoreCase))
+                    if (string.Equals(UniqueID, "REMB", StringComparison.OrdinalIgnoreCase))
                     {
                         // Copy NumSsrcs
-                        buffer[currentCounter] = NumSsrcs;
-                        currentCounter++;
-                       
+                        buffer[RTCPHeader.HEADER_BYTES_LENGTH + 12] = NumSsrcs;
 
-                        byte[] remaininMantissaBytes;
-                        if (BitConverter.IsLittleEndian)
-                        {
-                            remaininMantissaBytes = BitConverter.GetBytes(NetConvert.DoReverseEndian(BitrateMantissa));
-                        }
-                        else
-                        {
-                            remaininMantissaBytes = BitConverter.GetBytes(BitrateMantissa);
-                        }
-                        buffer[currentCounter] = (byte)((BitrateExp << 2) | (remaininMantissaBytes[1] & 3));
-                        buffer[currentCounter + 1] = remaininMantissaBytes[2];
-                        buffer[currentCounter + 2] = remaininMantissaBytes[3];
+                        var temp = BitrateMantissa;
+                        buffer[RTCPHeader.HEADER_BYTES_LENGTH + 15] = (byte)temp;
+                        buffer[RTCPHeader.HEADER_BYTES_LENGTH + 14] = (byte)(temp >>= 8);
+                        buffer[RTCPHeader.HEADER_BYTES_LENGTH + 13] = (byte)((BitrateExp << 2) | (byte)((temp >>= 8) & 0b11));
 
-                        currentCounter += 3;
-
-                        if (BitConverter.IsLittleEndian)
-                        {
-                            Buffer.BlockCopy(BitConverter.GetBytes(NetConvert.DoReverseEndian(FeedbackSSRC)), 0, buffer, currentCounter, 4);
-                        }
-                        else
-                        {
-                            Buffer.BlockCopy(BitConverter.GetBytes(FeedbackSSRC), 0, buffer, currentCounter, 4);
-                        }
+                        BinaryPrimitives.WriteUInt32BigEndian(buffer.Slice(RTCPHeader.HEADER_BYTES_LENGTH + 16), FeedbackSSRC);
                     }
 
                     break;
@@ -362,7 +331,6 @@ namespace SIPSorcery.Net
                     //throw new NotImplementedException($"Serialisation for feedback report {Header.PacketType} and message type "
                     //+ $"{Header.FeedbackMessageType} not yet implemented.");
             }
-            return buffer;
         }
     }
 }

--- a/src/net/RTCP/RTCPHeader.cs
+++ b/src/net/RTCP/RTCPHeader.cs
@@ -33,6 +33,8 @@
 //-----------------------------------------------------------------------------
 
 using System;
+using System.Buffers.Binary;
+using System.ComponentModel;
 using SIPSorcery.Sys;
 
 namespace SIPSorcery.Net
@@ -128,18 +130,20 @@ namespace SIPSorcery.Net
             }
         }
 
+        [Obsolete("Use ParseFeedbackType(ReadOnlySpan<byte> packet) instead.", false)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static RTCPFeedbackTypesEnum ParseFeedbackType(byte[] packet)
+            => ParseFeedbackType(new ReadOnlySpan<byte>(packet));
+
+        public static RTCPFeedbackTypesEnum ParseFeedbackType(ReadOnlySpan<byte> packet)
         {
             if (packet.Length < HEADER_BYTES_LENGTH)
             {
                 throw new ApplicationException("The packet did not contain the minimum number of bytes for an RTCP header packet.");
             }
-            UInt16 firstWord = BitConverter.ToUInt16(packet, 0);
 
-            if (BitConverter.IsLittleEndian)
-            {
-                firstWord = NetConvert.DoReverseEndian(firstWord);
-            }
+            var firstWord = BinaryPrimitives.ReadUInt16BigEndian(packet);
+
             return (RTCPFeedbackTypesEnum)((firstWord >> 8) & 0x1f);
         }
 
@@ -147,24 +151,21 @@ namespace SIPSorcery.Net
         /// Extract and load the RTCP header from an RTCP packet.
         /// </summary>
         /// <param name="packet"></param>
-        public RTCPHeader(byte[] packet)
+        [Obsolete("Use RTCPHeader(ReadOnlySpan<byte> packet) instead.", false)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public RTCPHeader(byte[] packet) : this(new ReadOnlySpan<byte>(packet))
+        {
+        }
+
+        public RTCPHeader(ReadOnlySpan<byte> packet)
         {
             if (packet.Length < HEADER_BYTES_LENGTH)
             {
                 throw new ApplicationException("The packet did not contain the minimum number of bytes for an RTCP header packet.");
             }
 
-            UInt16 firstWord = BitConverter.ToUInt16(packet, 0);
-
-            if (BitConverter.IsLittleEndian)
-            {
-                firstWord = NetConvert.DoReverseEndian(firstWord);
-                Length = NetConvert.DoReverseEndian(BitConverter.ToUInt16(packet, 2));
-            }
-            else
-            {
-                Length = BitConverter.ToUInt16(packet, 2);
-            }
+            var firstWord = BinaryPrimitives.ReadUInt16BigEndian(packet);
+            Length = BinaryPrimitives.ReadUInt16BigEndian(packet.Slice(2));
 
             Version = Convert.ToInt32(firstWord >> 14);
             PaddingFlag = Convert.ToInt32((firstWord >> 13) & 0x1);
@@ -209,11 +210,34 @@ namespace SIPSorcery.Net
             Length = length;
         }
 
+        public int GetPacketSize() => 4;
+
         public byte[] GetBytes()
         {
-            byte[] header = new byte[4];
+            var buffer = new byte[GetPacketSize()];
 
-            UInt32 firstWord = ((uint)Version << 30) + ((uint)PaddingFlag << 29) + ((uint)PacketType << 16) + Length;
+            WriteBytesCore(buffer);
+
+            return buffer;
+        }
+
+        public int WriteBytes(Span<byte> buffer)
+        {
+            var size = GetPacketSize();
+
+            if (buffer.Length < size)
+            {
+                throw new ArgumentOutOfRangeException($"The buffer should have at least {size} bytes and had only {buffer.Length}.");
+            }
+
+            WriteBytesCore(buffer.Slice(0, size));
+
+            return size;
+        }
+
+        private void WriteBytesCore(Span<byte> buffer)
+        {
+            var firstWord = ((uint)Version << 30) + ((uint)PaddingFlag << 29) + ((uint)PacketType << 16) + Length;
 
             if (IsFeedbackReport())
             {
@@ -231,16 +255,7 @@ namespace SIPSorcery.Net
                 firstWord += (uint)ReceptionReportCount << 24;
             }
 
-            if (BitConverter.IsLittleEndian)
-            {
-                Buffer.BlockCopy(BitConverter.GetBytes(NetConvert.DoReverseEndian(firstWord)), 0, header, 0, 4);
-            }
-            else
-            {
-                Buffer.BlockCopy(BitConverter.GetBytes(firstWord), 0, header, 0, 4);
-            }
-
-            return header;
+            BinaryPrimitives.WriteUInt32BigEndian(buffer, firstWord);
         }
     }
 }

--- a/src/net/RTCP/RTCPReceiverReport.cs
+++ b/src/net/RTCP/RTCPReceiverReport.cs
@@ -45,7 +45,9 @@
 //-----------------------------------------------------------------------------
 
 using System;
+using System.Buffers.Binary;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using SIPSorcery.Sys;
 
@@ -76,7 +78,17 @@ namespace SIPSorcery.Net
         /// Create a new RTCP Receiver Report from a serialised byte array.
         /// </summary>
         /// <param name="packet">The byte array holding the serialised receiver report.</param>
-        public RTCPReceiverReport(byte[] packet)
+        [Obsolete("Use RTCPReceiverReport(ReadOnlySpan<byte> packet) instead.", false)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public RTCPReceiverReport(byte[] packet) : this(new ReadOnlySpan<byte>(packet))
+        {
+        }
+
+        /// <summary>
+        /// Create a new RTCP Receiver Report from a serialised byte array.
+        /// </summary>
+        /// <param name="packet">The byte array holding the serialised receiver report.</param>
+        public RTCPReceiverReport(ReadOnlySpan<byte> packet)
         {
             if (packet.Length < MIN_PACKET_SIZE)
             {
@@ -86,19 +98,12 @@ namespace SIPSorcery.Net
             Header = new RTCPHeader(packet);
             ReceptionReports = new List<ReceptionReportSample>();
 
-            if (BitConverter.IsLittleEndian)
-            {
-                SSRC = NetConvert.DoReverseEndian(BitConverter.ToUInt32(packet, 4));
-            }
-            else
-            {
-                SSRC = BitConverter.ToUInt32(packet, 4);
-            }
+            SSRC = BinaryPrimitives.ReadUInt32BigEndian(packet.Slice(4, 4));
 
-            int rrIndex = 8;
-            for (int i = 0; i < Header.ReceptionReportCount; i++)
+            var rrIndex = 8;
+            for (var i = 0; i < Header.ReceptionReportCount; i++)
             {
-                var pkt = packet.Skip(rrIndex + i * ReceptionReportSample.PAYLOAD_SIZE).ToArray();
+                var pkt = packet.Slice(rrIndex + i * ReceptionReportSample.PAYLOAD_SIZE);
                 if (pkt.Length >= ReceptionReportSample.PAYLOAD_SIZE)
                 {
                     var rr = new ReceptionReportSample(pkt);
@@ -107,37 +112,51 @@ namespace SIPSorcery.Net
             }
         }
 
+        public int GetPacketSize() => RTCPHeader.HEADER_BYTES_LENGTH + 4 + (ReceptionReports?.Count).GetValueOrDefault() * ReceptionReportSample.PAYLOAD_SIZE;
+
         /// <summary>
         /// Gets the serialised bytes for this Receiver Report.
         /// </summary>
         /// <returns>A byte array.</returns>
         public byte[] GetBytes()
         {
-            int rrCount = (ReceptionReports != null) ? ReceptionReports.Count : 0;
-            byte[] buffer = new byte[RTCPHeader.HEADER_BYTES_LENGTH + 4 + rrCount * ReceptionReportSample.PAYLOAD_SIZE];
-            Header.SetLength((ushort)(buffer.Length / 4 - 1));
+            var buffer = new byte[GetPacketSize()];
 
-            Buffer.BlockCopy(Header.GetBytes(), 0, buffer, 0, RTCPHeader.HEADER_BYTES_LENGTH);
-            int payloadIndex = RTCPHeader.HEADER_BYTES_LENGTH;
-
-            if (BitConverter.IsLittleEndian)
-            {
-                Buffer.BlockCopy(BitConverter.GetBytes(NetConvert.DoReverseEndian(SSRC)), 0, buffer, payloadIndex, 4);
-            }
-            else
-            {
-                Buffer.BlockCopy(BitConverter.GetBytes(SSRC), 0, buffer, payloadIndex, 4);
-            }
-
-            int bufferIndex = payloadIndex + 4;
-            for (int i = 0; i < rrCount; i++)
-            {
-                var receptionReportBytes = ReceptionReports[i].GetBytes();
-                Buffer.BlockCopy(receptionReportBytes, 0, buffer, bufferIndex, ReceptionReportSample.PAYLOAD_SIZE);
-                bufferIndex += ReceptionReportSample.PAYLOAD_SIZE;
-            }
+            WriteBytesCore(buffer);
 
             return buffer;
+        }
+
+        public int WriteBytes(Span<byte> buffer)
+        {
+            var size = GetPacketSize();
+
+            if (buffer.Length < size)
+            {
+                throw new ArgumentOutOfRangeException($"The buffer should have at least {size} bytes and had only {buffer.Length}.");
+            }
+
+            WriteBytesCore(buffer.Slice(0, size));
+
+            return size;
+        }
+
+        private void WriteBytesCore(Span<byte> buffer)
+        {
+            Header.SetLength((ushort)(buffer.Length / 4 - 1));
+            _ = Header.WriteBytes(buffer);
+
+            BinaryPrimitives.WriteUInt32BigEndian(buffer.Slice(RTCPHeader.HEADER_BYTES_LENGTH), SSRC);
+
+            if (ReceptionReports is { Count: > 0 } receptionReports)
+            {
+                buffer = buffer.Slice(RTCPHeader.HEADER_BYTES_LENGTH + 4);
+                for (var i = 0; i < receptionReports.Count; i++)
+                {
+                    _ = receptionReports[i].WriteBytes(buffer);
+                    buffer = buffer.Slice(ReceptionReportSample.PAYLOAD_SIZE);
+                }
+            }
         }
     }
 }

--- a/src/net/RTCP/RTCPSdesReport.cs
+++ b/src/net/RTCP/RTCPSdesReport.cs
@@ -1,4 +1,4 @@
-//-----------------------------------------------------------------------------
+﻿//-----------------------------------------------------------------------------
 // Filename: RTCPSDesReport.cs
 //
 // Description: RTCP Source Description (SDES) report as defined in RFC3550.
@@ -51,6 +51,8 @@
 //-----------------------------------------------------------------------------
 
 using System;
+using System.Buffers.Binary;
+using System.ComponentModel;
 using System.Text;
 using SIPSorcery.Sys;
 
@@ -100,7 +102,17 @@ namespace SIPSorcery.Net
         /// Create a new RTCP SDES item from a serialised byte array.
         /// </summary>
         /// <param name="packet">The byte array holding the SDES report.</param>
-        public RTCPSDesReport(byte[] packet)
+        [Obsolete("Use RTCPSDesReport(ReadOnlySpan<byte> packet) instead.", false)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public RTCPSDesReport(byte[] packet) : this(new ReadOnlySpan<byte>(packet))
+        {
+        }
+
+        /// <summary>
+        /// Create a new RTCP SDES item from a serialised byte array.
+        /// </summary>
+        /// <param name="packet">The byte array holding the SDES report.</param>
+        public RTCPSDesReport(ReadOnlySpan<byte> packet)
         {
             // if (packet.Length < MIN_PACKET_SIZE)
             // {
@@ -117,16 +129,9 @@ namespace SIPSorcery.Net
                 return;
             }
 
-            if (packet.Length >= RTCPHeader.HEADER_BYTES_LENGTH+4)
+            if (packet.Length >= RTCPHeader.HEADER_BYTES_LENGTH + 4)
             {
-                if (BitConverter.IsLittleEndian)
-                {
-                    SSRC = NetConvert.DoReverseEndian(BitConverter.ToUInt32(packet, RTCPHeader.HEADER_BYTES_LENGTH));
-                }
-                else
-                {
-                    SSRC = BitConverter.ToUInt32(packet, RTCPHeader.HEADER_BYTES_LENGTH);
-                }
+                SSRC = BinaryPrimitives.ReadUInt32BigEndian(packet.Slice(RTCPHeader.HEADER_BYTES_LENGTH, 4));
             }
 
             if (packet.Length >= MIN_PACKET_SIZE)
@@ -137,9 +142,11 @@ namespace SIPSorcery.Net
                     CNAME = string.Empty;
                     return;
                 }
-                CNAME = Encoding.UTF8.GetString(packet, 10, cnameLength);
+                CNAME = Encoding.UTF8.GetString(packet.Slice(10, cnameLength));
             }
         }
+
+        public int GetPacketSize() => RTCPHeader.HEADER_BYTES_LENGTH + GetPaddedLength(Encoding.UTF8.GetByteCount(CNAME));
 
         /// <summary>
         /// Gets the raw bytes for the SDES item. This packet is ready to be included 
@@ -148,27 +155,37 @@ namespace SIPSorcery.Net
         /// <returns>A byte array containing the serialised SDES item.</returns>
         public byte[] GetBytes()
         {
-            byte[] cnameBytes = CNAME == null ? Array.Empty<byte>() : Encoding.UTF8.GetBytes(CNAME);
-            byte[] buffer = new byte[RTCPHeader.HEADER_BYTES_LENGTH + GetPaddedLength(cnameBytes.Length)]; // Array automatically initialised with 0x00 values.
-            Header.SetLength((ushort)(buffer.Length / 4 - 1));
+            var buffer = new byte[GetPacketSize()]; // Array automatically initialised with 0x00 values.
 
-            Buffer.BlockCopy(Header.GetBytes(), 0, buffer, 0, RTCPHeader.HEADER_BYTES_LENGTH);
-            int payloadIndex = RTCPHeader.HEADER_BYTES_LENGTH;
-
-            if (BitConverter.IsLittleEndian)
-            {
-                Buffer.BlockCopy(BitConverter.GetBytes(NetConvert.DoReverseEndian(SSRC)), 0, buffer, payloadIndex, 4);
-            }
-            else
-            {
-                Buffer.BlockCopy(BitConverter.GetBytes(SSRC), 0, buffer, payloadIndex, 4);
-            }
-
-            buffer[payloadIndex + 4] = CNAME_ID;
-            buffer[payloadIndex + 5] = (byte)cnameBytes.Length;
-            Buffer.BlockCopy(cnameBytes, 0, buffer, payloadIndex + 6, cnameBytes.Length);
+            WriteBytesCore(buffer);
 
             return buffer;
+        }
+
+        public int WriteBytes(Span<byte> buffer)
+        {
+            var size = GetPacketSize();
+
+            if (buffer.Length < size)
+            {
+                throw new ArgumentOutOfRangeException($"The buffer should have at least {size} bytes and had only {buffer.Length}.");
+            }
+
+            WriteBytesCore(buffer.Slice(0, size));
+
+            return size;
+        }
+
+        private void WriteBytesCore(Span<byte> buffer)
+        {
+            Header.SetLength((ushort)(buffer.Length / 4 - 1));
+            _ = Header.WriteBytes(buffer);
+
+            BinaryPrimitives.WriteUInt32BigEndian(buffer.Slice(RTCPHeader.HEADER_BYTES_LENGTH), SSRC);
+
+            buffer[RTCPHeader.HEADER_BYTES_LENGTH + 4] = CNAME_ID;
+            buffer[RTCPHeader.HEADER_BYTES_LENGTH + 5] =
+                (byte)Encoding.UTF8.GetBytes(CNAME.AsSpan(), buffer.Slice(RTCPHeader.HEADER_BYTES_LENGTH + 6));
         }
 
         /// <summary>

--- a/src/net/RTCP/RTCPSenderReport.cs
+++ b/src/net/RTCP/RTCPSenderReport.cs
@@ -45,7 +45,9 @@
 //-----------------------------------------------------------------------------
 
 using System;
+using System.Buffers.Binary;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using SIPSorcery.Sys;
 
@@ -91,7 +93,17 @@ namespace SIPSorcery.Net
         /// Create a new RTCP Sender Report from a serialised byte array.
         /// </summary>
         /// <param name="packet">The byte array holding the serialised sender report.</param>
-        public RTCPSenderReport(byte[] packet)
+        [Obsolete("Use RTCPSenderReport(ReadOnlySpan<byte> packet) instead.", false)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public RTCPSenderReport(byte[] packet) : this(new ReadOnlySpan<byte>(packet))
+        {
+        }
+
+        /// <summary>
+        /// Create a new RTCP Sender Report from a serialised byte array.
+        /// </summary>
+        /// <param name="packet">The byte array holding the serialised sender report.</param>
+        public RTCPSenderReport(ReadOnlySpan<byte> packet)
         {
             if (packet.Length < MIN_PACKET_SIZE)
             {
@@ -101,71 +113,69 @@ namespace SIPSorcery.Net
             Header = new RTCPHeader(packet);
             ReceptionReports = new List<ReceptionReportSample>();
 
-            if (BitConverter.IsLittleEndian)
-            {
-                SSRC = NetConvert.DoReverseEndian(BitConverter.ToUInt32(packet, 4));
-                NtpTimestamp = NetConvert.DoReverseEndian(BitConverter.ToUInt64(packet, 8));
-                RtpTimestamp = NetConvert.DoReverseEndian(BitConverter.ToUInt32(packet, 16));
-                PacketCount = NetConvert.DoReverseEndian(BitConverter.ToUInt32(packet, 20));
-                OctetCount = NetConvert.DoReverseEndian(BitConverter.ToUInt32(packet, 24));
-            }
-            else
-            {
-                SSRC = BitConverter.ToUInt32(packet, 4);
-                NtpTimestamp = BitConverter.ToUInt64(packet, 8);
-                RtpTimestamp = BitConverter.ToUInt32(packet, 16);
-                PacketCount = BitConverter.ToUInt32(packet, 20);
-                OctetCount = BitConverter.ToUInt32(packet, 24);
-            }
+            SSRC = BinaryPrimitives.ReadUInt32BigEndian(packet.Slice(RTCPHeader.HEADER_BYTES_LENGTH, 4));
+            NtpTimestamp = BinaryPrimitives.ReadUInt64BigEndian(packet.Slice(RTCPHeader.HEADER_BYTES_LENGTH + 4, 8));
+            RtpTimestamp = BinaryPrimitives.ReadUInt32BigEndian(packet.Slice(RTCPHeader.HEADER_BYTES_LENGTH + 12, 4));
+            PacketCount = BinaryPrimitives.ReadUInt32BigEndian(packet.Slice(RTCPHeader.HEADER_BYTES_LENGTH + 16, 4));
+            OctetCount = BinaryPrimitives.ReadUInt32BigEndian(packet.Slice(RTCPHeader.HEADER_BYTES_LENGTH + 20, 4));
 
-            int rrIndex = 28;
-            for (int i = 0; i < Header.ReceptionReportCount; i++)
+            var rrIndex = 28;
+            for (var i = 0; i < Header.ReceptionReportCount; i++)
             {
-                var pkt = packet.Skip(rrIndex + i * ReceptionReportSample.PAYLOAD_SIZE).ToArray();
+                var pkt = packet.Slice(rrIndex + i * ReceptionReportSample.PAYLOAD_SIZE);
                 if (pkt.Length >= ReceptionReportSample.PAYLOAD_SIZE)
                 {
                     var rr = new ReceptionReportSample(pkt);
                     ReceptionReports.Add(rr);
                 }
-                
             }
         }
 
+        public int GetPacketSize() => RTCPHeader.HEADER_BYTES_LENGTH + 4 + SENDER_PAYLOAD_SIZE + (ReceptionReports?.Count).GetValueOrDefault() * ReceptionReportSample.PAYLOAD_SIZE;
+
         public byte[] GetBytes()
         {
-            int rrCount = (ReceptionReports != null) ? ReceptionReports.Count : 0;
-            byte[] buffer = new byte[RTCPHeader.HEADER_BYTES_LENGTH + 4 + SENDER_PAYLOAD_SIZE + rrCount * ReceptionReportSample.PAYLOAD_SIZE];
-            Header.SetLength((ushort)(buffer.Length / 4 - 1));
+            var buffer = new byte[GetPacketSize()];
 
-            Buffer.BlockCopy(Header.GetBytes(), 0, buffer, 0, RTCPHeader.HEADER_BYTES_LENGTH);
-            int payloadIndex = RTCPHeader.HEADER_BYTES_LENGTH;
-
-            if (BitConverter.IsLittleEndian)
-            {
-                Buffer.BlockCopy(BitConverter.GetBytes(NetConvert.DoReverseEndian(SSRC)), 0, buffer, payloadIndex, 4);
-                Buffer.BlockCopy(BitConverter.GetBytes(NetConvert.DoReverseEndian(NtpTimestamp)), 0, buffer, payloadIndex + 4, 8);
-                Buffer.BlockCopy(BitConverter.GetBytes(NetConvert.DoReverseEndian(RtpTimestamp)), 0, buffer, payloadIndex + 12, 4);
-                Buffer.BlockCopy(BitConverter.GetBytes(NetConvert.DoReverseEndian(PacketCount)), 0, buffer, payloadIndex + 16, 4);
-                Buffer.BlockCopy(BitConverter.GetBytes(NetConvert.DoReverseEndian(OctetCount)), 0, buffer, payloadIndex + 20, 4);
-            }
-            else
-            {
-                Buffer.BlockCopy(BitConverter.GetBytes(SSRC), 0, buffer, payloadIndex, 4);
-                Buffer.BlockCopy(BitConverter.GetBytes(NtpTimestamp), 0, buffer, payloadIndex + 4, 8);
-                Buffer.BlockCopy(BitConverter.GetBytes(RtpTimestamp), 0, buffer, payloadIndex + 12, 4);
-                Buffer.BlockCopy(BitConverter.GetBytes(PacketCount), 0, buffer, payloadIndex + 16, 4);
-                Buffer.BlockCopy(BitConverter.GetBytes(OctetCount), 0, buffer, payloadIndex + 20, 4);
-            }
-
-            int bufferIndex = payloadIndex + 24;
-            for (int i = 0; i < rrCount; i++)
-            {
-                var receptionReportBytes = ReceptionReports[i].GetBytes();
-                Buffer.BlockCopy(receptionReportBytes, 0, buffer, bufferIndex, ReceptionReportSample.PAYLOAD_SIZE);
-                bufferIndex += ReceptionReportSample.PAYLOAD_SIZE;
-            }
+            WriteBytesCore(buffer);
 
             return buffer;
+        }
+
+        public int WriteBytes(Span<byte> buffer)
+        {
+            var size = GetPacketSize();
+
+            if (buffer.Length < size)
+            {
+                throw new ArgumentOutOfRangeException($"The buffer should have at least {size} bytes and had only {buffer.Length}.");
+            }
+
+            WriteBytesCore(buffer.Slice(0, size));
+
+            return size;
+        }
+
+        private void WriteBytesCore(Span<byte> buffer)
+        {
+            Header.SetLength((ushort)(buffer.Length / 4 - 1));
+            _ = Header.WriteBytes(buffer);
+
+            BinaryPrimitives.WriteUInt32BigEndian(buffer.Slice(RTCPHeader.HEADER_BYTES_LENGTH), SSRC);
+            BinaryPrimitives.WriteUInt64BigEndian(buffer.Slice(RTCPHeader.HEADER_BYTES_LENGTH + 4), NtpTimestamp);
+            BinaryPrimitives.WriteUInt32BigEndian(buffer.Slice(RTCPHeader.HEADER_BYTES_LENGTH + 12), RtpTimestamp);
+            BinaryPrimitives.WriteUInt32BigEndian(buffer.Slice(RTCPHeader.HEADER_BYTES_LENGTH + 16), PacketCount);
+            BinaryPrimitives.WriteUInt32BigEndian(buffer.Slice(RTCPHeader.HEADER_BYTES_LENGTH + 20), OctetCount);
+
+            if (ReceptionReports is { Count: > 0 } receptionReports)
+            {
+                buffer = buffer.Slice(RTCPHeader.HEADER_BYTES_LENGTH + 24);
+                for (var i = 0; i < receptionReports.Count; i++)
+                {
+                    _ = receptionReports[i].WriteBytes(buffer);
+                    buffer = buffer.Slice(ReceptionReportSample.PAYLOAD_SIZE);
+                }
+            }
         }
     }
 }

--- a/src/net/RTCP/RTCPTWCCFeedback.cs
+++ b/src/net/RTCP/RTCPTWCCFeedback.cs
@@ -35,7 +35,10 @@
 *   2025-02-20  Initial creation.
 */
 using System;
+using System.Buffers.Binary;
 using System.Collections.Generic;
+using System.ComponentModel;
+using System.Diagnostics;
 using System.Linq;
 using SIPSorcery.Sys;
 
@@ -155,31 +158,44 @@ namespace SIPSorcery.Net
         /// <summary>
         /// Parses a TWCC feedback packet from the given byte array.
         /// </summary>
-        public RTCPTWCCFeedback(byte[] packet)
+        [Obsolete("Use RTCPSDesReport(ReadOnlySpan<byte> packet) instead.", false)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public RTCPTWCCFeedback(byte[] packet) : this(new ReadOnlySpan<byte>(packet))
+        {
+        }
+
+        /// <summary>
+        /// Constructs a TWCC feedback message from the raw RTCP packet.
+        /// </summary>
+        /// <param name="packet">The complete RTCP TWCC feedback packet.</param>
+        /// <summary>
+        /// Parses a TWCC feedback packet from the given byte array.
+        /// </summary>
+        public RTCPTWCCFeedback(ReadOnlySpan<byte> packet)
         {
             ValidatePacket(packet);
 
             // Parse the RTCP header.
             Header = new RTCPHeader(packet);
-            int offset = RTCPHeader.HEADER_BYTES_LENGTH;
+            packet = packet.Slice(RTCPHeader.HEADER_BYTES_LENGTH);
 
             // Parse sender and media SSRCs
-            SenderSSRC = ReadUInt32(packet, ref offset);
-            MediaSSRC = ReadUInt32(packet, ref offset);
+            SenderSSRC = ReadUInt32(ref packet);
+            MediaSSRC = ReadUInt32(ref packet);
 
             // Parse Base Sequence Number and Packet Status Count
-            BaseSequenceNumber = ReadUInt16(packet, ref offset);
-            PacketStatusCount = ReadUInt16(packet, ref offset);
+            BaseSequenceNumber = ReadUInt16(ref packet);
+            PacketStatusCount = ReadUInt16(ref packet);
 
             // Parse Reference Time and Feedback Packet Count
-            ReferenceTime = ParseReferenceTime(packet, ref offset, out byte fbCount);
+            ReferenceTime = ParseReferenceTime(ref packet, out byte fbCount);
             FeedbackPacketCount = fbCount;
 
             // Parse status chunks
-            var statusSymbols = ParseStatusChunks(packet, ref offset);
+            var statusSymbols = ParseStatusChunks(ref packet);
 
             // Parse delta values with validation
-            var (deltaValues, lastOffset) = ParseDeltaValues(packet, offset, statusSymbols);
+            var deltaValues = ParseDeltaValues(ref packet, statusSymbols);
 
             // Build final packet status list
             BuildPacketStatusList(statusSymbols, deltaValues);
@@ -220,6 +236,8 @@ namespace SIPSorcery.Net
             remainingStatuses -= runLength;
         }
 
+        [Obsolete("Use ValidatePacket(ReadOnlySpan<byte> packet) instead.", false)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         private void ValidatePacket(byte[] packet)
         {
             if (packet == null)
@@ -227,23 +245,29 @@ namespace SIPSorcery.Net
                 throw new ArgumentNullException(nameof(packet));
             }
 
+            ValidatePacket(new ReadOnlySpan<byte>(packet));
+        }
+
+        private void ValidatePacket(ReadOnlySpan<byte> packet)
+        {
             if (packet.Length < (RTCPHeader.HEADER_BYTES_LENGTH + 12))
             {
                 throw new ArgumentException("Packet too short to be a valid TWCC feedback message.");
             }
         }
 
-        private uint ParseReferenceTime(byte[] packet, ref int offset, out byte fbCount)
+        private uint ParseReferenceTime(ref ReadOnlySpan<byte> packet, out byte fbCount)
         {
-            if (offset + 4 > packet.Length)
+            if (packet.Length < 4)
             {
                 throw new ArgumentException("Packet truncated at reference time.");
             }
 
-            byte b1 = packet[offset++];
-            byte b2 = packet[offset++];
-            byte b3 = packet[offset++];
-            fbCount = packet[offset++];
+            var b1 = packet[0];
+            var b2 = packet[1];
+            var b3 = packet[2];
+            fbCount = packet[3];
+            packet = packet.Slice(4);
             return (uint)((b1 << 16) | (b2 << 8) | b3);
         }
 
@@ -259,8 +283,40 @@ namespace SIPSorcery.Net
                     throw new ArgumentException($"Packet truncated during status chunk parsing. Expected {remainingStatuses} more statuses.");
                 }
 
-                ushort chunk = ReadUInt16(packet, ref offset);
-                int chunkType = chunk >> 14;
+                var chunk = ReadUInt16(packet, ref offset);
+                var chunkType = chunk >> 14;
+
+                switch (chunkType)
+                {
+                    case 0: // Run Length Chunk
+                        ParseRunLengthChunk(chunk, statusSymbols, ref remainingStatuses);
+                        break;
+                    case 2: // Two-bit Status Vector
+                        ParseTwoBitStatusVector(chunk, statusSymbols, ref remainingStatuses);
+                        break;
+                    case 3: // One-bit Status Vector
+                        ParseOneBitStatusVector(chunk, statusSymbols, ref remainingStatuses);
+                        break;
+                }
+            }
+
+            return statusSymbols;
+        }
+
+        private List<TWCCPacketStatusType> ParseStatusChunks(ref ReadOnlySpan<byte> packet)
+        {
+            var statusSymbols = new List<TWCCPacketStatusType>();
+            int remainingStatuses = PacketStatusCount;
+
+            while (remainingStatuses > 0)
+            {
+                if (packet.Length < 2)
+                {
+                    throw new ArgumentException($"Packet truncated during status chunk parsing. Expected {remainingStatuses} more statuses.");
+                }
+
+                var chunk = ReadUInt16(ref packet);
+                var chunkType = chunk >> 14;
 
                 switch (chunkType)
                 {
@@ -344,6 +400,44 @@ namespace SIPSorcery.Net
             return (deltaValues, offset);
         }
 
+        private List<int> ParseDeltaValues(ref ReadOnlySpan<byte> packet, List<TWCCPacketStatusType> statusSymbols)
+        {
+            var deltaValues = new List<int>();
+            int expectedDeltaCount = statusSymbols.Count(s => s is TWCCPacketStatusType.ReceivedSmallDelta or TWCCPacketStatusType.ReceivedLargeDelta);
+
+            foreach (var status in statusSymbols)
+            {
+                if (status is TWCCPacketStatusType.NotReceived or TWCCPacketStatusType.Reserved)
+                {
+                    deltaValues.Add(0);
+                    continue;
+                }
+
+                // Check if we have enough data for the delta
+                var deltaSize = status == TWCCPacketStatusType.ReceivedSmallDelta ? 1 : 2;
+                if (deltaSize > packet.Length)
+                {
+                    // Instead of throwing, we'll add a special value to indicate truncation
+                    deltaValues.Add(int.MinValue);
+                    break;
+                }
+
+                if (status == TWCCPacketStatusType.ReceivedSmallDelta)
+                {
+                    deltaValues.Add((sbyte)packet[0] * DeltaScale);
+                    packet = packet.Slice(1);
+                }
+                else // ReceivedLargeDelta
+                {
+                    var rawDelta = (short)((packet[0] << 8) | packet[1]);
+                    deltaValues.Add(rawDelta * DeltaScale);
+                    packet = packet.Slice(2);
+                }
+            }
+
+            return deltaValues;
+        }
+
         private void BuildPacketStatusList(List<TWCCPacketStatusType> statusSymbols, List<int> deltaValues)
         {
             PacketStatuses = new List<TWCCPacketStatus>();
@@ -364,27 +458,17 @@ namespace SIPSorcery.Net
             }
         }
 
-        /// <summary>
-        /// Serializes this TWCC feedback message to a byte array.
-        /// Note: The serialization logic rebuilds the packet status chunks from the PacketStatuses list.
-        /// This implements the run-length chunk when possible and defaults to two-bit
-        /// status vector chunks if a run-length encoding isn’t efficient.
-        /// </summary>
-        /// <returns>The serialized RTCP TWCC feedback packet.</returns>
-        public byte[] GetBytes()
+        public int GetPacketSize()
         {
-            // Build a list of TWCCPacketStatusType from PacketStatuses.
-            List<TWCCPacketStatusType> symbols = PacketStatuses.Select(ps => ps.Status).ToList();
+            var length = RTCPHeader.HEADER_BYTES_LENGTH + 4 + 4 + 2 + 2 + 4;
 
-            // Reconstruct packet status chunks.
-            List<ushort> chunks = new List<ushort>();
-            int i = 0;
-            while (i < symbols.Count)
+            var packageStatusesCount = PacketStatuses.Count;
+            for (var i = 0; i < packageStatusesCount;)
             {
                 // Try to use run-length chunk: count how many consecutive statuses are identical.
-                int runLength = 1;
-                TWCCPacketStatusType current = symbols[i];
-                while (i + runLength < symbols.Count && symbols[i + runLength] == current && runLength < 0x0FFF)
+                var runLength = 1;
+                var current = PacketStatuses[i].Status;
+                while (i + runLength < packageStatusesCount && PacketStatuses[i + runLength].Status == current && runLength < 0x0FFF)
                 {
                     runLength++;
                 }
@@ -413,22 +497,22 @@ namespace SIPSorcery.Net
                             break;
                     }
 
-                    ushort chunk = (ushort)(statusBits << 12);
+                    var chunk = (ushort)(statusBits << 12);
                     chunk |= (ushort)(runLength & 0x0FFF);
-                    chunks.Add(chunk);
+                    length += 2;
                     i += runLength;
                 }
                 else
                 {
                     // Otherwise, pack into a two-bit status vector chunk.
-                    int count = Math.Min(7, symbols.Count - i);
+                    var count = Math.Min(7, packageStatusesCount - i);
                     ushort chunk = 0x8000; // Set top bits to 10 for vector chunk
 
-                    for (int j = 0; j < count; j++)
+                    for (var j = 0; j < count; j++)
                     {
                         // Convert status to correct bit pattern
                         ushort statusBits;
-                        switch (symbols[i + j])
+                        switch (PacketStatuses[i + j].Status)
                         {
                             case TWCCPacketStatusType.NotReceived:
                                 statusBits = 0;
@@ -446,77 +530,178 @@ namespace SIPSorcery.Net
 
                         chunk |= (ushort)(statusBits << (12 - 2 * j));
                     }
-                    chunks.Add(chunk);
+                    length += 2;
                     i += count;
                 }
             }
 
-            // Build the delta values array.
-            List<byte> deltaBytes = new List<byte>();
+            foreach (var ps in PacketStatuses)
+            {
+                length += GetDeltaLength(ps);
+            }
+
+            var check = GetBytes().Length;
+
+            Debug.Assert(check == length);
+
+            return check;
+
+            static int GetDeltaLength(TWCCPacketStatus ps)
+            {
+                if (ps.Status == TWCCPacketStatusType.ReceivedSmallDelta)
+                {
+                    return 1;
+                }
+                
+                if (ps.Status == TWCCPacketStatusType.ReceivedLargeDelta)
+                {
+                    return 2;
+                }
+
+                return 0;
+            }
+        }
+
+        /// <summary>
+        /// Serializes this TWCC feedback message to a byte array.
+        /// Note: The serialization logic rebuilds the packet status chunks from the PacketStatuses list.
+        /// This implements the run-length chunk when possible and defaults to two-bit
+        /// status vector chunks if a run-length encoding isn’t efficient.
+        /// </summary>
+        /// <returns>The serialized RTCP TWCC feedback packet.</returns>
+        public byte[] GetBytes()
+                    {
+            var buffer = new byte[GetPacketSize()];
+
+            WriteBytesCore(buffer);
+
+            return buffer;
+                    }
+
+        public int WriteBytes(Span<byte> buffer)
+        {
+            var size = GetPacketSize();
+
+            if (buffer.Length < size)
+            {
+                throw new ArgumentOutOfRangeException($"The buffer should have at least {size} bytes and had only {buffer.Length}.");
+                }
+
+            WriteBytesCore(buffer.Slice(0, size));
+
+            return size;
+            }
+
+        private void WriteBytesCore(Span<byte> buffer)
+        {
+            // Update the header length (in 32-bit words minus one).
+            Header.SetLength((ushort)(buffer.Length / 4 - 1));
+            _ = Header.WriteBytes(buffer);
+            buffer = buffer.Slice(RTCPHeader.HEADER_BYTES_LENGTH);
+
+            // Write Sender and Media SSRC.
+            WriteUInt32(ref buffer, SenderSSRC);
+            WriteUInt32(ref buffer, MediaSSRC);
+
+            // Write Base Sequence Number and Packet Status Count.
+            WriteUInt16(ref buffer, BaseSequenceNumber);
+            WriteUInt16(ref buffer, PacketStatusCount);
+
+            // Build the 32-bit word for ReferenceTime and FeedbackPacketCount.
+            WriteUInt32(ref buffer, (ReferenceTime << 8) | FeedbackPacketCount);
+
+            for (var i = 0; i < PacketStatuses.Count;)
+            {
+                // Try to use run-length chunk: count how many consecutive statuses are identical.
+                var runLength = 1;
+                var current = PacketStatuses[i].Status;
+                while (i + runLength < PacketStatuses.Count && PacketStatuses[i + runLength].Status == current && runLength < 0x0FFF)
+            {
+                    runLength++;
+                }
+                if (runLength >= 2)
+                {
+                    // Build run-length chunk.
+                    // Currently:
+                    // ushort chunk = (ushort)(((int)current & 0x3) << 12);
+
+                    // Need to modify to use correct status bit mapping:
+                    ushort statusBits;
+                    switch (current)
+                    {
+                        case TWCCPacketStatusType.NotReceived:
+                            statusBits = 0; // 00
+                            break;
+                        case TWCCPacketStatusType.ReceivedSmallDelta:
+                            statusBits = 1; // 01 for small delta
+                                            // Note: status 10 (2) also means small delta
+                            break;
+                        case TWCCPacketStatusType.ReceivedLargeDelta:
+                            statusBits = 3; // 11 for large delta
+                            break;
+                        default:
+                            statusBits = 0;
+                            break;
+                    }
+
+                    var chunk = (ushort)(statusBits << 12);
+                    chunk |= (ushort)(runLength & 0x0FFF);
+                    WriteUInt16(ref buffer, chunk);
+                    i += runLength;
+            }
+                else
+                {
+                    // Otherwise, pack into a two-bit status vector chunk.
+                    var count = Math.Min(7, PacketStatuses.Count - i);
+                    ushort chunk = 0x8000; // Set top bits to 10 for vector chunk
+
+                    for (var j = 0; j < count; j++)
+                    {
+                        // Convert status to correct bit pattern
+                        ushort statusBits;
+                        switch (PacketStatuses[i + j].Status)
+            {
+                            case TWCCPacketStatusType.NotReceived:
+                                statusBits = 0;
+                                break;
+                            case TWCCPacketStatusType.ReceivedSmallDelta:
+                                statusBits = 1;
+                                break;
+                            case TWCCPacketStatusType.ReceivedLargeDelta:
+                                statusBits = 3;
+                                break;
+                            default:
+                                statusBits = 0;
+                                break;
+            }
+
+                        chunk |= (ushort)(statusBits << (12 - 2 * j));
+                    }
+                    WriteUInt16(ref buffer, chunk);
+                    i += count;
+                }
+            }
+
             foreach (var ps in PacketStatuses)
             {
                 if (ps.Status == TWCCPacketStatusType.ReceivedSmallDelta)
                 {
                     // Delta was stored already scaled; convert back to raw units.
-                    sbyte delta = (sbyte)(ps.Delta.HasValue ? ps.Delta.Value / DeltaScale : 0);
-                    deltaBytes.Add((byte)delta);
+                    var delta = (sbyte)(ps.Delta.GetValueOrDefault() / DeltaScale);
+                    buffer[0] = (byte)delta;
+                    buffer = buffer.Slice(1);
                 }
                 else if (ps.Status == TWCCPacketStatusType.ReceivedLargeDelta)
                 {
-                    if (!ps.Delta.HasValue)
-                    {
-                        ps.Delta = 0;
-                        //throw new ApplicationException("Missing delta for a large delta packet.");
-                    }
-                    short delta = (short)(ps.Delta.Value / DeltaScale);
-                    byte high = (byte)(delta >> 8);
-                    byte low = (byte)(delta & 0xFF);
-                    deltaBytes.Add(high);
-                    deltaBytes.Add(low);
+                    var delta = (short)(ps.Delta.GetValueOrDefault() / DeltaScale);
+                    var high = (byte)(delta >> 8);
+                    var low = (byte)(delta & 0xFF);
+                    buffer[0] = high;
+                    buffer[1] = low;
+                    buffer = buffer.Slice(2);
                 }
                 // For not received or reserved, no delta bytes are added.
             }
-
-            // Calculate fixed part length.
-            int fixedPart = RTCPHeader.HEADER_BYTES_LENGTH + 4 + 4 + 2 + 2 + 4; // header, two SSRCs, Base Seq, Status Count, RefTime+FbkCnt
-            int chunksPart = chunks.Count * 2;
-            int deltasPart = deltaBytes.Count;
-            int totalLength = fixedPart + chunksPart + deltasPart;
-            byte[] buffer = new byte[totalLength];
-
-            // Write header (we update length later).
-            Buffer.BlockCopy(Header.GetBytes(), 0, buffer, 0, RTCPHeader.HEADER_BYTES_LENGTH);
-            int offset = RTCPHeader.HEADER_BYTES_LENGTH;
-
-            // Write Sender and Media SSRC.
-            WriteUInt32(buffer, ref offset, SenderSSRC);
-            WriteUInt32(buffer, ref offset, MediaSSRC);
-
-            // Write Base Sequence Number and Packet Status Count.
-            WriteUInt16(buffer, ref offset, BaseSequenceNumber);
-            WriteUInt16(buffer, ref offset, PacketStatusCount);
-
-            // Build the 32-bit word for ReferenceTime and FeedbackPacketCount.
-            uint refTimeAndCount = (ReferenceTime << 8) | FeedbackPacketCount;
-            WriteUInt32(buffer, ref offset, refTimeAndCount);
-
-            // Write packet status chunks.
-            foreach (ushort chunk in chunks)
-            {
-                WriteUInt16(buffer, ref offset, chunk);
-            }
-
-            // Write delta values.
-            foreach (byte b in deltaBytes)
-            {
-                buffer[offset++] = b;
-            }
-
-            // Update the header length (in 32-bit words minus one).
-            Header.SetLength((ushort)(totalLength / 4 - 1));
-            Buffer.BlockCopy(Header.GetBytes(), 0, buffer, 0, RTCPHeader.HEADER_BYTES_LENGTH);
-
-            return buffer;
         }
 
         public override string ToString()
@@ -542,6 +727,13 @@ namespace SIPSorcery.Net
             return value;
         }
 
+        private uint ReadUInt32(ref ReadOnlySpan<byte> buffer)
+        {
+            var value = BinaryPrimitives.ReadUInt32BigEndian(buffer);
+            buffer = buffer.Slice(sizeof(uint));
+            return value;
+        }
+
         private ushort ReadUInt16(byte[] buffer, ref int offset)
         {
             ushort value = BitConverter.ToUInt16(buffer, offset);
@@ -550,6 +742,13 @@ namespace SIPSorcery.Net
                 value = NetConvert.DoReverseEndian(value);
             }
             offset += 2;
+            return value;
+        }
+
+        private ushort ReadUInt16(ref ReadOnlySpan<byte> buffer)
+        {
+            var value = BinaryPrimitives.ReadUInt16BigEndian(buffer);
+            buffer = buffer.Slice(sizeof(ushort));
             return value;
         }
 
@@ -571,6 +770,18 @@ namespace SIPSorcery.Net
             }
             Buffer.BlockCopy(BitConverter.GetBytes(value), 0, buffer, offset, 2);
             offset += 2;
+        }
+
+        private static void WriteUInt32(ref Span<byte> buffer, uint value)
+        {
+            BinaryPrimitives.WriteUInt32BigEndian(buffer, value);
+            buffer = buffer.Slice(sizeof(uint));
+        }
+
+        private static void WriteUInt16(ref Span<byte> buffer, ushort value)
+        {
+            BinaryPrimitives.WriteUInt16BigEndian(buffer, value);
+            buffer = buffer.Slice(sizeof(ushort));
         }
 
         #endregion

--- a/src/net/RTCP/ReceptionReport.cs
+++ b/src/net/RTCP/ReceptionReport.cs
@@ -1,4 +1,4 @@
-//-----------------------------------------------------------------------------
+﻿//-----------------------------------------------------------------------------
 // Filename: ReceptionReport.cs
 //
 // Description: One or more reception report blocks are included in each
@@ -34,6 +34,8 @@
 
 using System;
 using SIPSorcery.Sys;
+using System.Buffers.Binary;
+using System.ComponentModel;
 
 namespace SIPSorcery.Net
 {
@@ -111,29 +113,31 @@ namespace SIPSorcery.Net
             DelaySinceLastSenderReport = delaySinceLastSR;
         }
 
-        public ReceptionReportSample(byte[] packet)
+        [Obsolete("Use ReceptionReportSample(ReadOnlySpan<byte> packet) instead.", false)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public ReceptionReportSample(byte[] packet) : this(new ReadOnlySpan<byte>(packet))
         {
-            if (BitConverter.IsLittleEndian)
+        }
+
+        public ReceptionReportSample(ReadOnlySpan<byte> packet)
+        {
+            SSRC = BinaryPrimitives.ReadUInt32BigEndian(packet.Slice(0, 4));
+            FractionLost = packet[4];
+            PacketsLost = ReadInt24BigEndian(packet.Slice(5, 3));
+            ExtendedHighestSequenceNumber = BinaryPrimitives.ReadUInt32BigEndian(packet.Slice(8, 4));
+            Jitter = BinaryPrimitives.ReadUInt32BigEndian(packet.Slice(12, 4));
+            LastSenderReportTimestamp = BinaryPrimitives.ReadUInt32BigEndian(packet.Slice(16, 4));
+            DelaySinceLastSenderReport = BinaryPrimitives.ReadUInt32BigEndian(packet.Slice(20, 4));
+
+            static int ReadInt24BigEndian(ReadOnlySpan<byte> packet)
             {
-                SSRC = NetConvert.DoReverseEndian(BitConverter.ToUInt32(packet, 0));
-                FractionLost = packet[4];
-                PacketsLost = NetConvert.DoReverseEndian(BitConverter.ToInt32(new byte[] { 0x00, packet[5], packet[6], packet[7] }, 0));
-                ExtendedHighestSequenceNumber = NetConvert.DoReverseEndian(BitConverter.ToUInt32(packet, 8));
-                Jitter = NetConvert.DoReverseEndian(BitConverter.ToUInt32(packet, 12));
-                LastSenderReportTimestamp = NetConvert.DoReverseEndian(BitConverter.ToUInt32(packet, 16));
-                DelaySinceLastSenderReport = NetConvert.DoReverseEndian(BitConverter.ToUInt32(packet, 20));
-            }
-            else
-            {
-                SSRC = BitConverter.ToUInt32(packet, 4);
-                FractionLost = packet[4];
-                PacketsLost = BitConverter.ToInt32(new byte[] { 0x00, packet[5], packet[6], packet[7] }, 0);
-                ExtendedHighestSequenceNumber = BitConverter.ToUInt32(packet, 8);
-                Jitter = BitConverter.ToUInt32(packet, 12);
-                LastSenderReportTimestamp = BitConverter.ToUInt32(packet, 16);
-                DelaySinceLastSenderReport = BitConverter.ToUInt32(packet, 20);
+                Span<byte> buffer = stackalloc byte[4];
+                packet.CopyTo(buffer.Slice(BitConverter.IsLittleEndian ? 1 : 0, 3));
+                return BinaryPrimitives.ReadInt32BigEndian(buffer);
             }
         }
+
+        public int GetPacketSize() => 24;
 
         /// <summary>
         /// Serialises the reception report block to a byte array.
@@ -141,30 +145,36 @@ namespace SIPSorcery.Net
         /// <returns>A byte array.</returns>
         public byte[] GetBytes()
         {
-            byte[] payload = new byte[24];
+            var buffer = new byte[GetPacketSize()];
 
-            if (BitConverter.IsLittleEndian)
+            WriteBytesCore(buffer);
+
+            return buffer;
+        }
+
+        public int WriteBytes(Span<byte> buffer)
+        {
+            var size = GetPacketSize();
+
+            if (buffer.Length < size)
             {
-                Buffer.BlockCopy(BitConverter.GetBytes(NetConvert.DoReverseEndian(SSRC)), 0, payload, 0, 4);
-                payload[4] = FractionLost;
-                Buffer.BlockCopy(BitConverter.GetBytes(NetConvert.DoReverseEndian(PacketsLost)), 1, payload, 5, 3);
-                Buffer.BlockCopy(BitConverter.GetBytes(NetConvert.DoReverseEndian(ExtendedHighestSequenceNumber)), 0, payload, 8, 4);
-                Buffer.BlockCopy(BitConverter.GetBytes(NetConvert.DoReverseEndian(Jitter)), 0, payload, 12, 4);
-                Buffer.BlockCopy(BitConverter.GetBytes(NetConvert.DoReverseEndian(LastSenderReportTimestamp)), 0, payload, 16, 4);
-                Buffer.BlockCopy(BitConverter.GetBytes(NetConvert.DoReverseEndian(DelaySinceLastSenderReport)), 0, payload, 20, 4);
-            }
-            else
-            {
-                Buffer.BlockCopy(BitConverter.GetBytes(SSRC), 0, payload, 0, 4);
-                payload[4] = FractionLost;
-                Buffer.BlockCopy(BitConverter.GetBytes(PacketsLost), 1, payload, 5, 3);
-                Buffer.BlockCopy(BitConverter.GetBytes(ExtendedHighestSequenceNumber), 0, payload, 8, 4);
-                Buffer.BlockCopy(BitConverter.GetBytes(Jitter), 0, payload, 12, 4);
-                Buffer.BlockCopy(BitConverter.GetBytes(LastSenderReportTimestamp), 0, payload, 16, 4);
-                Buffer.BlockCopy(BitConverter.GetBytes(DelaySinceLastSenderReport), 0, payload, 20, 4);
+                throw new ArgumentOutOfRangeException(nameof(buffer), $"The buffer should have at least {size} bytes and had only {buffer.Length}.");
             }
 
-            return payload;
+            WriteBytesCore(buffer.Slice(0, size));
+
+            return size;
+            }
+
+        private void WriteBytesCore(Span<byte> buffer)
+        {
+            BinaryPrimitives.WriteUInt32BigEndian(buffer, SSRC);
+            BinaryPrimitives.WriteInt32BigEndian(buffer.Slice(4), PacketsLost); // only 24 bits
+            buffer[4] = FractionLost; // overwrite first 8 bits of PacketsLost
+            BinaryPrimitives.WriteUInt32BigEndian(buffer.Slice(8), ExtendedHighestSequenceNumber);
+            BinaryPrimitives.WriteUInt32BigEndian(buffer.Slice(12), Jitter);
+            BinaryPrimitives.WriteUInt32BigEndian(buffer.Slice(16), LastSenderReportTimestamp);
+            BinaryPrimitives.WriteUInt32BigEndian(buffer.Slice(20), DelaySinceLastSenderReport);
         }
     }
 

--- a/src/net/RTP/RTPHeader.cs
+++ b/src/net/RTP/RTPHeader.cs
@@ -142,45 +142,50 @@ namespace SIPSorcery.Net
             return GetBytes();
         }
 
+        public int GetPacketSize() => Length;
+
         public byte[] GetBytes()
         {
-            byte[] header = new byte[Length];
+            var buffer = new byte[Length];
 
-            UInt16 firstWord = Convert.ToUInt16(Version * 16384 + PaddingFlag * 8192 + HeaderExtensionFlag * 4096 + CSRCCount * 256 + MarkerBit * 128 + PayloadType);
+            WriteBytesCore(buffer);
 
-            if (BitConverter.IsLittleEndian)
+            return buffer;
+        }
+
+        public int WriteBytes(Span<byte> buffer)
             {
-                Buffer.BlockCopy(BitConverter.GetBytes(NetConvert.DoReverseEndian(firstWord)), 0, header, 0, 2);
-                Buffer.BlockCopy(BitConverter.GetBytes(NetConvert.DoReverseEndian(SequenceNumber)), 0, header, 2, 2);
-                Buffer.BlockCopy(BitConverter.GetBytes(NetConvert.DoReverseEndian(Timestamp)), 0, header, 4, 4);
-                Buffer.BlockCopy(BitConverter.GetBytes(NetConvert.DoReverseEndian(SyncSource)), 0, header, 8, 4);
+            var size = GetPacketSize();
+
+            if (buffer.Length < size)
+                {
+                throw new ArgumentOutOfRangeException($"The buffer should have at least {size} bytes and had only {buffer.Length}.");
+                }
+
+            WriteBytesCore(buffer.Slice(0, size));
+
+            return size;
+            }
+
+        private void WriteBytesCore(Span<byte> buffer)
+            {
+            var firstWord = Convert.ToUInt16(Version * 16384 + PaddingFlag * 8192 + HeaderExtensionFlag * 4096 + CSRCCount * 256 + MarkerBit * 128 + PayloadType);
+
+            BinaryPrimitives.WriteUInt16BigEndian(buffer, firstWord);
+            BinaryPrimitives.WriteUInt16BigEndian(buffer.Slice(2), SequenceNumber);
+            BinaryPrimitives.WriteUInt32BigEndian(buffer.Slice(4), Timestamp);
+            BinaryPrimitives.WriteUInt32BigEndian(buffer.Slice(8), SyncSource);
 
                 if (HeaderExtensionFlag == 1)
                 {
-                    Buffer.BlockCopy(BitConverter.GetBytes(NetConvert.DoReverseEndian(ExtensionProfile)), 0, header, 12 + 4 * CSRCCount, 2);
-                    Buffer.BlockCopy(BitConverter.GetBytes(NetConvert.DoReverseEndian(ExtensionLength)), 0, header, 14 + 4 * CSRCCount, 2);
-                }
+                BinaryPrimitives.WriteUInt16BigEndian(buffer.Slice(12 + 4 * CSRCCount), ExtensionProfile);
+                BinaryPrimitives.WriteUInt16BigEndian(buffer.Slice(14 + 4 * CSRCCount), ExtensionLength);
             }
-            else
+
+            if (ExtensionLength > 0 && ExtensionPayload is { Length: > 0 })
             {
-                Buffer.BlockCopy(BitConverter.GetBytes(firstWord), 0, header, 0, 2);
-                Buffer.BlockCopy(BitConverter.GetBytes(SequenceNumber), 0, header, 2, 2);
-                Buffer.BlockCopy(BitConverter.GetBytes(Timestamp), 0, header, 4, 4);
-                Buffer.BlockCopy(BitConverter.GetBytes(SyncSource), 0, header, 8, 4);
-
-                if (HeaderExtensionFlag == 1)
-                {
-                    Buffer.BlockCopy(BitConverter.GetBytes(ExtensionProfile), 0, header, 12 + 4 * CSRCCount, 2);
-                    Buffer.BlockCopy(BitConverter.GetBytes(ExtensionLength), 0, header, 14 + 4 * CSRCCount, 2);
-                }
+                ExtensionPayload.CopyTo(buffer.Slice(16 + 4 * CSRCCount));
             }
-
-            if (ExtensionLength > 0 && ExtensionPayload != null)
-            {
-                Buffer.BlockCopy(ExtensionPayload, 0, header, 16 + 4 * CSRCCount, ExtensionLength * 4);
-            }
-
-            return header;
         }
 
         private RTPHeaderExtensionData GetExtensionAtPosition(ref int position, int id, int len, RTPHeaderExtensionType type, out bool invalid)

--- a/src/net/SCTP/Chunks/SctpChunk.cs
+++ b/src/net/SCTP/Chunks/SctpChunk.cs
@@ -23,6 +23,7 @@ using System.Collections;
 using System.Collections.Generic;
 using Microsoft.Extensions.Logging;
 using SIPSorcery.Sys;
+using System.Buffers.Binary;
 
 namespace SIPSorcery.Net
 {
@@ -211,9 +212,22 @@ namespace SIPSorcery.Net
         /// <returns>The padded length of this chunk.</returns>
         protected void WriteChunkHeader(byte[] buffer, int posn)
         {
-            buffer[posn] = ChunkType;
-            buffer[posn + 1] = ChunkFlags;
-            NetConvert.ToBuffer(GetChunkLength(false), buffer, posn + 2);
+            WriteChunkHeader(buffer.AsSpan(posn));
+        }
+
+        /// <summary>
+        /// Writes the chunk header to the buffer. All chunks use the same three
+        /// header fields.
+        /// </summary>
+        /// <param name="buffer">The buffer to write the chunk header to.</param>
+        /// <returns>The number of bytes, including padding, written to the buffer.</returns>
+        protected int WriteChunkHeader(Span<byte> buffer)
+        {
+            buffer[0] = ChunkType;
+            buffer[1] = ChunkFlags;
+            var chunkLength = GetChunkLength(false);
+            BinaryPrimitives.WriteUInt16BigEndian(buffer.Slice(2), chunkLength);
+            return chunkLength + 2;
         }
 
         /// <summary>
@@ -227,14 +241,42 @@ namespace SIPSorcery.Net
         /// <returns>The number of bytes, including padding, written to the buffer.</returns>
         public virtual ushort WriteTo(byte[] buffer, int posn)
         {
-            WriteChunkHeader(buffer, posn);
-
-            if (ChunkValue?.Length > 0)
-            {
-                Buffer.BlockCopy(ChunkValue, 0, buffer, posn + SCTP_CHUNK_HEADER_LENGTH, ChunkValue.Length);
-            }
+            WriteToCore(buffer.AsSpan(posn));
 
             return GetChunkLength(true);
+        }
+
+        /// <summary>
+        /// Serialises the chunk to a pre-allocated buffer. This method gets overridden 
+        /// by specialised SCTP chunks that have their own parameters and need to be serialised
+        /// differently.
+        /// </summary>
+        /// <param name="buffer">The buffer to write the serialised chunk bytes to. It
+        /// must have the required space already allocated.</param>
+        /// <returns>The number of bytes, including padding, written to the buffer.</returns>
+        public virtual int WriteTo(Span<byte> buffer)
+        {
+            WriteToCore(buffer);
+
+            return GetChunkLength(true);
+        }
+
+        /// <summary>
+        /// Serialises the chunk to a pre-allocated buffer. This method gets overridden 
+        /// by specialised SCTP chunks that have their own parameters and need to be serialised
+        /// differently.
+        /// </summary>
+        /// <param name="buffer">The buffer to write the serialised chunk bytes to. It
+        /// must have the required space already allocated.</param>
+        /// <returns>The number of bytes, including padding, written to the buffer.</returns>
+        private void WriteToCore(Span<byte> buffer)
+        {
+            var bytesWritten = WriteChunkHeader(buffer);
+
+            if (ChunkValue is { Length: > 0 } chunkValue)
+            {
+                chunkValue.CopyTo(buffer.Slice(SCTP_CHUNK_HEADER_LENGTH));
+            }
         }
 
         /// <summary>

--- a/src/net/SCTP/Chunks/SctpDataChunk.cs
+++ b/src/net/SCTP/Chunks/SctpDataChunk.cs
@@ -18,6 +18,7 @@
 //-----------------------------------------------------------------------------
 
 using System;
+using System.Buffers.Binary;
 using SIPSorcery.Sys;
 
 namespace SIPSorcery.Net
@@ -156,24 +157,38 @@ namespace SIPSorcery.Net
         /// <returns>The number of bytes, including padding, written to the buffer.</returns>
         public override ushort WriteTo(byte[] buffer, int posn)
         {
-            WriteChunkHeader(buffer, posn);
-
-            // Write fixed parameters.
-            int startPosn = posn + SCTP_CHUNK_HEADER_LENGTH;
-
-            NetConvert.ToBuffer(TSN, buffer, startPosn);
-            NetConvert.ToBuffer(StreamID, buffer, startPosn + 4);
-            NetConvert.ToBuffer(StreamSeqNum, buffer, startPosn + 6);
-            NetConvert.ToBuffer(PPID, buffer, startPosn + 8);
-
-            int userDataPosn = startPosn + FIXED_PARAMETERS_LENGTH;
-
-            if (UserData != null)
-            {
-                Buffer.BlockCopy(UserData, 0, buffer, userDataPosn, UserData.Length);
-            }
+            WriteToCore(buffer.AsSpan(posn));
 
             return GetChunkLength(true);
+        }
+
+        /// <summary>
+        /// Serialises a DATA chunk to a pre-allocated buffer.
+        /// </summary>
+        /// <param name="buffer">The buffer to write the serialised chunk bytes to. It
+        /// must have the required space already allocated.</param>
+        /// <returns>The number of bytes, including padding, written to the buffer.</returns>
+        public override int WriteTo(Span<byte> buffer)
+        {
+            WriteToCore(buffer);
+
+            return GetChunkLength(true);
+        }
+
+        private void WriteToCore(Span<byte> buffer)
+        {
+            WriteChunkHeader(buffer);
+
+            // Write fixed parameters.
+            BinaryPrimitives.WriteUInt32BigEndian(buffer.Slice(SCTP_CHUNK_HEADER_LENGTH), TSN);
+            BinaryPrimitives.WriteUInt16BigEndian(buffer.Slice(SCTP_CHUNK_HEADER_LENGTH + 4), StreamID);
+            BinaryPrimitives.WriteUInt16BigEndian(buffer.Slice(SCTP_CHUNK_HEADER_LENGTH + 6), StreamSeqNum);
+            BinaryPrimitives.WriteUInt32BigEndian(buffer.Slice(SCTP_CHUNK_HEADER_LENGTH + 8), PPID);
+
+            if (UserData is { Length: > 0 } userData)
+            {
+                userData.CopyTo(buffer.Slice(SCTP_CHUNK_HEADER_LENGTH + FIXED_PARAMETERS_LENGTH));
+            }
         }
 
         public bool IsEmpty()

--- a/src/net/SCTP/Chunks/SctpErrorChunk.cs
+++ b/src/net/SCTP/Chunks/SctpErrorChunk.cs
@@ -109,16 +109,37 @@ namespace SIPSorcery.Net
         /// <returns>The number of bytes, including padding, written to the buffer.</returns>
         public override ushort WriteTo(byte[] buffer, int posn)
         {
-            WriteChunkHeader(buffer, posn);
-            if (ErrorCauses != null && ErrorCauses.Count > 0)
+            WriteToCore(buffer.AsSpan(posn));
+
+            return GetChunkLength(true);
+        }
+
+        /// <summary>
+        /// Serialises the ERROR chunk to a pre-allocated buffer.
+        /// </summary>
+        /// <param name="buffer">The buffer to write the serialised chunk bytes to. It
+        /// must have the required space already allocated.</param>
+        /// <returns>The number of bytes, including padding, written to the buffer.</returns>
+        public override int WriteTo(Span<byte> buffer)
+        {
+            WriteToCore(buffer);
+
+            return GetChunkLength(true);
+        }
+
+        private void WriteToCore(Span<byte> buffer)
+        {
+            WriteChunkHeader(buffer);
+
+            if (ErrorCauses is { Count: > 0 } errorCauses)
             {
-                int causePosn = posn + 4;
-                foreach (var cause in ErrorCauses)
+                buffer = buffer.Slice(4);
+                foreach (var cause in errorCauses)
                 {
-                    causePosn += cause.WriteTo(buffer, causePosn);
+                    var bytesWritten = cause.WriteTo(buffer);
+                    buffer = buffer.Slice(bytesWritten);
                 }
             }
-            return GetChunkLength(true);
         }
 
         /// <summary>

--- a/src/net/SCTP/Chunks/SctpInitChunk.cs
+++ b/src/net/SCTP/Chunks/SctpInitChunk.cs
@@ -18,6 +18,7 @@
 //-----------------------------------------------------------------------------
 
 using System;
+using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
@@ -288,30 +289,47 @@ namespace SIPSorcery.Net
         /// <returns>The number of bytes, including padding, written to the buffer.</returns>
         public override ushort WriteTo(byte[] buffer, int posn)
         {
-            WriteChunkHeader(buffer, posn);
-
-            // Write fixed parameters.
-            int startPosn = posn + SCTP_CHUNK_HEADER_LENGTH;
-
-            NetConvert.ToBuffer(InitiateTag, buffer, startPosn);
-            NetConvert.ToBuffer(ARwnd, buffer, startPosn + 4);
-            NetConvert.ToBuffer(NumberOutboundStreams, buffer, startPosn + 8);
-            NetConvert.ToBuffer(NumberInboundStreams, buffer, startPosn + 10);
-            NetConvert.ToBuffer(InitialTSN, buffer, startPosn + 12);
-
-            var varParameters = GetVariableParameters();
-
-            // Write optional parameters.
-            if (varParameters.Count > 0)
-            {
-                int paramPosn = startPosn + FIXED_PARAMETERS_LENGTH;
-                foreach (var optParam in varParameters)
-                {
-                    paramPosn += optParam.WriteTo(buffer, paramPosn);
-                }
-            }
+            WriteToCore(buffer.AsSpan(posn));
 
             return GetChunkLength(true);
+        }
+
+        /// <summary>
+        /// Serialises an INIT or INIT ACK chunk to a pre-allocated buffer.
+        /// </summary>
+        /// <param name="buffer">The buffer to write the serialised chunk bytes to. It
+        /// must have the required space already allocated.</param>
+        /// <param name="posn">The position in the buffer to write to.</param>
+        /// <returns>The number of bytes, including padding, written to the buffer.</returns>
+        public override int WriteTo(Span<byte> buffer)
+        {
+            WriteToCore(buffer);
+
+            return GetChunkLength(true);
+        }
+
+        private void WriteToCore(Span<byte> buffer)
+        {
+            var bytesWritten = WriteChunkHeader(buffer);
+
+            // Write fixed parameters.
+
+            BinaryPrimitives.WriteUInt32BigEndian(buffer.Slice(SCTP_CHUNK_HEADER_LENGTH), InitiateTag);
+            BinaryPrimitives.WriteUInt32BigEndian(buffer.Slice(SCTP_CHUNK_HEADER_LENGTH + 4), ARwnd);
+            BinaryPrimitives.WriteUInt16BigEndian(buffer.Slice(SCTP_CHUNK_HEADER_LENGTH + 8), NumberOutboundStreams);
+            BinaryPrimitives.WriteUInt16BigEndian(buffer.Slice(SCTP_CHUNK_HEADER_LENGTH + 10), NumberInboundStreams);
+            BinaryPrimitives.WriteUInt32BigEndian(buffer.Slice(SCTP_CHUNK_HEADER_LENGTH + 12), InitialTSN);
+
+            // Write optional parameters.
+            if (GetVariableParameters() is { Count: > 0 } varParameters)
+            {
+                buffer = buffer.Slice(SCTP_CHUNK_HEADER_LENGTH + FIXED_PARAMETERS_LENGTH);
+                foreach (var optParam in varParameters)
+                {
+                    var bytesWriten = optParam.WriteTo(buffer);
+                    buffer = buffer.Slice(bytesWriten);
+                }
+            }
         }
 
         /// <summary>

--- a/src/net/SCTP/Chunks/SctpSackChunk.cs
+++ b/src/net/SCTP/Chunks/SctpSackChunk.cs
@@ -17,6 +17,8 @@
 // BSD 3-Clause "New" or "Revised" License, see included LICENSE.md file.
 //-----------------------------------------------------------------------------
 
+using System;
+using System.Buffers.Binary;
 using System.Collections.Generic;
 using SIPSorcery.Sys;
 
@@ -79,7 +81,7 @@ namespace SIPSorcery.Net
         /// <returns>The length of the chunk.</returns>
         public override ushort GetChunkLength(bool padded)
         {
-            var len = (ushort)(SCTP_CHUNK_HEADER_LENGTH + 
+            var len = (ushort)(SCTP_CHUNK_HEADER_LENGTH +
                 FIXED_PARAMETERS_LENGTH +
                 GapAckBlocks.Count * GAP_REPORT_LENGTH +
                 DuplicateTSN.Count * DUPLICATE_TSN_LENGTH);
@@ -97,31 +99,47 @@ namespace SIPSorcery.Net
         /// <returns>The number of bytes, including padding, written to the buffer.</returns>
         public override ushort WriteTo(byte[] buffer, int posn)
         {
-            WriteChunkHeader(buffer, posn);
+            WriteToCore(buffer.AsSpan(posn));
 
-            ushort startPosn = (ushort)(posn + SCTP_CHUNK_HEADER_LENGTH);
+            return GetChunkLength(true);
+        }
 
-            NetConvert.ToBuffer(CumulativeTsnAck, buffer, startPosn);
-            NetConvert.ToBuffer(ARwnd, buffer, startPosn + 4);
-            NetConvert.ToBuffer((ushort)GapAckBlocks.Count, buffer, startPosn + 8);
-            NetConvert.ToBuffer((ushort)DuplicateTSN.Count, buffer, startPosn + 10);
+        /// <summary>
+        /// Serialises the SACK chunk to a pre-allocated buffer.
+        /// </summary>
+        /// <param name="buffer">The buffer to write the serialised chunk bytes to. It
+        /// must have the required space already allocated.</param>
+        /// <returns>The number of bytes, including padding, written to the buffer.</returns>
+        public override int WriteTo(Span<byte> buffer)
+        {
+            WriteToCore(buffer);
 
-            int reportPosn = startPosn + FIXED_PARAMETERS_LENGTH;
+            return GetChunkLength(true);
+        }
+
+        private void WriteToCore(Span<byte> buffer)
+        {
+            var bytesWritten = WriteChunkHeader(buffer);
+
+            BinaryPrimitives.WriteUInt32BigEndian(buffer.Slice(SCTP_CHUNK_HEADER_LENGTH), CumulativeTsnAck);
+            BinaryPrimitives.WriteUInt32BigEndian(buffer.Slice(SCTP_CHUNK_HEADER_LENGTH + 4), ARwnd);
+            BinaryPrimitives.WriteUInt16BigEndian(buffer.Slice(SCTP_CHUNK_HEADER_LENGTH + 8), (ushort)GapAckBlocks.Count);
+            BinaryPrimitives.WriteUInt16BigEndian(buffer.Slice(SCTP_CHUNK_HEADER_LENGTH + 10), (ushort)DuplicateTSN.Count);
+
+            var reportPosn = SCTP_CHUNK_HEADER_LENGTH + FIXED_PARAMETERS_LENGTH;
 
             foreach (var gapBlock in GapAckBlocks)
             {
-                NetConvert.ToBuffer(gapBlock.Start, buffer, reportPosn);
-                NetConvert.ToBuffer(gapBlock.End, buffer, reportPosn + 2);
+                BinaryPrimitives.WriteUInt16BigEndian(buffer.Slice(reportPosn), gapBlock.Start);
+                BinaryPrimitives.WriteUInt16BigEndian(buffer.Slice(reportPosn + 2), gapBlock.End);
                 reportPosn += GAP_REPORT_LENGTH;
             }
 
-            foreach(var dupTSN in DuplicateTSN)
+            foreach (var dupTSN in DuplicateTSN)
             {
-                NetConvert.ToBuffer(dupTSN, buffer, reportPosn);
+                BinaryPrimitives.WriteUInt32BigEndian(buffer.Slice(reportPosn), dupTSN);
                 reportPosn += DUPLICATE_TSN_LENGTH;
             }
-
-            return GetChunkLength(true);
         }
 
         /// <summary>
@@ -143,7 +161,7 @@ namespace SIPSorcery.Net
 
             int reportPosn = startPosn + FIXED_PARAMETERS_LENGTH;
 
-            for (int i=0; i < numGapAckBlocks; i++)
+            for (int i = 0; i < numGapAckBlocks; i++)
             {
                 ushort start = NetConvert.ParseUInt16(buffer, reportPosn);
                 ushort end = NetConvert.ParseUInt16(buffer, reportPosn + 2);
@@ -151,7 +169,7 @@ namespace SIPSorcery.Net
                 reportPosn += GAP_REPORT_LENGTH;
             }
 
-            for(int j=0; j < numDuplicateTSNs; j++)
+            for (int j = 0; j < numDuplicateTSNs; j++)
             {
                 sackChunk.DuplicateTSN.Add(NetConvert.ParseUInt32(buffer, reportPosn));
                 reportPosn += DUPLICATE_TSN_LENGTH;

--- a/src/net/SCTP/Chunks/SctpShutdownChunk.cs
+++ b/src/net/SCTP/Chunks/SctpShutdownChunk.cs
@@ -17,7 +17,10 @@
 // BSD 3-Clause "New" or "Revised" License, see included LICENSE.md file.
 //-----------------------------------------------------------------------------
 
+using System;
+using System.Buffers.Binary;
 using SIPSorcery.Sys;
+using static Org.BouncyCastle.Asn1.Cmp.Challenge;
 
 namespace SIPSorcery.Net
 {
@@ -69,9 +72,29 @@ namespace SIPSorcery.Net
         /// <returns>The number of bytes, including padding, written to the buffer.</returns>
         public override ushort WriteTo(byte[] buffer, int posn)
         {
-            WriteChunkHeader(buffer, posn);
-            NetConvert.ToBuffer(CumulativeTsnAck.GetValueOrDefault(), buffer, posn + SCTP_CHUNK_HEADER_LENGTH);
+            WriteToCore(buffer.AsSpan(posn));
+
             return GetChunkLength(true);
+        }
+
+        /// <summary>
+        /// Serialises the SHUTDOWN chunk to a pre-allocated buffer.
+        /// </summary>
+        /// <param name="buffer">The buffer to write the serialised chunk bytes to. It
+        /// must have the required space already allocated.</param>
+        /// <returns>The number of bytes, including padding, written to the buffer.</returns>
+        public override int WriteTo(Span<byte> buffer)
+        {
+            WriteToCore(buffer);
+
+            return GetChunkLength(true);
+        }
+
+        private void WriteToCore(Span<byte> buffer)
+        {
+            var bytesWritten = WriteChunkHeader(buffer);
+
+            BinaryPrimitives.WriteUInt32BigEndian(buffer.Slice(SCTP_CHUNK_HEADER_LENGTH), CumulativeTsnAck.GetValueOrDefault());
         }
 
         /// <summary>

--- a/src/net/SCTP/Chunks/SctpTlvChunkParameter.cs
+++ b/src/net/SCTP/Chunks/SctpTlvChunkParameter.cs
@@ -19,6 +19,7 @@
 //-----------------------------------------------------------------------------
 
 using System;
+using System.Buffers.Binary;
 using System.Net;
 using System.Net.Sockets;
 using Microsoft.Extensions.Logging;
@@ -159,8 +160,18 @@ namespace SIPSorcery.Net
         /// <param name="posn">The position in the buffer to write at.</param>
         protected void WriteParameterHeader(byte[] buffer, int posn)
         {
-            NetConvert.ToBuffer(ParameterType, buffer, posn);
-            NetConvert.ToBuffer(GetParameterLength(false), buffer, posn + 2);
+            WriteParameterHeader(buffer.AsSpan(posn));
+        }
+
+        /// <summary>
+        /// Writes the parameter header to the buffer. All chunk parameters use the same two
+        /// header fields.
+        /// </summary>
+        /// <param name="buffer">The buffer to write the chunk parameter header to.</param>
+        protected void WriteParameterHeader(Span<byte> buffer)
+        {
+            BinaryPrimitives.WriteUInt16BigEndian(buffer, ParameterType);
+            BinaryPrimitives.WriteUInt16BigEndian(buffer.Slice(2), GetParameterLength(false));
         }
 
         /// <summary>
@@ -174,15 +185,37 @@ namespace SIPSorcery.Net
         /// <returns>The number of bytes, including padding, written to the buffer.</returns>
         public virtual int WriteTo(byte[] buffer, int posn)
         {
-            WriteParameterHeader(buffer, posn);
-
-            if (ParameterValue?.Length > 0)
-            {
-                Buffer.BlockCopy(ParameterValue, 0, buffer, posn + SCTP_PARAMETER_HEADER_LENGTH, ParameterValue.Length);
-            }
+            WriteToCore(buffer.AsSpan(posn));
 
             return GetParameterLength(true);
         }
+
+        /// <summary>
+        /// Serialises the chunk parameter to a pre-allocated buffer. This method gets overridden 
+        /// by specialised SCTP chunk parameters that have their own data and need to be serialised
+        /// differently.
+        /// </summary>
+        /// <param name="buffer">The buffer to write the serialised chunk parameter bytes to. It
+        /// must have the required space already allocated.</param>
+        /// <returns>The number of bytes, including padding, written to the buffer.</returns>
+        public virtual int WriteTo(Span<byte> buffer)
+        {
+            WriteToCore(buffer);
+
+            return GetParameterLength(true);
+        }
+
+        private void WriteToCore(Span<byte> buffer)
+        {
+            WriteParameterHeader(buffer);
+
+            if (ParameterValue is { Length: > 0 } parameterValue)
+            {
+                parameterValue.CopyTo(buffer.Slice(SCTP_PARAMETER_HEADER_LENGTH));
+            }
+        }
+
+        public int GetPacketSize() => GetParameterLength(true);
 
         /// <summary>
         /// Serialises an SCTP chunk parameter to a byte array.
@@ -193,6 +226,24 @@ namespace SIPSorcery.Net
             byte[] buffer = new byte[GetParameterLength(true)];
             WriteTo(buffer, 0);
             return buffer;
+        }
+
+        public int WriteBytes(Span<byte> buffer)
+        {
+            var size = GetPacketSize();
+
+            if (buffer.Length < size)
+            {
+                throw new ArgumentOutOfRangeException($"The buffer should have at least {size} bytes and had only {buffer.Length}.");
+            }
+
+            WriteBytesCore(buffer.Slice(0, size));
+
+            return size;
+        }
+
+        private void WriteBytesCore(Span<byte> buffer)
+        {
         }
 
         /// <summary>

--- a/src/net/SCTP/SctpHeader.cs
+++ b/src/net/SCTP/SctpHeader.cs
@@ -18,6 +18,7 @@
 //-----------------------------------------------------------------------------
 
 using System;
+using System.Buffers.Binary;
 using SIPSorcery.Sys;
 
 namespace SIPSorcery.Net
@@ -56,9 +57,22 @@ namespace SIPSorcery.Net
         /// bytes to.</param>
         public void WriteToBuffer(byte[] buffer, int posn)
         {
-            NetConvert.ToBuffer(SourcePort, buffer, posn);
-            NetConvert.ToBuffer(DestinationPort, buffer, posn + 2);
-            NetConvert.ToBuffer(VerificationTag, buffer, posn + 4);
+            _ = WriteBytes(buffer.AsSpan(posn));
+        }
+
+        /// <summary>
+        /// Serialises the header to a pre-allocated buffer.
+        /// </summary>
+        /// <param name="buffer">The buffer to write the SCTP header bytes to. It
+        /// must have the required space already allocated.</param>
+        /// <returns>The number of bytes written.</returns>
+        public int WriteBytes(Span<byte> buffer)
+        { 
+            BinaryPrimitives.WriteUInt16BigEndian(buffer, SourcePort);
+            BinaryPrimitives.WriteUInt16BigEndian(buffer.Slice(2), DestinationPort);
+            BinaryPrimitives.WriteUInt32BigEndian(buffer.Slice(4), VerificationTag);
+
+            return 8;
         }
 
         /// <summary>

--- a/src/sys/EncodingExtensions.cs
+++ b/src/sys/EncodingExtensions.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Text;
+
+namespace SIPSorcery.Sys
+{
+    internal static class EncodingExtensions
+    {
+#if NETSTANDARD2_0 || NETFRAMEWORK
+        public unsafe static string GetString(this Encoding encoding, ReadOnlySpan<byte> bytes)
+        {
+            fixed (byte* ptr = bytes)
+            {
+                return encoding.GetString(ptr, bytes.Length);
+            }
+        }
+
+        public unsafe static int GetBytes(this Encoding encoding, ReadOnlySpan<char> chars, Span<byte> bytes)
+        {
+            fixed (char* pChars = chars)
+            fixed (byte* pBytes = bytes)
+            {
+                return encoding.GetBytes(pChars, chars.Length, pBytes, bytes.Length);
+            }
+        }
+#endif
+    }
+}


### PR DESCRIPTION
This PR adds methods that use `ReadOnlySpan<byte>`/`Span<byte>` instead of `byte[]`.

This allows callers to have complete ownership of the memory and use pooled memory.

Not being a complete solution, it already achieves some level of reducing allocations and memory copying and constitutes ground work for applying this across the library.

Some normalization of reading and writing bytes using [`BinaryPrimitives`](https://learn.microsoft.com/en-us/dotnet/api/system.buffers.binary.binaryprimitives). This can be improved by creating helper methods that read/write and advance to make the code more readable and error prone, but I left that for later.