### PR TITLE
Add digest store support for SIP registration authentication

### DIFF
--- a/src/SIPSorcery.Cli.Common/HTTPDigestStore.cs
+++ b/src/SIPSorcery.Cli.Common/HTTPDigestStore.cs
@@ -1,0 +1,169 @@
+//-----------------------------------------------------------------------------
+// Filename: HTTPDigestStore.cs
+//
+// Description: Reads and writes the CLI digest-store file format and resolves
+// HA1 values for SIP digest authentication challenges.
+//
+// License:
+// BSD 3-Clause "New" or "Revised" License.
+//-----------------------------------------------------------------------------
+
+using SIPSorcery.SIP;
+
+namespace SIPSorcery.Cli.Common;
+
+
+/// <summary>
+/// A file-backed set of HA1 digests used by command-line SIP clients.
+/// </summary>
+public sealed class HTTPDigestStore
+{
+    public const string HA1MD5Key = "ha1_md5";
+
+    public const string HA1SHA256Key = "ha1_sha256";
+
+
+    // Static members >>
+
+    public static HTTPDigestStore NewFromPassword(string username, string realm, string password)
+    {
+        var store = new HTTPDigestStore();
+        store.CalcDigests(username, realm, password);
+        return store;
+    }
+
+    public static HTTPDigestStore ReadFromFile(string path)
+    {
+        var store = new HTTPDigestStore();
+        store.Read(path);
+        return store;
+    }
+
+    public static void WriteToFile(string path, string username, string realm, string password)
+    {
+        NewFromPassword(username, realm, password).Write(path);
+    }
+
+    /// <summary>
+    /// For SIP, RFC 8760 specifies the digest representation as ASCII characters from exactly '0123456789abcdef'.
+    /// </summary>
+    public static bool IsValidDigestValue(string value)
+    {
+        if (string.IsNullOrEmpty(value) || value.Length % 2 != 0)
+        {
+            return false;
+        }
+
+        foreach(char ch in value)
+        {
+            bool isHex = ((ch >= '0' && ch <= '9') || (ch >= 'a' && ch <= 'f'));
+            if (!isHex)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    // Public members >>
+
+    public string? HA1_MD5 { get; set; }
+
+    public string? HA1_SHA256 { get; set; }
+
+
+    // Implementation >>
+
+    /// <summary>
+    /// Resolves an HA1 digest for a challenge. This store represents one credential, so the username
+    /// and realm identify the challenge supplied to Core but are not encoded in the file format.
+    /// </summary>
+    public string? GetHA1Digest(string username, string realm, DigestAlgorithmsEnum digestAlgorithm)
+    {
+        _ = username;
+        _ = realm;
+
+        return digestAlgorithm switch
+        {
+            DigestAlgorithmsEnum.SHA256 => HA1_SHA256,
+            DigestAlgorithmsEnum.MD5 => HA1_MD5,
+            _ => null
+        };
+    }
+
+    public void CalcDigests(string username, string realm, string password)
+    {
+        if (string.IsNullOrWhiteSpace(username))
+        {
+            throw new ArgumentException("Username is required to create a digest store.", nameof(username));
+        }
+
+        if (string.IsNullOrWhiteSpace(realm))
+        {
+            throw new ArgumentException("Realm is required to create a digest store.", nameof(realm));
+        }
+
+        if (password == null)
+        {
+            throw new ArgumentException("Password is required to create a digest store.", nameof(password));
+        }
+
+        HA1_MD5 = HTTPDigest.DigestCalcHA1(username, realm, password, DigestAlgorithmsEnum.MD5);
+        HA1_SHA256 = HTTPDigest.DigestCalcHA1(username, realm, password, DigestAlgorithmsEnum.SHA256);
+    }
+
+    /// <summary>
+    /// Reads recognized values that are non-empty lowercase hexadecimal strings with an even number of characters.
+    /// It intentionally does not validate algorithm-specific digest lengths.
+    /// </summary>
+    /// <returns>Count of valid values parsed.</returns>
+    public int Read(string path)
+    {
+        int count = 0;
+        foreach (string rawLine in File.ReadLines(path))
+        {
+            string line = rawLine.Trim();
+            if (line.Length == 0)
+            {
+                continue;
+            }
+
+            int separatorIndex = line.IndexOf('=');
+            if (separatorIndex <= 0)
+            {
+                continue;
+            }
+
+            string key = line[..separatorIndex].Trim();
+            string value = line[(separatorIndex + 1)..].Trim();
+
+            if (!IsValidDigestValue(value))
+            {
+                continue;
+            }
+
+            if (key.Equals(HA1MD5Key, StringComparison.OrdinalIgnoreCase))
+            {
+                HA1_MD5 = value;
+                count++;
+            }
+            else if (key.Equals(HA1SHA256Key, StringComparison.OrdinalIgnoreCase))
+            {
+                HA1_SHA256 = value;
+                count++;
+            }
+        }
+
+        return count;
+    }
+
+    public void Write(string path)
+    {
+        string content =
+            $"{HA1MD5Key}={HA1_MD5}{Environment.NewLine}" +
+            $"{HA1SHA256Key}={HA1_SHA256}{Environment.NewLine}";
+
+        File.WriteAllText(path, content);
+    }
+}

--- a/src/SIPSorcery.Diagnostics/Commands/sip/SipDigestCommand.cs
+++ b/src/SIPSorcery.Diagnostics/Commands/sip/SipDigestCommand.cs
@@ -1,0 +1,106 @@
+﻿//-----------------------------------------------------------------------------
+// Filename: SipDigestCommand.cs
+//
+// Description: The "sipsorcery-diags sip digest" verb. Creates a digest store
+// file that SIP diagnostic commands can use instead of a clear text password.
+//
+// License:
+// BSD 3-Clause "New" or "Revised" License, see included LICENSE.md file.
+//-----------------------------------------------------------------------------
+
+using System.CommandLine;
+using SIPSorcery.SIP;
+
+namespace SIPSorcery.Diagnostics.Commands;
+
+public sealed class SipDigestCommand : CommandBase
+{
+    private sealed record DigestResult(
+        bool Success,
+        string Path,
+        string? Error);
+
+    public SipDigestCommand() : base(defaultTimeoutSeconds: 0)
+    { }
+
+    public override Command Build()
+    {
+        var usernameOption = new Option<string>("--username", "-u")
+        {
+            Description = "The SIP account username used to compute username:realm:password.",
+            Required = true
+        };
+
+        var realmOption = new Option<string>("--realm")
+        {
+            Description = "The SIP authentication realm used to compute username:realm:password.",
+            Required = true
+        };
+
+        var passwordOption = new Option<string>("--password")
+        {
+            Description = "The clear text password used to compute the digest store. It is not written to the output file.",
+            Required = true
+        };
+
+        var outOption = new Option<string>("--out")
+        {
+            Description = "The digest store file to create. Existing file will be overwritten.",
+            Required = true
+        };
+
+        var command = new Command("digest", "Create a digest store file for SIP authentication.");
+        command.Options.Add(usernameOption);
+        command.Options.Add(realmOption);
+        command.Options.Add(passwordOption);
+        command.Options.Add(outOption);
+        AddCommonOptions(command);
+
+        command.SetAction((parseResult, cancellationToken) => Task.FromResult(Run(
+            parseResult.GetValue(usernameOption)!,
+            parseResult.GetValue(realmOption)!,
+            parseResult.GetValue(passwordOption)!,
+            parseResult.GetValue(outOption)!,
+            parseResult.GetValue(JsonOption))));
+
+        return command;
+    }
+
+    private static int Run(string username, string realm, string password, string path, bool asJson)
+    {
+        try
+        {
+            HTTPDigestStore.WriteToFile(path, username, realm, password);
+
+            return WriteResult(
+                asJson,
+                new DigestResult(true, path, null),
+                ExitCodes.Ok);
+        }
+        catch (Exception excp) when (excp is ArgumentException or IOException or UnauthorizedAccessException)
+        {
+            return WriteResult(
+                asJson,
+                new DigestResult(false, path, excp.Message),
+                ExitCodes.InvalidArgument);
+        }
+    }
+
+    private static int WriteResult(bool asJson, DigestResult result, int exitCode)
+    {
+        if (asJson)
+        {
+            WriteJson(result);
+        }
+        else if (result.Success)
+        {
+            Console.WriteLine($"Created digest store file {result.Path}.");
+        }
+        else
+        {
+            Console.Error.WriteLine(result.Error);
+        }
+
+        return exitCode;
+    }
+}

--- a/src/SIPSorcery.Diagnostics/Commands/sip/SipRegisterCommand.cs
+++ b/src/SIPSorcery.Diagnostics/Commands/sip/SipRegisterCommand.cs
@@ -18,6 +18,7 @@
 
 using System.CommandLine;
 using System.Diagnostics;
+using System.Net;
 using Microsoft.Extensions.Logging;
 using SIPSorcery.SIP;
 using SIPSorcery.SIP.App;
@@ -61,6 +62,11 @@ public sealed class SipRegisterCommand : CommandBase
             Description = "The account password used to authenticate the registration."
         };
 
+        var digestStoreOption = new Option<string?>("--digest-store")
+        {
+            Description = "A digest store used to authenticate the registration instead of --password."
+        };
+
         var expiryOption = new Option<int>("--expiry")
         {
             Description = "The requested registration expiry in seconds.",
@@ -84,6 +90,7 @@ public sealed class SipRegisterCommand : CommandBase
         command.Arguments.Add(destinationArg);
         command.Options.Add(usernameOption);
         command.Options.Add(passwordOption);
+        command.Options.Add(digestStoreOption);
         command.Options.Add(expiryOption);
         command.Options.Add(durationOption);
         command.Options.Add(keepOption);
@@ -94,6 +101,7 @@ public sealed class SipRegisterCommand : CommandBase
             parseResult.GetValue(destinationArg)!,
             parseResult.GetValue(usernameOption),
             parseResult.GetValue(passwordOption),
+            parseResult.GetValue(digestStoreOption),
             parseResult.GetValue(expiryOption),
             parseResult.GetValue(durationOption),
             parseResult.GetValue(keepOption),
@@ -106,7 +114,7 @@ public sealed class SipRegisterCommand : CommandBase
         return command;
     }
 
-    private static async Task<int> RunAsync(string destination, string? username, string? password, int expiry,
+    private static async Task<int> RunAsync(string destination, string? username, string? password, string? digestFile, int expiry,
         int durationSeconds, bool keep, string? hep, int timeoutSeconds, bool asJson, bool verbose, CancellationToken ct)
     {
         using var loggerFactory = InitLogging(verbose);
@@ -117,6 +125,29 @@ public sealed class SipRegisterCommand : CommandBase
             return WriteResult(asJson,
                 new RegisterResult(false, destination, string.Empty, expiry, 0, false, parseError),
                 ExitCodes.InvalidArgument);
+        }
+
+        if (!string.IsNullOrWhiteSpace(password) && !string.IsNullOrWhiteSpace(digestFile))
+        {
+            return WriteResult(asJson,
+                new RegisterResult(false, dstUri.ToString(), string.Empty, expiry, 0, false,
+                    "Options '--password' and '--digest-store' cannot be combined."),
+                ExitCodes.InvalidArgument);
+        }
+
+        HTTPDigestStore? digestStore = null;
+        if (!string.IsNullOrWhiteSpace(digestFile))
+        {
+            try
+            {
+                digestStore = HTTPDigestStore.ReadFromFile(digestFile);
+            }
+            catch (Exception excp) when (excp is ArgumentException or IOException or UnauthorizedAccessException)
+            {
+                return WriteResult(asJson,
+                    new RegisterResult(false, dstUri.ToString(), string.Empty, expiry, 0, false, excp.Message),
+                    ExitCodes.InvalidArgument);
+            }
         }
 
         username ??= dstUri.User;
@@ -150,7 +181,31 @@ public sealed class SipRegisterCommand : CommandBase
             sipTransport.EnableTraceLogs();
         }
 
-        var regUserAgent = new SIPRegistrationUserAgent(sipTransport, username, password ?? string.Empty, registrar, expiry);
+        SIPRegistrationUserAgent regUserAgent;
+        if (digestStore != null)
+        {
+            SIPURI sipAccountAOR = dstUri.CopyOf();
+            sipAccountAOR.User = username;
+
+            // Match the simple constructor's default contact: let the transport fill in the actual address at send time.
+            SIPURI contactURI = new SIPURI(sipAccountAOR.Scheme, IPAddress.Any, 0);
+
+            regUserAgent = new SIPRegistrationUserAgent(
+                sipTransport,
+                null,
+                sipAccountAOR,
+                digestStore.GetHA1Digest,
+                username,
+                null,
+                registrar,
+                contactURI,
+                expiry,
+                null);
+        }
+        else
+        {
+            regUserAgent = new SIPRegistrationUserAgent(sipTransport, username, password ?? string.Empty, registrar, expiry);
+        }
 
         var outcome = new TaskCompletionSource<(bool Success, string? Error)>(TaskCreationOptions.RunContinuationsAsynchronously);
 

--- a/src/SIPSorcery.Diagnostics/Program.cs
+++ b/src/SIPSorcery.Diagnostics/Program.cs
@@ -40,6 +40,7 @@ sipCommand.Subcommands.Add(new SipOptionsCommand().Build());
 sipCommand.Subcommands.Add(new SipCallCommand().Build());
 sipCommand.Subcommands.Add(new SipRegisterCommand().Build());
 sipCommand.Subcommands.Add(new SipLoadCommand().Build());
+sipCommand.Subcommands.Add(new SipDigestCommand().Build());
 rootCommand.Subcommands.Add(sipCommand);
 
 var stunCommand = new Command("stun", "STUN operations: public address lookups, NAT diagnostics.");

--- a/src/SIPSorcery.Diagnostics/README.md
+++ b/src/SIPSorcery.Diagnostics/README.md
@@ -43,6 +43,10 @@ sipsorcery-diags sip call 100@pbx.example.com -u user --password pass --play ton
 sipsorcery-diags sip register sipsorcery.com -u myuser --password mypass
 sipsorcery-diags sip register tls:sip.example.com -u myuser --password mypass -d 30  # hold 30s then remove
 sipsorcery-diags sip register sipsorcery.com -u myuser --password mypass --keep      # leave registered
+sipsorcery-diags sip register sipsorcery.com -u myuser --digest-store myuser.digest
+
+# SIP digest: create a digest store file for passwordless registration.
+sipsorcery-diags sip digest --username myuser --realm sipsorcery.com --password mypass --out myuser.digest
 
 # SIP load: generate concurrent OPTIONS load and report aggregate timing/success stats.
 sipsorcery-diags sip load myserver.org -c 1000 -x 25            # 1000 requests, 25 in flight at once

--- a/src/SIPSorcery/app/SIPUserAgents/SIPRegistrationUserAgent.cs
+++ b/src/SIPSorcery/app/SIPUserAgents/SIPRegistrationUserAgent.cs
@@ -45,6 +45,7 @@ namespace SIPSorcery.SIP.App
         private SIPURI m_sipAccountAOR;
         private string m_authUsername;
         private string m_password;
+        private GetHA1DigestDelegate m_getHA1Digest;
         private string m_realm;
         private string m_registrarHost;
         private SIPURI m_contactURI;
@@ -200,6 +201,40 @@ namespace SIPSorcery.SIP.App
             m_maxRegisterAttempts = maxRegisterAttempts;
             m_exitOnUnequivocalFailure = exitOnUnequivocalFailure;
             m_exit = true;
+        }
+
+        public SIPRegistrationUserAgent(
+            SIPTransport sipTransport,
+            SIPEndPoint outboundProxy,
+            SIPURI sipAccountAOR,
+            GetHA1DigestDelegate getHA1Digest,
+            string authUsername,
+            string realm,
+            string registrarHost,
+            SIPURI contactURI,
+            int expiry,
+            string[] customHeaders,
+            int maxRegistrationAttemptTimeout = DEFAULT_MAX_REGISTRATION_ATTEMPT_TIMEOUT,
+            int registerFailureRetryInterval = DEFAULT_REGISTER_FAILURE_RETRY_INTERVAL,
+            int maxRegisterAttempts = DEFAULT_MAX_REGISTER_ATTEMPTS,
+            bool exitOnUnequivocalFailure = true)
+            : this(
+                sipTransport,
+                outboundProxy,
+                sipAccountAOR,
+                authUsername,
+                string.Empty,
+                realm,
+                registrarHost,
+                contactURI,
+                expiry,
+                customHeaders,
+                maxRegistrationAttemptTimeout,
+                registerFailureRetryInterval,
+                maxRegisterAttempts,
+                exitOnUnequivocalFailure)
+        {
+            m_getHA1Digest = getHA1Digest;
         }
 
         public void Start()
