### PR TITLE
Allow invite to be cancelled while waiting for ack transaction

### DIFF
--- a/src/core/SIPTransactions/UASInviteTransaction.cs
+++ b/src/core/SIPTransactions/UASInviteTransaction.cs
@@ -123,7 +123,7 @@ namespace SIPSorcery.SIP
         /// <returns>A socket error with the result of the cancel.</returns>
         public void CancelCall(SIPRequest sipCancelRequest = null)
         {
-            if (TransactionState == SIPTransactionStatesEnum.Calling || TransactionState == SIPTransactionStatesEnum.Trying || TransactionState == SIPTransactionStatesEnum.Proceeding)
+            if (TransactionState == SIPTransactionStatesEnum.Calling || TransactionState == SIPTransactionStatesEnum.Trying || TransactionState == SIPTransactionStatesEnum.Proceeding || TransactionState == SIPTransactionStatesEnum.Completed)
             {
                 base.UpdateTransactionState(SIPTransactionStatesEnum.Cancelled);
                 UASInviteTransactionCancelled?.Invoke(this, sipCancelRequest);
@@ -134,7 +134,7 @@ namespace SIPSorcery.SIP
             }
             else
             {
-                logger.LogWarning("A request was made to cancel transaction {TransactionId} that was not in the calling, trying or proceeding states, state={TransactionState}.", TransactionId, TransactionState);
+                logger.LogWarning("A request was made to cancel transaction {TransactionId} that was not in the calling, trying, proceeding or completed states, state={TransactionState}.", TransactionId, TransactionState);
             }
         }
 


### PR DESCRIPTION
This is a bugfix for when an invite is waiting for the final ack to be cancelled. This is a typical scenario when a call is being forked to multiple clients and they happen to answer at the same time. Only one client will get the ack and the rest will get a cancel. Before this fix the SIP Cancel had no effect as the sip invite transaction was in a completed state causing the cancel to be ignored. As a consequence the system considered the cancelled call to be active, which is not right. With this fix the cancel is accepted even in the invite transaction state completed, while waiting for the ack. 