### PR TITLE
Fix (MediaStream.cs + RTCPeerConnection.cs)

### DIFF
--- a/src/SIPSorcery/net/RTP/Streams/MediaStream.cs
+++ b/src/SIPSorcery/net/RTP/Streams/MediaStream.cs
@@ -410,7 +410,7 @@ namespace SIPSorcery.Net
 
         protected void SendRtpRaw(ArraySegment<byte> data, uint timestamp, int markerBit, int payloadType, Boolean checkDone, ushort? seqNum = null)
         {
-            if (checkDone || CheckIfCanSendRtpRaw())
+            if (HasRtpChannel() && (checkDone || CheckIfCanSendRtpRaw()))
             {
                 ProtectRtpPacket protectRtpPacket = SecureContext?.ProtectRtpPacket;
                 int srtpProtectionLength = (protectRtpPacket != null) ? RTPSession.SRTP_MAX_PREFIX_LENGTH : 0;
@@ -643,7 +643,7 @@ namespace SIPSorcery.Net
                 logger.LogWarning("SendRtcpReport cannot be called on a secure session before calling SetSecurityContext.");
                 return false;
             }
-            else if (ControlDestinationEndPoint != null)
+            else if (HasRtpChannel() && ControlDestinationEndPoint != null)
             {
                 //logger.LogDebug("SendRtcpReport: {ReportBytes}", reportBytes.HexStr());
 

--- a/src/SIPSorcery/net/WebRTC/RTCPeerConnection.cs
+++ b/src/SIPSorcery/net/WebRTC/RTCPeerConnection.cs
@@ -870,19 +870,42 @@ namespace SIPSorcery.Net
 
                     var localHeaderExtensions = AudioStreamList[indexAudioStream].LocalTrack?.HeaderExtensions?.Values;
                     var remoteHeaderExtensions = AudioStreamList[indexAudioStream].RemoteTrack?.HeaderExtensions?.Values;
-                    if ((remoteHeaderExtensions?.Count > 0) && (localHeaderExtensions?.Count > 0))
+
+                    if (localHeaderExtensions?.Count > 0)
                     {
-                        foreach (var remoteExtension in remoteHeaderExtensions)
+                        // Do we have already some extensions set ?
+                        if (remoteHeaderExtensions is null || remoteHeaderExtensions.Count == 0)
                         {
-                            var localExtension = localHeaderExtensions.FirstOrDefault(ext => ext.MatchesExtension(remoteExtension.Uri));
-                            if ((localExtension != null) && _rtpExtensionsUsed.ContainsKey(remoteExtension.Uri))
+                            foreach (var localExtension in localHeaderExtensions)
                             {
                                 // We must ensure to use same Id by extension
-                                localExtension.Id = _rtpExtensionsUsed[remoteExtension.Uri];
-                                localExtension.Uri = remoteExtension.Uri;// Keep same Uri as remote
+                                if (_rtpExtensionsUsed.ContainsKey(localExtension.Uri))
+                                {
+                                    localExtension.Id = _rtpExtensionsUsed[localExtension.Uri];
+                                }
+                                else
+                                {
+                                    _rtpExtensionsUsed[localExtension.Uri] = localExtension.Id;
+                                }
 
                                 logger.LogDebug("[createOffer] - {Media}:[{MediaID}] - Add HeaderExtensions:[{Id} - {Uri}]", ann.Media, ann.MediaID, localExtension.Id, localExtension.Uri);
-                                ann.HeaderExtensions.Add(localExtension.Id, localExtension);
+                                ann.HeaderExtensions[localExtension.Id] = localExtension;
+                            }
+                        }
+                        else
+                        {
+                            foreach (var remoteExtension in remoteHeaderExtensions)
+                            {
+                                var localExtension = localHeaderExtensions.FirstOrDefault(ext => ext.MatchesExtension(remoteExtension.Uri));
+                                if ((localExtension != null) && _rtpExtensionsUsed.ContainsKey(remoteExtension.Uri))
+                                {
+                                    // We must ensure to use same Id by extension
+                                    localExtension.Id = _rtpExtensionsUsed[remoteExtension.Uri];
+                                    localExtension.Uri = remoteExtension.Uri;// Keep same Uri as remote
+
+                                    logger.LogDebug("[createOffer] - {Media}:[{MediaID}] - Add HeaderExtensions:[{Id} - {Uri}]", ann.Media, ann.MediaID, localExtension.Id, localExtension.Uri);
+                                    ann.HeaderExtensions.Add(localExtension.Id, localExtension);
+                                }
                             }
                         }
                     }
@@ -895,19 +918,41 @@ namespace SIPSorcery.Net
 
                     var localHeaderExtensions = VideoStreamList[indexVideoStream].LocalTrack?.HeaderExtensions?.Values;
                     var remoteHeaderExtensions = VideoStreamList[indexVideoStream].RemoteTrack?.HeaderExtensions?.Values;
-                    if ((remoteHeaderExtensions?.Count > 0) && (localHeaderExtensions?.Count > 0))
+                    if (localHeaderExtensions?.Count > 0)
                     {
-                        foreach (var remoteExtension in remoteHeaderExtensions)
+                        // Do we have already some extensions set ?
+                        if (remoteHeaderExtensions is null || remoteHeaderExtensions.Count == 0)
                         {
-                            var localExtension = localHeaderExtensions.FirstOrDefault(ext => ext.MatchesExtension(remoteExtension.Uri));
-                            if ((localExtension != null) && _rtpExtensionsUsed.ContainsKey(remoteExtension.Uri))
+                            foreach (var localExtension in localHeaderExtensions)
                             {
                                 // We must ensure to use same Id by extension
-                                localExtension.Id = _rtpExtensionsUsed[remoteExtension.Uri];
-                                localExtension.Uri = remoteExtension.Uri; // Keep same Uri as remote
+                                if (_rtpExtensionsUsed.ContainsKey(localExtension.Uri))
+                                {
+                                    localExtension.Id = _rtpExtensionsUsed[localExtension.Uri];
+                                }
+                                else
+                                {
+                                    _rtpExtensionsUsed[localExtension.Uri] = localExtension.Id;
+                                }
 
                                 logger.LogDebug("[createOffer] - {Media}:[{MediaID}] - Add HeaderExtensions:[{Id} - {Uri}]", ann.Media, ann.MediaID, localExtension.Id, localExtension.Uri);
-                                ann.HeaderExtensions.Add(localExtension.Id, localExtension);
+                                ann.HeaderExtensions[localExtension.Id] = localExtension;
+                            }
+                        }
+                        else
+                        {
+                            foreach (var remoteExtension in remoteHeaderExtensions)
+                            {
+                                var localExtension = localHeaderExtensions.FirstOrDefault(ext => ext.MatchesExtension(remoteExtension.Uri));
+                                if ((localExtension != null) && _rtpExtensionsUsed.ContainsKey(remoteExtension.Uri))
+                                {
+                                    // We must ensure to use same Id by extension
+                                    localExtension.Id = _rtpExtensionsUsed[remoteExtension.Uri];
+                                    localExtension.Uri = remoteExtension.Uri;// Keep same Uri as remote
+
+                                    logger.LogDebug("[createOffer] - {Media}:[{MediaID}] - Add HeaderExtensions:[{Id} - {Uri}]", ann.Media, ann.MediaID, localExtension.Id, localExtension.Uri);
+                                    ann.HeaderExtensions.Add(localExtension.Id, localExtension);
+                                }
                             }
                         }
                     }

--- a/src/SIPSorcery/net/WebRTC/RTCPeerConnection.cs
+++ b/src/SIPSorcery/net/WebRTC/RTCPeerConnection.cs
@@ -869,22 +869,21 @@ namespace SIPSorcery.Net
                     ann.HeaderExtensions.Clear();
 
                     var localHeaderExtensions = AudioStreamList[indexAudioStream].LocalTrack?.HeaderExtensions?.Values;
-                    if (localHeaderExtensions != null)
+                    var remoteHeaderExtensions = AudioStreamList[indexAudioStream].RemoteTrack?.HeaderExtensions?.Values;
+                    if ((remoteHeaderExtensions?.Count > 0) && (localHeaderExtensions?.Count > 0))
                     {
-                        foreach (var localExtension in localHeaderExtensions)
+                        foreach (var remoteExtension in remoteHeaderExtensions)
                         {
-                            // We must ensure to use same Id by extension
-                            if (_rtpExtensionsUsed.ContainsKey(localExtension.Uri))
+                            var localExtension = localHeaderExtensions.FirstOrDefault(ext => ext.MatchesExtension(remoteExtension.Uri));
+                            if ((localExtension != null) && _rtpExtensionsUsed.ContainsKey(remoteExtension.Uri))
                             {
-                                localExtension.Id = _rtpExtensionsUsed[localExtension.Uri];
-                            }
-                            else
-                            {
-                                _rtpExtensionsUsed[localExtension.Uri] = localExtension.Id;
-                            }
+                                // We must ensure to use same Id by extension
+                                localExtension.Id = _rtpExtensionsUsed[remoteExtension.Uri];
+                                localExtension.Uri = remoteExtension.Uri;// Keep same Uri as remote
 
-                            logger.LogDebug("[createOffer] - {Media}:[{MediaID}] - Add HeaderExtensions:[{Id} - {Uri}]", ann.Media, ann.MediaID, localExtension.Id, localExtension.Uri);
-                            ann.HeaderExtensions[localExtension.Id] = localExtension;
+                                logger.LogDebug("[createOffer] - {Media}:[{MediaID}] - Add HeaderExtensions:[{Id} - {Uri}]", ann.Media, ann.MediaID, localExtension.Id, localExtension.Uri);
+                                ann.HeaderExtensions.Add(localExtension.Id, localExtension);
+                            }
                         }
                     }
                     indexAudioStream++;
@@ -895,22 +894,21 @@ namespace SIPSorcery.Net
                     ann.HeaderExtensions.Clear();
 
                     var localHeaderExtensions = VideoStreamList[indexVideoStream].LocalTrack?.HeaderExtensions?.Values;
-                    if (localHeaderExtensions != null)
+                    var remoteHeaderExtensions = VideoStreamList[indexVideoStream].RemoteTrack?.HeaderExtensions?.Values;
+                    if ((remoteHeaderExtensions?.Count > 0) && (localHeaderExtensions?.Count > 0))
                     {
-                        foreach (var localExtension in localHeaderExtensions)
+                        foreach (var remoteExtension in remoteHeaderExtensions)
                         {
-                            // We must ensure to use same Id by extension
-                            if (_rtpExtensionsUsed.ContainsKey(localExtension.Uri))
+                            var localExtension = localHeaderExtensions.FirstOrDefault(ext => ext.MatchesExtension(remoteExtension.Uri));
+                            if ((localExtension != null) && _rtpExtensionsUsed.ContainsKey(remoteExtension.Uri))
                             {
-                                localExtension.Id = _rtpExtensionsUsed[localExtension.Uri];
-                            }
-                            else
-                            {
-                                _rtpExtensionsUsed[localExtension.Uri] = localExtension.Id;
-                            }
+                                // We must ensure to use same Id by extension
+                                localExtension.Id = _rtpExtensionsUsed[remoteExtension.Uri];
+                                localExtension.Uri = remoteExtension.Uri; // Keep same Uri as remote
 
-                            logger.LogDebug("[createOffer] - {Media}:[{MediaID}] - Add HeaderExtensions:[{Id} - {Uri}]", ann.Media, ann.MediaID, localExtension.Id, localExtension.Uri);
-                            ann.HeaderExtensions[localExtension.Id] = localExtension;
+                                logger.LogDebug("[createOffer] - {Media}:[{MediaID}] - Add HeaderExtensions:[{Id} - {Uri}]", ann.Media, ann.MediaID, localExtension.Id, localExtension.Uri);
+                                ann.HeaderExtensions.Add(localExtension.Id, localExtension);
+                            }
                         }
                     }
                     indexVideoStream++;
@@ -1511,8 +1509,14 @@ namespace SIPSorcery.Net
             }
             return Task.Run(async () =>
             {
-                //Call Renegotiation Delayed
-                await Task.Delay(RENEGOTIATION_CALL_DELAY, token);
+                try
+                {
+                    //Call Renegotiation Delayed
+                    await Task.Delay(RENEGOTIATION_CALL_DELAY, token);
+                }
+                catch (TaskCanceledException)
+                {
+                }
 
                 //Prevent continue with cancellation requested
                 if (token.IsCancellationRequested)
@@ -1544,6 +1548,7 @@ namespace SIPSorcery.Net
                         _cancellationSource.Cancel();
                     }
 
+                    _cancellationSource.Dispose();
                     _cancellationSource = null;
                 }
             }


### PR DESCRIPTION
MediaStream.cs:
- prevent crash when rtpChannel object is used for an inactive track

RTCPeerConnection.cs:
- dispose _cancellationSource and catch TaskCanceledException
- bad logic use in createoffer() to set correct RTP extension id. Re-use the same on used in cerateAnswer() 
   => can easily be reproduced when using RTP Exnetions (audio + video) with Firefox: (audio call then add video media)