@@ -508,8 +543,37 @@ namespace SIPSorcery.SIP.App
             m_attempts++;
 
             string username = (m_authUsername != null) ? m_authUsername : m_sipAccountAOR.User;
-            var authenticatedRequest = sipTransaction.TransactionRequest.DuplicateAndAuthenticate(
-                sipResponse.Header.AuthenticationHeaders, username, m_password);
+            var challenges = sipResponse.Header.AuthenticationHeaders;
+            SIPRequest authenticatedRequest = null;
+            if (m_getHA1Digest != null)
+            {
+                // If an HA1 resolver exists, then it is the main option without fallback to a password.
+                authenticatedRequest = sipTransaction.TransactionRequest.DuplicateAndAuthenticate(challenges, username, m_getHA1Digest);
+                if (authenticatedRequest == null)
+                {
+                    logger.LogWarning("No HA1 credential is available for any of the server challenges.");
+                }
+            }
+            else if (m_password != null)
+            {
+                authenticatedRequest = sipTransaction.TransactionRequest.DuplicateAndAuthenticate(challenges, username, m_password);
+            }
+            else
+            {
+                logger.LogWarning("No password provided to respond to server challenges.");
+            }
+
+            if (authenticatedRequest == null)
+            {
+                m_exit = m_exitOnUnequivocalFailure;
+
+                logger.LogWarning("Registration unequivocal failure with {Status} for {SIPAccountAOR}. No further registration attempts will be made: {Exit}.", sipResponse.Status, m_sipAccountAOR, m_exit);
+                string reasonPhrase = (sipResponse.ReasonPhrase.IsNullOrBlank()) ? sipResponse.Status.ToString() : sipResponse.ReasonPhrase;
+                RegistrationFailed?.Invoke(m_sipAccountAOR, sipResponse, $"Registration failed with {(int)sipResponse.Status} {reasonPhrase}.");
+
+                m_waitForRegistrationMRE.Set();
+                return;
+            }
 
             SIPEndPoint registrarSIPEndPoint = m_outboundProxy;
             if (registrarSIPEndPoint == null)

