### PR TITLE
Improve FFmpeg initialisation and error handling

### DIFF
--- a/src/SIPSorceryMedia.FFmpeg/FFmpegAudioDecoder.cs
+++ b/src/SIPSorceryMedia.FFmpeg/FFmpegAudioDecoder.cs
@@ -41,6 +41,8 @@ namespace SIPSorceryMedia.FFmpeg
 
         public unsafe FFmpegAudioDecoder(string url, AVInputFormat* inputFormat = null, bool repeat = false, bool isMicrophone = false)
         {
+            FFmpegInit.EnsureBinariesRegistered();
+
             _sourceUrl = url;
             _inputFormat = inputFormat;
             _repeat = repeat;

--- a/src/SIPSorceryMedia.FFmpeg/FFmpegAudioSource.cs
+++ b/src/SIPSorceryMedia.FFmpeg/FFmpegAudioSource.cs
@@ -42,6 +42,8 @@ namespace SIPSorceryMedia.FFmpeg
         public FFmpegAudioSource(IAudioEncoder audioEncoder, uint frameSize = 960)
 #pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
         {
+            FFmpegInit.EnsureBinariesRegistered();
+
             if (audioEncoder == null)
             {
                 throw new ApplicationException("Audio encoder provided is null");

--- a/src/SIPSorceryMedia.FFmpeg/FFmpegCameraManager.cs
+++ b/src/SIPSorceryMedia.FFmpeg/FFmpegCameraManager.cs
@@ -11,6 +11,8 @@ namespace SIPSorceryMedia.FFmpeg
     {
         static public List<Camera>? GetCameraDevices()
         {
+            FFmpegInit.EnsureBinariesRegistered();
+
             List<Camera>? result = null;
 
             string inputFormat = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "dshow"

--- a/src/SIPSorceryMedia.FFmpeg/FFmpegFileSource.cs
+++ b/src/SIPSorceryMedia.FFmpeg/FFmpegFileSource.cs
@@ -36,6 +36,8 @@ public class FFmpegFileSource: IAudioSource, IVideoSource, IDisposable
 
     public unsafe FFmpegFileSource(string path, bool repeat, IAudioEncoder? audioEncoder, uint audioFrameSize = 960, bool useVideo = true)
     {
+        FFmpegInit.EnsureBinariesRegistered();
+
         if (!File.Exists(path))
         {
             if (!Uri.TryCreate(path, UriKind.Absolute, out Uri? result))

--- a/src/SIPSorceryMedia.FFmpeg/FFmpegFileSource.cs
+++ b/src/SIPSorceryMedia.FFmpeg/FFmpegFileSource.cs
@@ -36,8 +36,6 @@ public class FFmpegFileSource: IAudioSource, IVideoSource, IDisposable
 
     public unsafe FFmpegFileSource(string path, bool repeat, IAudioEncoder? audioEncoder, uint audioFrameSize = 960, bool useVideo = true)
     {
-        FFmpegInit.EnsureBinariesRegistered();
-
         if (!File.Exists(path))
         {
             if (!Uri.TryCreate(path, UriKind.Absolute, out Uri? result))
@@ -45,6 +43,8 @@ public class FFmpegFileSource: IAudioSource, IVideoSource, IDisposable
                 throw new ApplicationException($"Requested path is not a valid file path or not a valid Uri: {path}.");
             }
         }
+
+        FFmpegInit.EnsureBinariesRegistered();
 
         if (audioEncoder != null)
         {

--- a/src/SIPSorceryMedia.FFmpeg/FFmpegMonitorManager.cs
+++ b/src/SIPSorceryMedia.FFmpeg/FFmpegMonitorManager.cs
@@ -14,7 +14,9 @@ namespace SIPSorceryMedia.FFmpeg
     {
         static public List<Monitor>? GetMonitorDevices()
         {
-            List<Monitor>? result = null ; 
+            FFmpegInit.EnsureBinariesRegistered();
+
+            List<Monitor>? result = null ;
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {

--- a/src/SIPSorceryMedia.FFmpeg/FFmpegVideoDecoder.cs
+++ b/src/SIPSorceryMedia.FFmpeg/FFmpegVideoDecoder.cs
@@ -49,6 +49,8 @@ namespace SIPSorceryMedia.FFmpeg
 
         public unsafe FFmpegVideoDecoder(string url, AVInputFormat* inputFormat, bool repeat = false, bool isCamera = false)
         {
+            FFmpegInit.EnsureBinariesRegistered();
+
             _sourceUrl = url;
 
             _inputFormat = inputFormat;

--- a/src/SIPSorceryMedia.FFmpeg/FFmpegVideoEncoder.cs
+++ b/src/SIPSorceryMedia.FFmpeg/FFmpegVideoEncoder.cs
@@ -17,6 +17,12 @@ namespace SIPSorceryMedia.FFmpeg
         // it via the encoderOptions dictionary ("cpu-used"), which is applied after this default.
         private const string DEFAULT_LIBVPX_REALTIME_CPU_USED = "5";
 
+        /// <summary>
+        /// The threshold frame rate at which to use a key frame rate of 1 (every frame is a key frame).
+        /// This is to avoid the encoder lagging behind when the frame rate is very low.
+        /// </summary>
+        private const int ALL_KEY_FRAMES_FPS_THRESHOLD = 5;
+
         private static readonly List<VideoFormat> _supportedFormats = Helper.GetSupportedVideoFormats();
 
         public List<VideoFormat> SupportedFormats
@@ -320,7 +326,7 @@ namespace SIPSorceryMedia.FFmpeg
                     _encoderContext->thread_count = _thread_count ?? 0;
 
                     // Set Key frame interval
-                    _encoderContext->gop_size = (fps < 5) ? 1 : fps;
+                    _encoderContext->gop_size = (fps < ALL_KEY_FRAMES_FPS_THRESHOLD) ? 1 : fps;
 
                     try
                     {

--- a/src/SIPSorceryMedia.FFmpeg/FFmpegVideoEncoder.cs
+++ b/src/SIPSorceryMedia.FFmpeg/FFmpegVideoEncoder.cs
@@ -267,152 +267,166 @@ namespace SIPSorceryMedia.FFmpeg
 
         public void InitialiseEncoder(AVCodecID codecID, int width, int height, int fps)
         {
-            if (!_isEncoderInitialised)
+            try
             {
-                _codecID = codecID;
-
-                var codec = GetCodec(codecID);
-                if (codec == null)
+                if (!_isEncoderInitialised)
                 {
-                    // A null codec means the loaded FFmpeg build has no encoder for this codec
-                    // (e.g. H264/H265 when built without libx264/libx265). Check before
-                    // dereferencing codec->name below so this surfaces as a clear, actionable
-                    // error rather than a NullReferenceException.
-                    throw new ApplicationException(
-                        $"The loaded FFmpeg build does not provide an encoder for {codecID}. " +
-                        $"For H264/H265 this usually means FFmpeg was built without libx264/libx265; " +
-                        $"verify with 'ffmpeg -encoders' or select a codec the build supports (e.g. VP8).");
-                }
+                    _codecID = codecID;
 
-                var cdcname = GetNameString(codec->name);
-                //var encOpts = GetCodecOptions(cdcname);
-
-                _encoderContext = ffmpeg.avcodec_alloc_context3(codec);
-                if (_encoderContext == null)
-                {
-                    throw new ApplicationException("Failed to allocate encoder codec context.");
-                }
-
-                _encoderContext->width = width;
-                _encoderContext->height = height;
-                _encoderContext->time_base.den = fps;
-                _encoderContext->time_base.num = 1;
-                _encoderContext->framerate.den = 1;
-                _encoderContext->framerate.num = fps;
-
-                var supportedPixFmts = GetSupportedPixelFormats(_encoderContext, codec);
-                if (supportedPixFmts.Length == 0)
-                {
-                    throw new ApplicationException($"Encoder {cdcname} does not report any supported pixel formats.");
-                }
-
-                _encoderContext->pix_fmt = _negotiatedPixFmt ?? supportedPixFmts[0];
-
-                if (_bit_rate != null) { _encoderContext->bit_rate = (long)_bit_rate; }
-                if (_bit_rate_tolerance != null) { _encoderContext->bit_rate_tolerance = (int)_bit_rate_tolerance; }
-                if (_rc_min_rate != null) { _encoderContext->rc_min_rate = (long)_rc_min_rate; }
-                if (_rc_max_rate != null) { _encoderContext->rc_max_rate = (long)_rc_max_rate; }
-                // Default to auto (0) so encoding uses all available cores; callers can pin a specific
-                // count via SetThreadCount. Single threaded (the libavcodec default if left unset) is far
-                // too slow at higher resolutions.
-                _encoderContext->thread_count = _thread_count ?? 0;
-
-                // Set Key frame interval
-                if (fps < 5)
-                {
-                    _encoderContext->gop_size = 1;
-                }
-                else
-                {
-                    _encoderContext->gop_size = fps;
-                }
-
-                try
-                {
-                    // Real-time oriented defaults for the common encoders: a fast preset / cpu-used,
-                    // low-latency tuning and (via thread_count above) multi-threading. These suit the
-                    // typical WebRTC/live use case; callers wanting different trade-offs override them
-                    // through encoderOptions, which are applied after this block.
-                    switch (cdcname)
+                    var codec = GetCodec(codecID);
+                    if (codec == null)
                     {
-                        case "libx264":
-                            ffmpeg.av_opt_set(_encoderContext->priv_data, "profile", "baseline", 0).ThrowExceptionIfError();
-                            ffmpeg.av_opt_set(_encoderContext->priv_data, "preset", "veryfast", 0).ThrowExceptionIfError();
-                            ffmpeg.av_opt_set(_encoderContext->priv_data, "tune", "zerolatency", 0).ThrowExceptionIfError();
-                            break;
-                        case "h264_qsv":
-                            ffmpeg.av_opt_set(_encoderContext->priv_data, "profile", "66" /* baseline */, 0).ThrowExceptionIfError();
-                            ffmpeg.av_opt_set(_encoderContext->priv_data, "preset", "7" /* veryfast */, 0).ThrowExceptionIfError();
-                            break;
-                        case "libx265":
-                            ffmpeg.av_opt_set(_encoderContext->priv_data, "preset", "ultrafast", 0).ThrowExceptionIfError();
-                            ffmpeg.av_opt_set(_encoderContext->priv_data, "tune", "zerolatency", 0).ThrowExceptionIfError();
-                            break;
-                        case "libvpx":
-                            ffmpeg.av_opt_set(_encoderContext->priv_data, "quality", "realtime", 0).ThrowExceptionIfError();
-                            ffmpeg.av_opt_set(_encoderContext->priv_data, "cpu-used", DEFAULT_LIBVPX_REALTIME_CPU_USED, 0).ThrowExceptionIfError();
-                            break;
-                        case "libvpx-vp9":
-                            ffmpeg.av_opt_set(_encoderContext->priv_data, "quality", "realtime", 0).ThrowExceptionIfError();
-                            // VP9 realtime cpu-used range is 0-9 (higher is faster); row-mt enables
-                            // tile-row multi-threading which is what makes VP9 keep up at high rates.
-                            ffmpeg.av_opt_set(_encoderContext->priv_data, "cpu-used", "8", 0).ThrowExceptionIfError();
-                            ffmpeg.av_opt_set(_encoderContext->priv_data, "row-mt", "1", 0).ThrowExceptionIfError();
-                            break;
-                        case "libaom-av1":
-                            // libaom's default (good/best) is far too slow for live use; usage=realtime
-                            // plus a high cpu-used (0-11 in realtime, higher is faster) and row-mt makes it
-                            // usable, though it is still the slowest of the software encoders.
-                            ffmpeg.av_opt_set(_encoderContext->priv_data, "usage", "realtime", 0).ThrowExceptionIfError();
-                            ffmpeg.av_opt_set(_encoderContext->priv_data, "cpu-used", "8", 0).ThrowExceptionIfError();
-                            ffmpeg.av_opt_set(_encoderContext->priv_data, "row-mt", "1", 0).ThrowExceptionIfError();
-                            break;
-                        case "libsvtav1":
-                            // SVT-AV1 is the realtime-oriented AV1 encoder. preset 0-13 (higher is faster);
-                            // the high presets plus a low-latency, low-delay prediction structure suit live.
-                            // SVT-AV1's low-delay structure does NOT support VBR rate control, so when a
-                            // target bitrate is set the rate control must be CBR (rc=2); otherwise it errors
-                            // ("VBR Rate control is currently not supported for LOW_DELAY") and produces no
-                            // output. With no bitrate the default constant-quality mode is used, which
-                            // low-delay does support.
-                            ffmpeg.av_opt_set(_encoderContext->priv_data, "preset", "11", 0).ThrowExceptionIfError();
-                            ffmpeg.av_opt_set(_encoderContext->priv_data, "svtav1-params",
-                                _encoderContext->bit_rate > 0 ? "lp=0:pred-struct=1:rc=2" : "lp=0:pred-struct=1", 0).ThrowExceptionIfError();
-                            break;
-                        case "librav1e":
-                            // rav1e exposes speed 0-10 (higher is faster); use a fast, low-latency setting.
-                            ffmpeg.av_opt_set(_encoderContext->priv_data, "speed", "10", 0).ThrowExceptionIfError();
-                            ffmpeg.av_opt_set(_encoderContext->priv_data, "low_latency", "true", 0).ThrowExceptionIfError();
-                            break;
-                        default:
-                            break;
+                        // A null codec means the loaded FFmpeg build has no encoder for this codec
+                        // (e.g. H264/H265 when built without libx264/libx265). Check before
+                        // dereferencing codec->name below so this surfaces as a clear, actionable
+                        // error rather than a NullReferenceException.
+                        throw new ApplicationException(
+                            $"The loaded FFmpeg build does not provide an encoder for {codecID}. " +
+                            $"For H264/H265 this usually means FFmpeg was built without libx264/libx265; " +
+                            $"verify with 'ffmpeg -encoders' or select a codec the build supports (e.g. VP8).");
+                    }
+
+                    var cdcname = GetNameString(codec->name);
+                    //var encOpts = GetCodecOptions(cdcname);
+
+                    _encoderContext = ffmpeg.avcodec_alloc_context3(codec);
+                    if (_encoderContext == null)
+                    {
+                        throw new ApplicationException("Failed to allocate encoder codec context.");
+                    }
+
+                    _encoderContext->width = width;
+                    _encoderContext->height = height;
+                    _encoderContext->time_base.den = fps;
+                    _encoderContext->time_base.num = 1;
+                    _encoderContext->framerate.den = 1;
+                    _encoderContext->framerate.num = fps;
+
+                    var supportedPixFmts = GetSupportedPixelFormats(_encoderContext, codec);
+                    if (supportedPixFmts.Length == 0)
+                    {
+                        throw new ApplicationException($"Encoder {cdcname} does not report any supported pixel formats.");
+                    }
+
+                    _encoderContext->pix_fmt = _negotiatedPixFmt ?? supportedPixFmts[0];
+
+                    if (_bit_rate != null) { _encoderContext->bit_rate = (long)_bit_rate; }
+                    if (_bit_rate_tolerance != null) { _encoderContext->bit_rate_tolerance = (int)_bit_rate_tolerance; }
+                    if (_rc_min_rate != null) { _encoderContext->rc_min_rate = (long)_rc_min_rate; }
+                    if (_rc_max_rate != null) { _encoderContext->rc_max_rate = (long)_rc_max_rate; }
+                    // Default to auto (0) so encoding uses all available cores; callers can pin a specific
+                    // count via SetThreadCount. Single threaded (the libavcodec default if left unset) is far
+                    // too slow at higher resolutions.
+                    _encoderContext->thread_count = _thread_count ?? 0;
+
+                    // Set Key frame interval
+                    if (fps < 5)
+                    {
+                        _encoderContext->gop_size = 1;
+                    }
+                    else
+                    {
+                        _encoderContext->gop_size = fps;
+                    }
+
+                    try
+                    {
+                        // Real-time oriented defaults for the common encoders: a fast preset / cpu-used,
+                        // low-latency tuning and (via thread_count above) multi-threading. These suit the
+                        // typical WebRTC/live use case; callers wanting different trade-offs override them
+                        // through encoderOptions, which are applied after this block.
+                        switch (cdcname)
+                        {
+                            case "libx264":
+                                ffmpeg.av_opt_set(_encoderContext->priv_data, "profile", "baseline", 0).ThrowExceptionIfError();
+                                ffmpeg.av_opt_set(_encoderContext->priv_data, "preset", "veryfast", 0).ThrowExceptionIfError();
+                                ffmpeg.av_opt_set(_encoderContext->priv_data, "tune", "zerolatency", 0).ThrowExceptionIfError();
+                                break;
+                            case "h264_qsv":
+                                ffmpeg.av_opt_set(_encoderContext->priv_data, "profile", "66" /* baseline */, 0).ThrowExceptionIfError();
+                                ffmpeg.av_opt_set(_encoderContext->priv_data, "preset", "7" /* veryfast */, 0).ThrowExceptionIfError();
+                                break;
+                            case "libx265":
+                                ffmpeg.av_opt_set(_encoderContext->priv_data, "preset", "ultrafast", 0).ThrowExceptionIfError();
+                                ffmpeg.av_opt_set(_encoderContext->priv_data, "tune", "zerolatency", 0).ThrowExceptionIfError();
+                                break;
+                            case "libvpx":
+                                ffmpeg.av_opt_set(_encoderContext->priv_data, "quality", "realtime", 0).ThrowExceptionIfError();
+                                ffmpeg.av_opt_set(_encoderContext->priv_data, "cpu-used", DEFAULT_LIBVPX_REALTIME_CPU_USED, 0).ThrowExceptionIfError();
+                                break;
+                            case "libvpx-vp9":
+                                ffmpeg.av_opt_set(_encoderContext->priv_data, "quality", "realtime", 0).ThrowExceptionIfError();
+                                // VP9 realtime cpu-used range is 0-9 (higher is faster); row-mt enables
+                                // tile-row multi-threading which is what makes VP9 keep up at high rates.
+                                ffmpeg.av_opt_set(_encoderContext->priv_data, "cpu-used", "8", 0).ThrowExceptionIfError();
+                                ffmpeg.av_opt_set(_encoderContext->priv_data, "row-mt", "1", 0).ThrowExceptionIfError();
+                                break;
+                            case "libaom-av1":
+                                // libaom's default (good/best) is far too slow for live use; usage=realtime
+                                // plus a high cpu-used (0-11 in realtime, higher is faster) and row-mt makes it
+                                // usable, though it is still the slowest of the software encoders.
+                                ffmpeg.av_opt_set(_encoderContext->priv_data, "usage", "realtime", 0).ThrowExceptionIfError();
+                                ffmpeg.av_opt_set(_encoderContext->priv_data, "cpu-used", "8", 0).ThrowExceptionIfError();
+                                ffmpeg.av_opt_set(_encoderContext->priv_data, "row-mt", "1", 0).ThrowExceptionIfError();
+                                break;
+                            case "libsvtav1":
+                                // SVT-AV1 is the realtime-oriented AV1 encoder. preset 0-13 (higher is faster);
+                                // the high presets plus a low-latency, low-delay prediction structure suit live.
+                                // SVT-AV1's low-delay structure does NOT support VBR rate control, so when a
+                                // target bitrate is set the rate control must be CBR (rc=2); otherwise it errors
+                                // ("VBR Rate control is currently not supported for LOW_DELAY") and produces no
+                                // output. With no bitrate the default constant-quality mode is used, which
+                                // low-delay does support.
+                                ffmpeg.av_opt_set(_encoderContext->priv_data, "preset", "11", 0).ThrowExceptionIfError();
+                                ffmpeg.av_opt_set(_encoderContext->priv_data, "svtav1-params",
+                                    _encoderContext->bit_rate > 0 ? "lp=0:pred-struct=1:rc=2" : "lp=0:pred-struct=1", 0).ThrowExceptionIfError();
+                                break;
+                            case "librav1e":
+                                // rav1e exposes speed 0-10 (higher is faster); use a fast, low-latency setting.
+                                ffmpeg.av_opt_set(_encoderContext->priv_data, "speed", "10", 0).ThrowExceptionIfError();
+                                ffmpeg.av_opt_set(_encoderContext->priv_data, "low_latency", "true", 0).ThrowExceptionIfError();
+                                break;
+                            default:
+                                break;
+                        }
+                    }
+                    catch (ApplicationException ex)
+                    {
+                        logger.LogCritical(ex, "Failed to set default encoder options for codec {name}. {msg}", cdcname, ex.Message);
+                        throw;
+                    }
+
+                    foreach (var option in _codecOptions)
+                    {
+                        var ok = ffmpeg.av_opt_set(_encoderContext->priv_data, option.Key, option.Value, ffmpeg.AV_OPT_SEARCH_CHILDREN);
+                        if (ok < 0)
+                        {
+                            logger.LogWarning("Failed to set encoder option \"{key}\"=\"{val}\", Skipping this option. {msg}", option.Key, option.Value, FFmpegInit.av_strerror(ok));
+                        }
+                    }
+
+                    ffmpeg.avcodec_open2(_encoderContext, codec, null).ThrowExceptionIfError();
+
+                    logger.LogDebug("Successfully initialised ffmpeg based image encoder: CodecId:[{id}] - Name:[{name}] - {w}:{h} - {fps} Fps - {fmt}",
+                        codecID, GetNameString(codec->name), width, height, fps, _encoderContext->pix_fmt);
+
+                    // Only mark initialised once the context is fully built and opened. Setting this
+                    // earlier means a failure part-way through latches a half-initialised state, and
+                    // every later Encode call then dereferences the null/unopened context (a repeating
+                    // NullReferenceException) instead of surfacing the real error.
+                    _isEncoderInitialised = true;
+                }
+            }
+            finally
+            {
+                if (!_isEncoderInitialised && _encoderContext != null)
+                {
+                    // IF the encoder failed to initialise, free the context so a later attempt can try again.
+                    fixed (AVCodecContext** pCtx = &_encoderContext)
+                    {
+                        ffmpeg.avcodec_free_context(pCtx);
                     }
                 }
-                catch (ApplicationException ex)
-                {
-                    logger.LogCritical(ex, "Failed to set default encoder options for codec {name}. {msg}", cdcname, ex.Message);
-                    throw;
-                }
-
-                foreach (var option in _codecOptions)
-                {
-                    var ok = ffmpeg.av_opt_set(_encoderContext->priv_data, option.Key, option.Value, ffmpeg.AV_OPT_SEARCH_CHILDREN);
-                    if (ok < 0)
-                    {
-                        logger.LogWarning("Failed to set encoder option \"{key}\"=\"{val}\", Skipping this option. {msg}", option.Key, option.Value, FFmpegInit.av_strerror(ok));
-                    }
-                }
-
-                ffmpeg.avcodec_open2(_encoderContext, codec, null).ThrowExceptionIfError();
-
-                logger.LogDebug("Successfully initialised ffmpeg based image encoder: CodecId:[{id}] - Name:[{name}] - {w}:{h} - {fps} Fps - {fmt}",
-                    codecID, GetNameString(codec->name), width, height, fps, _encoderContext->pix_fmt);
-
-                // Only mark initialised once the context is fully built and opened. Setting this
-                // earlier means a failure part-way through latches a half-initialised state, and
-                // every later Encode call then dereferences the null/unopened context (a repeating
-                // NullReferenceException) instead of surfacing the real error.
-                _isEncoderInitialised = true;
             }
         }
 

--- a/src/SIPSorceryMedia.FFmpeg/FFmpegVideoEncoder.cs
+++ b/src/SIPSorceryMedia.FFmpeg/FFmpegVideoEncoder.cs
@@ -293,7 +293,6 @@ namespace SIPSorceryMedia.FFmpeg
                     }
 
                     var cdcname = GetNameString(codec->name);
-                    //var encOpts = GetCodecOptions(cdcname);
 
                     _encoderContext = ffmpeg.avcodec_alloc_context3(codec);
                     if (_encoderContext == null)

--- a/src/SIPSorceryMedia.FFmpeg/FFmpegVideoEncoder.cs
+++ b/src/SIPSorceryMedia.FFmpeg/FFmpegVideoEncoder.cs
@@ -259,15 +259,10 @@ namespace SIPSorceryMedia.FFmpeg
 
         private Dictionary<string, string> GetCodecOptions(string? name)
         {
-            if (!string.IsNullOrWhiteSpace(name)
+            return (!string.IsNullOrWhiteSpace(name)
                 && (_codecOptionsByName?.TryGetValue(name!, out var opt) ?? false))
-            {
-                return opt;
-            }
-            else
-            {
-                return _codecOptions;
-            }
+                ? opt
+                : _codecOptions;
         }
 
         public void InitialiseEncoder(AVCodecID codecID, int width, int height, int fps)

--- a/src/SIPSorceryMedia.FFmpeg/FFmpegVideoEncoder.cs
+++ b/src/SIPSorceryMedia.FFmpeg/FFmpegVideoEncoder.cs
@@ -320,14 +320,7 @@ namespace SIPSorceryMedia.FFmpeg
                     _encoderContext->thread_count = _thread_count ?? 0;
 
                     // Set Key frame interval
-                    if (fps < 5)
-                    {
-                        _encoderContext->gop_size = 1;
-                    }
-                    else
-                    {
-                        _encoderContext->gop_size = fps;
-                    }
+                    _encoderContext->gop_size = (fps < 5) ? 1 : fps;
 
                     try
                     {

--- a/src/SIPSorceryMedia.FFmpeg/FFmpegVideoEncoder.cs
+++ b/src/SIPSorceryMedia.FFmpeg/FFmpegVideoEncoder.cs
@@ -116,7 +116,9 @@ namespace SIPSorceryMedia.FFmpeg
 
             var decodedFrames = DecodeFaster(codecID.Value, encodedSample, out int width, out int height);
             if (decodedFrames != null && decodedFrames.Count > 0)
+            {
                 return decodedFrames;
+            }
 
             return new List<RawImage>();
         }
@@ -170,7 +172,9 @@ namespace SIPSorceryMedia.FFmpeg
             (_specificEncoders ??= [])[cdc] = (IntPtr)codec;
 
             if (opts != null)
+            {
                 (_codecOptionsByName ??= [])[name] = opts;
+            }
 
             return codec != null;
         }
@@ -178,7 +182,9 @@ namespace SIPSorceryMedia.FFmpeg
         private AVCodec* GetCodec(AVCodecID codecID, string? wrapName, bool isEncoder = true)
         {
             if (wrapName == null)
+            {
                 return null;
+            }
 
             IntPtr? iterator = null;
             var cdc = ffmpeg.av_codec_iterate((void**)&iterator);
@@ -190,15 +196,19 @@ namespace SIPSorceryMedia.FFmpeg
                         || (!isEncoder && ffmpeg.av_codec_is_decoder(cdc) != 0)
                         )
                     )
+                {
                     break;
+                }
 
                 cdc = ffmpeg.av_codec_iterate((void**)&iterator);
             }
 
             (_specificEncoders ??= [])[codecID] = (IntPtr)cdc;
-            
+
             if (cdc == null)
+            {
                 logger.LogWarning("Codec not found for {id} with wrapper {wrap}", codecID, _wrapName);
+            }
 
             return cdc;
         }
@@ -208,7 +218,9 @@ namespace SIPSorceryMedia.FFmpeg
             AVCodec* codec = null;
 
             if (_specificEncoders?.TryGetValue(codecID, out var cdc) ?? false)
+            {
                 codec = (AVCodec*)cdc;
+            }
 
             if (codec == null)
             {
@@ -247,11 +259,15 @@ namespace SIPSorceryMedia.FFmpeg
 
         private Dictionary<string, string> GetCodecOptions(string? name)
         {
-            if (!string.IsNullOrWhiteSpace(name) 
+            if (!string.IsNullOrWhiteSpace(name)
                 && (_codecOptionsByName?.TryGetValue(name!, out var opt) ?? false))
+            {
                 return opt;
+            }
             else
+            {
                 return _codecOptions;
+            }
         }
 
         public void InitialiseEncoder(AVCodecID codecID, int width, int height, int fps)
@@ -274,7 +290,7 @@ namespace SIPSorceryMedia.FFmpeg
                 }
 
                 var cdcname = GetNameString(codec->name);
-                var encOpts = GetCodecOptions(cdcname);
+                //var encOpts = GetCodecOptions(cdcname);
 
                 _encoderContext = ffmpeg.avcodec_alloc_context3(codec);
                 if (_encoderContext == null)
@@ -289,12 +305,18 @@ namespace SIPSorceryMedia.FFmpeg
                 _encoderContext->framerate.den = 1;
                 _encoderContext->framerate.num = fps;
 
-                _encoderContext->pix_fmt = _negotiatedPixFmt ?? codec->pix_fmts[0];
+                var supportedPixFmts = GetSupportedPixelFormats(_encoderContext, codec);
+                if (supportedPixFmts.Length == 0)
+                {
+                    throw new ApplicationException($"Encoder {cdcname} does not report any supported pixel formats.");
+                }
 
-                if (_bit_rate != null) _encoderContext->bit_rate = (long)_bit_rate;
-                if (_bit_rate_tolerance != null) _encoderContext->bit_rate_tolerance = (int)_bit_rate_tolerance;
-                if (_rc_min_rate != null) _encoderContext->rc_min_rate = (long)_rc_min_rate;
-                if (_rc_max_rate != null) _encoderContext->rc_max_rate = (long)_rc_max_rate;
+                _encoderContext->pix_fmt = _negotiatedPixFmt ?? supportedPixFmts[0];
+
+                if (_bit_rate != null) { _encoderContext->bit_rate = (long)_bit_rate; }
+                if (_bit_rate_tolerance != null) { _encoderContext->bit_rate_tolerance = (int)_bit_rate_tolerance; }
+                if (_rc_min_rate != null) { _encoderContext->rc_min_rate = (long)_rc_min_rate; }
+                if (_rc_max_rate != null) { _encoderContext->rc_max_rate = (long)_rc_max_rate; }
                 // Default to auto (0) so encoding uses all available cores; callers can pin a specific
                 // count via SetThreadCount. Single threaded (the libavcodec default if left unset) is far
                 // too slow at higher resolutions.
@@ -302,9 +324,13 @@ namespace SIPSorceryMedia.FFmpeg
 
                 // Set Key frame interval
                 if (fps < 5)
+                {
                     _encoderContext->gop_size = 1;
+                }
                 else
+                {
                     _encoderContext->gop_size = fps;
+                }
 
                 try
                 {
@@ -377,7 +403,9 @@ namespace SIPSorceryMedia.FFmpeg
                 {
                     var ok = ffmpeg.av_opt_set(_encoderContext->priv_data, option.Key, option.Value, ffmpeg.AV_OPT_SEARCH_CHILDREN);
                     if (ok < 0)
+                    {
                         logger.LogWarning("Failed to set encoder option \"{key}\"=\"{val}\", Skipping this option. {msg}", option.Key, option.Value, FFmpegInit.av_strerror(ok));
+                    }
                 }
 
                 ffmpeg.avcodec_open2(_encoderContext, codec, null).ThrowExceptionIfError();
@@ -744,13 +772,17 @@ namespace SIPSorceryMedia.FFmpeg
 
         public void AdjustStream(int bitrate, int fps)
         {
-            
             if (_encoderContext == null)
+            {
                 return;
+            }
+
             lock (_encoderLock)
             {
                 if (_encoderContext == null)
+                {
                     return;
+                }
                 _encoderContext->bit_rate = bitrate;
                 _encoderContext->framerate.num = fps;
                 _encoderContext->gop_size = Math.Max(5, fps * 2);
@@ -766,9 +798,7 @@ namespace SIPSorceryMedia.FFmpeg
                         
                         break;
                 }
-                
             }
-            
         }
 
         public List<RawImage>? DecodeFaster(AVCodecID codecID, byte[] buffer, out int width, out int height)
@@ -812,7 +842,9 @@ namespace SIPSorceryMedia.FFmpeg
                 height = 0;
 
                 if (_isDecoderInitialised && _codecID != codecID)
+                {
                     ResetDecoder();
+                }
 
                 if (!_isDecoderInitialised)
                 {
@@ -965,28 +997,38 @@ namespace SIPSorceryMedia.FFmpeg
             lock (_encoderLock)
             {
                 if (_isEncoderInitialised)
+                {
                     ResetEncoder();
+                }
 
                 InitialiseEncoder(codecid, width, height, frameRate);
 
                 if (logger.IsEnabled(LogLevel.Trace))
+                {
                     logger.LogTrace("Negotiating pixel format for codec [{name}].", GetNameString(_encoderContext->codec->name));
+                }
 
                 var fmts = _encoderContext->codec->pix_fmts;
                 while (*fmts != AVPixelFormat.AV_PIX_FMT_NONE
                     && sourcePixFmts?.Length > 0 && !sourcePixFmts.Contains(*fmts))
                 {
                     if (logger.IsEnabled(LogLevel.Trace))
+                    {
                         logger.LogTrace("Skipping unsupported pixel format {fmt}.", *fmts);
+                    }
                     fmts++;
                 }
 
                 var ret = false;
                 fmt = *fmts;
                 if (fmt == AVPixelFormat.AV_PIX_FMT_NONE)
+                {
                     fmt = _encoderContext->codec->pix_fmts[0];
+                }
                 else
+                {
                     ret = true;
+                }
 
                 ResetEncoder();
                 
@@ -996,6 +1038,34 @@ namespace SIPSorceryMedia.FFmpeg
 
                 return ret;
             }
+        }
+
+        private static AVPixelFormat[] GetSupportedPixelFormats(AVCodecContext* codecContext, AVCodec* codec)
+        {
+            void* configs = null;
+            int configsCount = 0;
+
+            ffmpeg.avcodec_get_supported_config(
+                codecContext,
+                codec,
+                AVCodecConfig.AV_CODEC_CONFIG_PIX_FORMAT,
+                0,
+                &configs,
+                &configsCount).ThrowExceptionIfError();
+
+            if (configs == null || configsCount <= 0)
+            {
+                return Array.Empty<AVPixelFormat>();
+            }
+
+            var pixFmts = (AVPixelFormat*)configs;
+            var result = new AVPixelFormat[configsCount];
+            for (int i = 0; i < configsCount; i++)
+            {
+                result[i] = pixFmts[i];
+            }
+
+            return result;
         }
 
         private static string? GetNameString(byte* name) => Marshal.PtrToStringAnsi((IntPtr)name);

--- a/src/SIPSorceryMedia.FFmpeg/FFmpegVideoEncoder.cs
+++ b/src/SIPSorceryMedia.FFmpeg/FFmpegVideoEncoder.cs
@@ -65,6 +65,7 @@ namespace SIPSorceryMedia.FFmpeg
 
         public FFmpegVideoEncoder(Dictionary<string, string>? encoderOptions = null, AVHWDeviceType HWDeviceType = AVHWDeviceType.AV_HWDEVICE_TYPE_NONE)
         {
+            FFmpegInit.EnsureBinariesRegistered();
             _codecOptions = encoderOptions ?? new Dictionary<string, string>();
             _HwDeviceType = HWDeviceType;
         }
@@ -257,17 +258,23 @@ namespace SIPSorceryMedia.FFmpeg
         {
             if (!_isEncoderInitialised)
             {
-                _isEncoderInitialised = true;
                 _codecID = codecID;
-                
-                var codec = GetCodec(codecID);
-                var cdcname = GetNameString(codec->name);
-                var encOpts = GetCodecOptions(cdcname);
 
+                var codec = GetCodec(codecID);
                 if (codec == null)
                 {
-                    throw new ApplicationException($"Codec encoder could not be found for {codecID}.");
+                    // A null codec means the loaded FFmpeg build has no encoder for this codec
+                    // (e.g. H264/H265 when built without libx264/libx265). Check before
+                    // dereferencing codec->name below so this surfaces as a clear, actionable
+                    // error rather than a NullReferenceException.
+                    throw new ApplicationException(
+                        $"The loaded FFmpeg build does not provide an encoder for {codecID}. " +
+                        $"For H264/H265 this usually means FFmpeg was built without libx264/libx265; " +
+                        $"verify with 'ffmpeg -encoders' or select a codec the build supports (e.g. VP8).");
                 }
+
+                var cdcname = GetNameString(codec->name);
+                var encOpts = GetCodecOptions(cdcname);
 
                 _encoderContext = ffmpeg.avcodec_alloc_context3(codec);
                 if (_encoderContext == null)
@@ -377,6 +384,12 @@ namespace SIPSorceryMedia.FFmpeg
 
                 logger.LogDebug("Successfully initialised ffmpeg based image encoder: CodecId:[{id}] - Name:[{name}] - {w}:{h} - {fps} Fps - {fmt}",
                     codecID, GetNameString(codec->name), width, height, fps, _encoderContext->pix_fmt);
+
+                // Only mark initialised once the context is fully built and opened. Setting this
+                // earlier means a failure part-way through latches a half-initialised state, and
+                // every later Encode call then dereferences the null/unopened context (a repeating
+                // NullReferenceException) instead of surfacing the real error.
+                _isEncoderInitialised = true;
             }
         }
 

--- a/src/SIPSorceryMedia.FFmpeg/FFmpegVideoEndPoint.cs
+++ b/src/SIPSorceryMedia.FFmpeg/FFmpegVideoEndPoint.cs
@@ -70,6 +70,7 @@ public class FFmpegVideoEndPoint : IVideoSource, IVideoSink, IDisposable
 
     public FFmpegVideoEndPoint(Dictionary<string, string>? decoderOptions = null)
     {
+        FFmpegInit.EnsureBinariesRegistered();
         _videoFormatManager = new MediaFormatManager<VideoFormat>(_supportedFormats);
         _ffmpegEncoder = new FFmpegVideoEncoder(decoderOptions);
     }

--- a/src/SIPSorceryMedia.FFmpeg/FFmpegVideoSource.cs
+++ b/src/SIPSorceryMedia.FFmpeg/FFmpegVideoSource.cs
@@ -43,6 +43,7 @@ namespace SIPSorceryMedia.FFmpeg
 
         public FFmpegVideoSource()
         {
+            FFmpegInit.EnsureBinariesRegistered();
             _videoFormatManager = new MediaFormatManager<VideoFormat>(_supportedVideoFormats);
             _videoEncoder = new FFmpegVideoEncoder();
             path = "";

--- a/src/SIPSorceryMedia.FFmpeg/FfmpegInit.cs
+++ b/src/SIPSorceryMedia.FFmpeg/FfmpegInit.cs
@@ -142,13 +142,14 @@ namespace SIPSorceryMedia.FFmpeg
         internal static void SetFFmpegBinariesPath(string path)
         {
             ffmpeg.RootPath = path;
-            registered = true;
 
             DynamicallyLoadedBindings.ThrowErrorIfFunctionNotFound = true;
 
             try
             {
                 ffmpeg.avdevice_register_all();
+
+                registered = true;
             }
             catch (Exception e)
             {
@@ -161,14 +162,16 @@ namespace SIPSorceryMedia.FFmpeg
         internal static void RegisterFFmpegBinaries(String? libPath = null)
         {
             if (registered)
+            {
                 return;
+            }
 
             if (libPath == null)
             {
                 // search the system path, handle with and without .exe extension
                 string ffmpegExecutable = "ffmpeg";
                 string? path = Environment.GetEnvironmentVariable("PATH")?
-                    .Split([';'], StringSplitOptions.RemoveEmptyEntries)
+                    .Split([Path.PathSeparator], StringSplitOptions.RemoveEmptyEntries)
                     .Where(s => File.Exists(Path.Combine(s, ffmpegExecutable)) || File.Exists(Path.Combine(s, $"{ffmpegExecutable}.exe")))
                     .FirstOrDefault();
 

--- a/src/SIPSorceryMedia.FFmpeg/FfmpegInit.cs
+++ b/src/SIPSorceryMedia.FFmpeg/FfmpegInit.cs
@@ -108,7 +108,10 @@ namespace SIPSorceryMedia.FFmpeg
                 }
                 catch (Exception excp)
                 {
-                    logger.LogWarning("FFmpeg binaries could not be located automatically ({Message}). Call FFmpegInit.Initialise with an explicit library path.", excp.Message);
+                    registered = false;
+                    ffmpeg.RootPath = string.Empty;
+                    logger.LogWarning(excp,
+                        "FFmpeg binaries could not be located automatically. Call FFmpegInit.Initialise with an explicit library path.");
                 }
 
                 return registered;

--- a/src/SIPSorceryMedia.FFmpeg/FfmpegInit.cs
+++ b/src/SIPSorceryMedia.FFmpeg/FfmpegInit.cs
@@ -25,6 +25,7 @@ namespace SIPSorceryMedia.FFmpeg
     {
         private static ILogger logger = NullLogger.Instance;
         private static bool registered = false;
+        private static readonly object registerLock = new object();
 
         private static av_log_set_callback_callback? logCallback;
         private static String storedLogs = "";
@@ -74,6 +75,46 @@ namespace SIPSorceryMedia.FFmpeg
             ffmpeg.av_log_set_callback(logCallback);
         }
 
+        /// <summary>
+        /// Ensures the FFmpeg native binaries have been located and registered, attempting
+        /// auto-discovery if no explicit <see cref="Initialise"/> call has been made yet. This is
+        /// invoked implicitly by the FFmpeg components (encoder, sources, etc.) from their
+        /// constructors so that, when the binaries are discoverable via the system PATH or an
+        /// FFmpeg/bin/x64 folder, no explicit initialisation is required.
+        ///
+        /// Unlike <see cref="Initialise"/> this performs auto-discovery only and never throws: if
+        /// the binaries cannot be found it leaves the library unregistered and returns false, so a
+        /// subsequent explicit <see cref="Initialise"/> call with a known path can still take over.
+        /// It is safe to call repeatedly and from multiple threads; the first registration wins.
+        /// </summary>
+        /// <returns>True if the binaries are registered (now or previously), otherwise false.</returns>
+        public static bool EnsureBinariesRegistered()
+        {
+            if (registered)
+            {
+                return true;
+            }
+
+            lock (registerLock)
+            {
+                if (registered)
+                {
+                    return true;
+                }
+
+                try
+                {
+                    RegisterFFmpegBinaries();
+                }
+                catch (Exception excp)
+                {
+                    logger.LogWarning("FFmpeg binaries could not be located automatically ({Message}). Call FFmpegInit.Initialise with an explicit library path.", excp.Message);
+                }
+
+                return registered;
+            }
+        }
+
         public static void Initialise(FfmpegLogLevelEnum? logLevel = null, String? libPath = null, ILogger? appLogger = null)
         {
             if (appLogger != null)
@@ -81,7 +122,10 @@ namespace SIPSorceryMedia.FFmpeg
                 logger = appLogger;
             }
 
-            RegisterFFmpegBinaries(libPath);
+            lock (registerLock)
+            {
+                RegisterFFmpegBinaries(libPath);
+            }
 
             if (logger.IsEnabled(LogLevel.Information))
             {


### PR DESCRIPTION
It's common to foget to call the FFmpg init method. In most cases it can be done implicily and this PR adds support for that. An explicit call can still be used if the FFmpeg path is non-standard. Some additional error handling has also been added to assist in dealing with cases where the FFmpeg install does not support the requested codec.