### PR TITLE
Fix SCTP zero-length chunk parser infinite loop

### DIFF
--- a/src/SIPSorcery/net/SCTP/SctpPacket.cs
+++ b/src/SIPSorcery/net/SCTP/SctpPacket.cs
@@ -184,7 +184,23 @@ namespace SIPSorcery.Net
 
             while (posn < length)
             {
+                if (length - posn < SctpChunk.SCTP_CHUNK_HEADER_LENGTH)
+                {
+                    throw new ApplicationException("The SCTP packet buffer was too short to contain a complete chunk header.");
+                }
+
                 byte chunkType = buffer[posn];
+
+                uint chunkLength = SctpChunk.GetChunkLengthFromHeader(buffer, posn, false);
+                if (chunkLength < SctpChunk.SCTP_CHUNK_HEADER_LENGTH)
+                {
+                    throw new ApplicationException($"The SCTP chunk length was invalid. The minimum length is {SctpChunk.SCTP_CHUNK_HEADER_LENGTH} bytes but the packet specified {chunkLength} bytes.");
+                }
+
+                if (posn + chunkLength > length)
+                {
+                    throw new ApplicationException($"The SCTP packet buffer was too short. Required {chunkLength} chunk bytes but only {length - posn} available.");
+                }
 
                 if (Enum.IsDefined(typeof(SctpChunkType), chunkType))
                 {
@@ -216,7 +232,7 @@ namespace SIPSorcery.Net
                     break;
                 }
 
-                posn += (int)SctpChunk.GetChunkLengthFromHeader(buffer, posn, true);
+                posn += (int)SctpPadding.PadTo4ByteBoundary((int)chunkLength);
             }
 
             return (chunks, unrecognisedChunks);

--- a/test/unit/net/SCTP/SctpPacketUnitTest.cs
+++ b/test/unit/net/SCTP/SctpPacketUnitTest.cs
@@ -13,7 +13,9 @@
 // BSD 3-Clause "New" or "Revised" License, see included LICENSE.md file.
 //-----------------------------------------------------------------------------
 
+using System;
 using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using SIPSorcery.Sys;
 using SIPSorcery.UnitTests;
@@ -200,6 +202,30 @@ namespace SIPSorcery.Net.UnitTests
             var cookieAckChunk = sctpPkt.Chunks.First();
 
             Assert.Equal(4, cookieAckChunk.GetChunkLength(true));
+        }
+
+        /// <summary>
+        /// Tests that a recognised SCTP chunk with a declared length of zero is rejected rather
+        /// than sending the chunk parser into an infinite loop. The chunk walking logic advances
+        /// the buffer cursor by the declared chunk length, so a zero length previously left the
+        /// cursor stationary and the parse loop spinning forever. This packet is the valid
+        /// COOKIE ACK from <see cref="ParseUsrSctpCookieAckPacket"/> with the chunk length field
+        /// zeroed. Reported by Team Atlanta.
+        /// </summary>
+        [Fact]
+        public async Task ParseZeroLengthChunkDoesNotHang()
+        {
+            byte[] buffer = {
+                0x00, 0x07, 0xdf, 0x90, 0xe3, 0x1c, 0x55, 0x36, 0xb2, 0x04, 0xdf, 0x21, 0x0b, 0x00, 0x00, 0x00 };
+
+            // Run the parse on a worker task with a timeout so that a regression manifests as a
+            // test failure rather than a hung test run.
+            var parseTask = Task.Run(() => SctpPacket.Parse(buffer, 0, buffer.Length));
+
+            var completed = await Task.WhenAny(parseTask, Task.Delay(TimeSpan.FromSeconds(2)));
+
+            Assert.True(completed == parseTask, "SctpPacket.Parse did not return, the zero-length chunk parser hang has regressed.");
+            await Assert.ThrowsAsync<ApplicationException>(() => parseTask);
         }
 
         /// <summary>


### PR DESCRIPTION
A recognised SCTP chunk with a declared length of zero sent the chunk walking loop in SctpPacket.ParseChunks into an infinite (hot-spinning) loop: the cursor is advanced by the declared chunk length, so a zero length left it stationary and the loop never terminated. A remote peer delivering a checksum-valid SCTP-over-UDP (SctpUdpTransport) or SCTP-over-DTLS/WebRTC (RTCSctpTransport) packet could pin the receive thread at 100% CPU, a denial of service for that SCTP session.

Enforce the SCTP minimum chunk length (and buffer bounds) before advancing the cursor. Malformed chunks now throw ApplicationException, which both receive loops already treat as a recoverable, per-packet parse failure. Same length-precheck class as CVE-2021-3655.

Reported by Team Atlanta.