--- a/src/SIPSorcery/core/SIP/SIPAuthChallenge.cs
+++ b/src/SIPSorcery/core/SIP/SIPAuthChallenge.cs
@@ -11,9 +11,9 @@
 // BSD 3-Clause "New" or "Revised" License, see included LICENSE.md file.
 //-----------------------------------------------------------------------------
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
-using SIPSorcery.SIP;
 
 namespace SIPSorcery.SIP
 {
@@ -40,7 +40,52 @@ namespace SIPSorcery.SIP
             var challenge = authenticationChallenges.First().SIPDigest.CopyOf();
             challenge.DigestAlgorithm = digestAlgorithm;
             challenge.SetCredentials(username, password,uri.ToString(), method.ToString());
+            return GetAuthenticationHeader(challenge);
+        }
 
+        /// <summary>
+        /// Attempts to generate a SIP request authentication header from a digest challenge with a resolvable HA1 digest.
+        /// </summary>
+        /// <param name="authenticationChallenges">The challenges to authenticate the request against. Typically the challenges come from a
+        /// SIP response.</param>
+        /// <param name="uri">The URI of the SIP request being authenticated.</param>
+        /// <param name="method">The method of the SIP request being authenticated.</param>
+        /// <param name="username">The username to authenticate with.</param>
+        /// <param name="getHA1Digest">Resolves an HA1 digest for a username, challenge realm and digest algorithm.
+        /// Return <c>null</c> when no credential is available for a challenge.</param>
+        /// <returns>An authentication header that can be added to a SIP header.</returns>
+        public static SIPAuthenticationHeader GetAuthenticationHeader(List<SIPAuthenticationHeader> authenticationChallenges,
+            SIPURI uri,
+            SIPMethodsEnum method,
+            string username,
+            GetHA1DigestDelegate getHA1Digest)
+        {
+            // Prefer SHA-256 when available, matching the existing stored-digest behaviour.
+            foreach (DigestAlgorithmsEnum digestAlgorithm in new[] { DigestAlgorithmsEnum.SHA256, DigestAlgorithmsEnum.MD5 })
+            {
+                foreach (SIPAuthenticationHeader authenticationChallenge in authenticationChallenges.Where(x =>
+                    (x.SIPDigest != null) &&
+                    (x.SIPDigest.DigestAlgorithm == digestAlgorithm)))
+                {
+                    SIPAuthorisationDigest challenge = authenticationChallenge.SIPDigest.CopyOf();
+                    string ha1Digest = getHA1Digest(username, challenge.Realm, challenge.DigestAlgorithm);
+
+                    if (ha1Digest == null)
+                    {
+                        continue;
+                    }
+
+                    challenge.Username = username;
+                    challenge.SetCredentials(ha1Digest, uri.ToString(), method.ToString());
+                    return GetAuthenticationHeader(challenge);
+                }
+            }
+
+            return null;
+        }
+
+        public static SIPAuthenticationHeader GetAuthenticationHeader(SIPAuthorisationDigest challenge)
+        {
             var authHeader = new SIPAuthenticationHeader(challenge);
             authHeader.SIPDigest.Response = challenge.GetDigest();
 

--- a/src/SIPSorcery/core/SIP/SIPAuthorisationDigest.cs
+++ b/src/SIPSorcery/core/SIP/SIPAuthorisationDigest.cs
@@ -38,6 +38,15 @@ namespace SIPSorcery.SIP
         //SHA512
     }
 
