### PR TITLE
Unsubscribe `VoIPMediaSession` from `SendAudio` on close.

### DIFF
--- a/src/SIPSorcery/app/Media/VoIPMediaSession.cs
+++ b/src/SIPSorcery/app/Media/VoIPMediaSession.cs
@@ -293,6 +293,7 @@ namespace SIPSorcery.Media
 
                 if (Media.AudioSource != null)
                 {
+                    Media.AudioSource.OnAudioSourceEncodedSample -= SendAudio;
                     await Media.AudioSource.CloseAudio().ConfigureAwait(false);
                 }
 


### PR DESCRIPTION
Ensures VoIPMediaSession stops receiving SendAudio events after it is closed.

For context, the event is subscribed to on line 130:
```
Media.AudioSource.OnAudioSourceEncodedSample += SendAudio;
```