+    /// <summary>
+    /// Resolves the HA1 digest for a SIP authentication challenge. Return <c>null</c> when no
+    /// credential is available for the supplied username, realm and digest algorithm.
+    /// </summary>
+    public delegate string GetHA1DigestDelegate(
+        string username,
+        string realm,
+        DigestAlgorithmsEnum algorithm);
+
     public class SIPAuthorisationDigest
     {
         public const string METHOD = "Digest";
@@ -452,4 +461,5 @@ namespace SIPSorcery.SIP
 #pragma warning restore SYSLIB0021
         }
     }
+
 }

--- a/src/SIPSorcery/core/SIP/SIPRequest.cs
+++ b/src/SIPSorcery/core/SIP/SIPRequest.cs
@@ -344,11 +344,7 @@ namespace SIPSorcery.SIP
             string username,
             string password)
         {
-            var dupRequest = this.Copy();
-            dupRequest.Header.Vias.TopViaHeader.Branch = CallProperties.CreateBranchId();
-            dupRequest.Header.CSeq = dupRequest.Header.CSeq + 1;
-
-            dupRequest.Header.AuthenticationHeaders.Clear();
+            var dupRequest = DuplicateRequest();
 
             // RFC8760 (which introduces SHA256/512 for SIP) states that multiple authentication headers with different digest algorithms
             // can be included in a SIP request. When testing this with the latest versions (Jul 2021) of Asterisk v18.5.0 and FreeSWITCH v1.10.6
@@ -369,6 +365,42 @@ namespace SIPSorcery.SIP
                 dupRequest.Header.AuthenticationHeaders.Add(md5AuthHeader);
             }
 
+            return dupRequest;
+        }
+
+        /// <summary>
+        /// Duplicates an existing SIP request, typically one that received an unauthorised response, to an
+        /// authenticated version using an HA1 digest resolver. The CSeq and Via branch ID are also incremented so
+        /// that the request will not be flagged as a retransmit.
+        /// </summary>
+        /// <param name="authenticationChallenges">The challenges to authenticate the request against. Typically
+        /// the challenges come from a SIP response.</param>
+        /// <param name="username">The username to authenticate with.</param>
+        /// <param name="getHA1Digest">Resolves an HA1 digest for a username, challenge realm and digest algorithm.
+        /// Return <c>null</c> when no credential is available for a challenge.</param>
+        /// <returns>A SIP request that is a duplicate of the original but with an authentication header added and
+        /// the state header values updated so as not to be flagged as a retransmit.</returns>
+        public SIPRequest DuplicateAndAuthenticate(List<SIPAuthenticationHeader> authenticationChallenges,
+            string username,
+            GetHA1DigestDelegate getHA1Digest)
+        {
+            var digestAuthHeader = SIPAuthChallenge.GetAuthenticationHeader(authenticationChallenges, this.URI, this.Method, username, getHA1Digest);
+            if (digestAuthHeader == null)
+            {
+                return null;
+            }
+
+            var dupRequest = DuplicateRequest();
+            dupRequest.Header.AuthenticationHeaders.Add(digestAuthHeader);
+            return dupRequest;
+        }
+
+        private SIPRequest DuplicateRequest()
+        {
+            var dupRequest = this.Copy();
+            dupRequest.Header.Vias.TopViaHeader.Branch = CallProperties.CreateBranchId();
+            dupRequest.Header.CSeq = dupRequest.Header.CSeq + 1;
+            dupRequest.Header.AuthenticationHeaders.Clear();
             return dupRequest;
         }
     }

--- a/test/SIPSorcery.Cli.UnitTest/HTTPDigestStoreTests.cs
+++ b/test/SIPSorcery.Cli.UnitTest/HTTPDigestStoreTests.cs
@@ -1,0 +1,112 @@
+﻿using SIPSorcery.Diagnostics.Commands;
+using SIPSorcery.Cli.Common;
+using SIPSorcery.SIP;
+using Xunit;
+using DiagnosticsExitCodes = SIPSorcery.Diagnostics.ExitCodes;
+
+namespace SIPSorcery.Cli.UnitTest;
+
+[Trait("Category", "unit")]
+public class HTTPDigestStoreTests
+{
+    [Fact]
+    public void SipDigestCommandUsesDigestVerb()
+    {
+        Assert.Equal("digest", new SipDigestCommand().Build().Name);
+    }
+
+    [Fact]
+    public void WriteToFileAndReadRoundTripsDigestStore()
+    {
+        string tempDirectory = CreateTempDirectory();
+
+        try
+        {
+            string path = Path.Combine(tempDirectory, "alice.digest");
+
+            HTTPDigestStore.WriteToFile(path, "alice", "example.com", "secret");
+
+            var credential = HTTPDigestStore.ReadFromFile(path);
+
+            Assert.Equal(HTTPDigest.DigestCalcHA1("alice", "example.com", "secret"), credential.HA1_MD5);
+            Assert.Equal(
+                HTTPDigest.DigestCalcHA1("alice", "example.com", "secret", DigestAlgorithmsEnum.SHA256),
+                credential.HA1_SHA256);
+
+            string content = File.ReadAllText(path);
+            Assert.Contains("ha1_md5=", content);
+            Assert.Contains("ha1_sha256=", content);
+            Assert.DoesNotContain("secret", content);
+        }
+        finally
+        {
+            Directory.Delete(tempDirectory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ReadAllowsMissingDigestValues()
+    {
+        string tempDirectory = CreateTempDirectory();
+
+        try
+        {
+            string path = Path.Combine(tempDirectory, "empty.digest");
+            File.WriteAllText(path, string.Empty);
+
+            var credential = HTTPDigestStore.ReadFromFile(path);
+
+            Assert.Null(credential.HA1_MD5);
+            Assert.Null(credential.HA1_SHA256);
+        }
+        finally
+        {
+            Directory.Delete(tempDirectory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void WriteToFileOverwritesExistingFile()
+    {
+        string tempDirectory = CreateTempDirectory();
+
+        try
+        {
+            string path = Path.Combine(tempDirectory, "alice.digest");
+            File.WriteAllText(path, "existing");
+
+            HTTPDigestStore.WriteToFile(
+                path,
+                "alice",
+                "example.com",
+                "secret");
+
+            string content = File.ReadAllText(path);
+            Assert.DoesNotContain("existing", content);
+            Assert.Contains("ha1_md5=", content);
+            Assert.Contains("ha1_sha256=", content);
+        }
+        finally
+        {
+            Directory.Delete(tempDirectory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task SipRegisterRejectsPasswordCombinedWithDigestStore()
+    {
+        int exitCode = await new SipRegisterCommand()
+            .Build()
+            .Parse(new[] { "sip:alice@example.com", "--password", "secret", "--digest-store", "missing.txt", "--json" })
+            .InvokeAsync();
+
+        Assert.Equal(DiagnosticsExitCodes.InvalidArgument, exitCode);
+    }
+
+    private static string CreateTempDirectory()
+    {
+        string path = Path.Combine(Path.GetTempPath(), $"sipsorcery-digest-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(path);
+        return path;
+    }
+}

--- a/test/SIPSorcery.Cli.UnitTest/SIPSorcery.Cli.UnitTest.csproj
+++ b/test/SIPSorcery.Cli.UnitTest/SIPSorcery.Cli.UnitTest.csproj
@@ -20,6 +20,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\SIPSorcery.Cli\SIPSorcery.Cli.csproj" />
     <ProjectReference Include="..\..\src\SIPSorcery.Cli.Common\SIPSorcery.Cli.Common.csproj" />
+    <ProjectReference Include="..\..\src\SIPSorcery.Diagnostics\SIPSorcery.Diagnostics.csproj" />
   </ItemGroup>
 
 </Project>

--- a/test/unit/app/SIPUserAgents/SIPRegistrationUserAgentUnitTest.cs
+++ b/test/unit/app/SIPUserAgents/SIPRegistrationUserAgentUnitTest.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Net;
 using Microsoft.Extensions.Logging;
 using SIPSorcery.UnitTests;
@@ -81,6 +82,91 @@ namespace SIPSorcery.SIP.App.UnitTests
             Assert.Contains(testHeader.ToString(), channel.LastSIPMessageSent);
 
             userAgent.Stop();
+        }
+
+        [Fact]
+        public void RegisterWithHA1DigestResolverRespondsToSHA256ChallengeTest()
+        {
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
+
+            string username = "alice";
+            string password = "password123";
+            string registrarHost = "192.168.11.50";
+            GetHA1DigestDelegate getHA1Digest = (resolvedUsername, realm, digestAlgorithm) =>
+                resolvedUsername == username && realm == registrarHost && digestAlgorithm == DigestAlgorithmsEnum.SHA256
+                    ? HTTPDigest.DigestCalcHA1(username, registrarHost, password, DigestAlgorithmsEnum.SHA256)
+                    : null;
+
+            SIPTransport transport = new SIPTransport();
+            MockSIPChannel channel = new MockSIPChannel(new IPEndPoint(IPAddress.Any, 0));
+            transport.AddSIPChannel(channel);
+
+            SIPRegistrationUserAgent userAgent = new SIPRegistrationUserAgent(
+                transport,
+                null,
+                new SIPURI(username, registrarHost, null, SIPSchemesEnum.sip, SIPProtocolsEnum.udp),
+                getHA1Digest,
+                username,
+                null,
+                registrarHost,
+                new SIPURI(SIPSchemesEnum.sip, IPAddress.Any, 0),
+                120,
+                null);
+
+            try
+            {
+                userAgent.Start();
+
+                Assert.True(channel.SIPMessageSent.WaitOne(5000));
+                SIPRequest initialRegister = SIPRequest.ParseSIPRequest(channel.LastSIPMessageSent);
+
+                SIPResponse challenge = SIPResponse.GetResponse(
+                    initialRegister,
+                    SIPResponseStatusCodesEnum.Unauthorised,
+                    "Authentication Required");
+                SIPAuthenticationHeader authHeader = new SIPAuthenticationHeader(
+                    SIPAuthorisationHeadersEnum.WWWAuthenticate,
+                    registrarHost,
+                    "nonce123");
+                authHeader.SIPDigest = null;
+                authHeader.Value = $"Digest realm=\"{registrarHost}\",nonce=\"nonce123\",algorithm=SHA-256";
+                challenge.Header.AuthenticationHeaders.Add(authHeader);
+
+                channel.SIPMessageSent.Reset();
+                channel.FireMessageReceived(
+                    new SIPEndPoint(SIPProtocolsEnum.udp, IPAddress.Any, 0),
+                    new SIPEndPoint(SIPProtocolsEnum.udp, IPAddress.Parse(registrarHost), SIPConstants.DEFAULT_SIP_PORT),
+                    challenge.GetBytes());
+
+                Assert.True(channel.SIPMessageSent.WaitOne(5000));
+                SIPRequest authenticatedRegister = SIPRequest.ParseSIPRequest(channel.LastSIPMessageSent);
+                SIPAuthorisationDigest digest = authenticatedRegister.Header.AuthenticationHeaders[0].SIPDigest;
+
+                Assert.Equal(DigestAlgorithmsEnum.SHA256, digest.DigestAlgorithm);
+                Assert.Equal(username, digest.Username);
+                Assert.Equal(registrarHost, digest.Realm);
+
+                string expectedHA1 = HTTPDigest.DigestCalcHA1(
+                    username,
+                    registrarHost,
+                    password,
+                    DigestAlgorithmsEnum.SHA256);
+                string expectedResponse = HTTPDigest.DigestCalcResponse(
+                    expectedHA1,
+                    digest.URI,
+                    digest.Nonce,
+                    digest.NonceCount == 0 ? null : digest.NonceCount.ToString().PadLeft(8, '0'),
+                    digest.Cnonce,
+                    digest.Qop,
+                    SIPMethodsEnum.REGISTER.ToString(),
+                    DigestAlgorithmsEnum.SHA256);
+                Assert.Equal(expectedResponse, digest.Response);
+            }
+            finally
+            {
+                userAgent.Stop();
+            }
         }
     }
 }

--- a/test/unit/core/SIP/SIPAuthorisationDigestUnitTest.cs
+++ b/test/unit/core/SIP/SIPAuthorisationDigestUnitTest.cs
@@ -400,7 +400,7 @@ opaque=""FQhe/qaU925kfnzjCev0ciny7QMkPqMAFRtzCUYo5tdS""");
 
             var authResult = SIPRequestAuthenticator.AuthenticateSIPRequest(SIPEndPoint.Empty, SIPEndPoint.Empty, req, account);
 
-            var authReq = req.DuplicateAndAuthenticate(new List<SIPAuthenticationHeader> { authResult.AuthenticationRequiredHeader }, 
+            var authReq = req.DuplicateAndAuthenticate(new List<SIPAuthenticationHeader> { authResult.AuthenticationRequiredHeader },
                 account.SIPUsername, account.SIPPassword);
 
             logger.LogDebug("Auth req={authReq}", authReq);
@@ -425,13 +425,63 @@ opaque=""FQhe/qaU925kfnzjCev0ciny7QMkPqMAFRtzCUYo5tdS""");
             var authResult = SIPRequestAuthenticator.AuthenticateSIPRequest(SIPEndPoint.Empty, SIPEndPoint.Empty, req, account);
             authResult.AuthenticationRequiredHeader.SIPDigest.DigestAlgorithm = DigestAlgorithmsEnum.SHA256;
 
+            string ha1Digest = HTTPDigest.DigestCalcHA1(
+                account.SIPUsername,
+                authResult.AuthenticationRequiredHeader.SIPDigest.Realm,
+                account.SIPPassword,
+                DigestAlgorithmsEnum.SHA256);
+            GetHA1DigestDelegate getHA1Digest = (username, realm, digestAlgorithm) =>
+                username == account.SIPUsername &&
+                realm == authResult.AuthenticationRequiredHeader.SIPDigest.Realm &&
+                digestAlgorithm == DigestAlgorithmsEnum.SHA256
+                    ? ha1Digest
+                    : null;
+
             var authReq = req.DuplicateAndAuthenticate(new List<SIPAuthenticationHeader> { authResult.AuthenticationRequiredHeader },
-                account.SIPUsername, account.SIPPassword);
+                account.SIPUsername, getHA1Digest);
 
             logger.LogDebug("Auth req={authReq}", authReq);
 
             authResult = SIPRequestAuthenticator.AuthenticateSIPRequest(SIPEndPoint.Empty, SIPEndPoint.Empty, authReq, account);
 
+            Assert.True(authResult.Authenticated);
+        }
+
+        [Fact]
+        public void SIPRequestHA1ResolverFallsBackWhenPreferredChallengeHasNoCredential()
+        {
+            var account = new MockSIPAccount("user", "password");
+            var req = SIPRequest.GetRequest(SIPMethodsEnum.OPTIONS, SIPURI.ParseSIPURI("sip:100@0.0.0.0"));
+            var authResult = SIPRequestAuthenticator.AuthenticateSIPRequest(SIPEndPoint.Empty, SIPEndPoint.Empty, req, account);
+            var md5Challenge = authResult.AuthenticationRequiredHeader;
+            var sha256Challenge = new SIPAuthenticationHeader(md5Challenge.SIPDigest.CopyOf());
+            sha256Challenge.SIPDigest.DigestAlgorithm = DigestAlgorithmsEnum.SHA256;
+
+            string md5HA1Digest = HTTPDigest.DigestCalcHA1(
+                account.SIPUsername,
+                md5Challenge.SIPDigest.Realm,
+                account.SIPPassword,
+                DigestAlgorithmsEnum.MD5);
+            var resolvedAlgorithms = new List<DigestAlgorithmsEnum>();
+            GetHA1DigestDelegate getHA1Digest = (username, realm, digestAlgorithm) =>
+            {
+                resolvedAlgorithms.Add(digestAlgorithm);
+                return username == account.SIPUsername &&
+                    realm == md5Challenge.SIPDigest.Realm &&
+                    digestAlgorithm == DigestAlgorithmsEnum.MD5
+                        ? md5HA1Digest
+                        : null;
+            };
+
+            var authReq = req.DuplicateAndAuthenticate(
+                new List<SIPAuthenticationHeader> { sha256Challenge, md5Challenge },
+                account.SIPUsername,
+                getHA1Digest);
+
+            Assert.Equal(new[] { DigestAlgorithmsEnum.SHA256, DigestAlgorithmsEnum.MD5 }, resolvedAlgorithms);
+            Assert.Equal(DigestAlgorithmsEnum.MD5, authReq.Header.AuthenticationHeaders[0].SIPDigest.DigestAlgorithm);
+
+            authResult = SIPRequestAuthenticator.AuthenticateSIPRequest(SIPEndPoint.Empty, SIPEndPoint.Empty, authReq, account);
             Assert.True(authResult.Authenticated);
         }
 


### PR DESCRIPTION
Open design question: Preferred `HTTPDigestStore` API home? I placed the reusable type as `SIPSorcery.SIP.HTTPDigestStore` beside the existing digest-auth primitives. Happy to move/rename it if `SIPDigestStore` or CLI-only file helpers fit the project better.

Possible alternatives:
- Keep HTTPDigestStore in SIPSorcery.SIP, including read/write helpers.
- Keep only the auth/value object in SIPSorcery.SIP, and put file read/write helpers in CLI/common code.
- Rename it to SIPDigestStore to make the SIP-facing use clearer, even though the underlying algorithm is HTTP Digest.
Use a different home/name entirely.


And if talking about the actual implementation inside this PR, I’m looking at a small change to support SIP client authentication without storing a clear-text password in scripts, examples, or CLI arguments.

The idea is a simple “digest store” file containing precomputed HA1 values:

```text
ha1_md5=<hex>
ha1_sha256=<hex>
```

The file would be generated once and then used for SIP registration authentication. The clear-text password is not stored. At runtime the client can pick the stored digest matching the server’s authentication challenge, preferring SHA-256 when offered and falling back to MD5 when needed.
