### PR TITLE
Use PackageLicenseFile instead of PackageLicenseExpression (#1766)

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -2,7 +2,7 @@
 
 ## 1. BSD 3-Clause "New" or "Revised" License
 
-Copyright (c) 2006–2025 Aaron Clauson
+Copyright (c) 2006–2026 Aaron Clauson
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -15,17 +15,15 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” 
 
 ---
 
-## 2. Additional Restriction: Boycott, Divestment, Sanctions (BDS) – Attribution-NonCommercial-ShareAlike
+## 2. Additional Use Restriction
 
-**Boycott Divestment Sanctions – Attribution-NonCommercial-ShareAlike (BDS BY-NC-SA)**
-
-This software **must not be used** to further the Apartheid policies of Israel. Use, modification, or distribution **inside** Israel and the Occupied Territories is strictly forbidden until the demands of the Boycott, Divestment and Sanctions movement have been met:
+This software **must not be used** to further the apartheid policies of the state of Israel. Use, modification, or distribution **inside** Israel and the Occupied Territories is not permitted until the demands of the Boycott, Divestment and Sanctions (BDS) movement have been met:
 
 * Israel has ended the occupation and colonization of all Arab lands occupied in 1967 and dismantled the Wall;
 * Arab-Palestinian citizens of Israel have been granted full equality; and
 * Palestinian refugees have obtained the right to return to their homes and properties as stipulated in UN Resolution 194.
 
-For all other geographic regions **outside** of Israel and the Occupied Territories, use, modification, and distribution are permitted under the terms of the **BSD 3-Clause "New" or "Revised" License** above (Section 1), provided that any future use, modification, or distribution carries the above BDS restriction and abides by the ShareAlike and NonCommercial principles.
+For all other geographic regions **outside** of Israel and the Occupied Territories, use, modification, and distribution are permitted under the terms of the **BSD 3-Clause "New" or "Revised" License** above (Section 1), with **no additional restriction on commercial use** and **no requirement to license derivative works under any particular terms**.
 
 This restriction is **not** intended to limit the rights of Israelis or any other people residing outside of Israel and the Occupied Territories.
 
@@ -540,37 +538,3 @@ necessary.  Here is a sample; alter the names:
   Ty Coon, President of Vice
 
 That's all there is to it!
-
----
-
-## 4. BSD 3-Clause License (VP8.Net)
-
-BSD 3-Clause License
-
-Copyright (c) 2020, Aaron Clauson
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-
-1. Redistributions of source code must retain the above copyright notice, this
-   list of conditions and the following disclaimer.
-
-2. Redistributions in binary form must reproduce the above copyright notice,
-   this list of conditions and the following disclaimer in the documentation
-   and/or other materials provided with the distribution.
-
-3. Neither the name of the copyright holder nor the names of its
-   contributors may be used to endorse or promote products derived from
-   this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/src/SIPSorcery.Cli/SIPSorcery.Cli.csproj
+++ b/src/SIPSorcery.Cli/SIPSorcery.Cli.csproj
@@ -19,7 +19,7 @@
     <Version>0.2.0-beta</Version>
     <Authors>Aaron Clauson</Authors>
     <Description>SIPSorcery CLI: route and bridge live media streams between SIP, WebRTC and the major realtime fabrics (Cloudflare Realtime, LiveKit) and AI agents (OpenAI Realtime), built on the SIPSorcery library. A stream is the primitive; verbs attach edges to it. Human and agent friendly with JSON output and meaningful exit codes.</Description>
-    <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
+    <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
     <PackageProjectUrl>https://sipsorcery-org.github.io/sipsorcery/</PackageProjectUrl>
     <RepositoryUrl>https://github.com/sipsorcery-org/sipsorcery</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
@@ -62,6 +62,7 @@
 
   <ItemGroup>
     <None Include="README.md" Pack="true" PackagePath="\" />
+    <None Include="..\..\LICENSE.md" Pack="true" PackagePath="\" />
     <None Include="..\SIPSorcery\icon.png" Pack="true" PackagePath="\" Visible="false" />
   </ItemGroup>
 

--- a/src/SIPSorcery.Diagnostics/SIPSorcery.Diagnostics.csproj
+++ b/src/SIPSorcery.Diagnostics/SIPSorcery.Diagnostics.csproj
@@ -20,7 +20,7 @@
     <Version>0.2.0-beta</Version>
     <Authors>Aaron Clauson</Authors>
     <Description>Diagnostics and benchmarking CLI for SIP and WebRTC, built on the SIPSorcery library: OPTIONS pings, test calls, registration and load, STUN/TURN/ICE connectivity probes, WHEP/WHIP and echo-test peers, and video pipeline benchmarks. Probe/test tooling (not a general softphone); human and agent friendly with JSON output and meaningful exit codes. For routing streams and the Cloudflare/LiveKit/OpenAI fabric verbs see the SIPSorcery.Cli tool.</Description>
-    <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
+    <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
     <PackageProjectUrl>https://sipsorcery-org.github.io/sipsorcery/</PackageProjectUrl>
     <RepositoryUrl>https://github.com/sipsorcery-org/sipsorcery</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
@@ -51,6 +51,7 @@
 
   <ItemGroup>
     <None Include="README.md" Pack="true" PackagePath="\" />
+    <None Include="..\..\LICENSE.md" Pack="true" PackagePath="\" />
     <None Include="..\SIPSorcery\icon.png" Pack="true" PackagePath="\" Visible="false" />
   </ItemGroup>
 

--- a/src/SIPSorcery.OpenAI.Realtime/SIPSorcery.OpenAI.Realtime.csproj
+++ b/src/SIPSorcery.OpenAI.Realtime/SIPSorcery.OpenAI.Realtime.csproj
@@ -23,7 +23,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Authors>Aaron Clauson</Authors>
     <Copyright>Copyright © 2025-2026 Aaron Clauson</Copyright>
-    <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
+    <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
     <Title>SIPSorcery</Title>
     <Summary>A .NET library for interacting with OpenAI's real-time WebRTC API.</Summary>
     <Description>A .NET library for interacting with OpenAI's real-time WebRTC API. It provides helper classes to negotiate peer connections, send and receive Opus audio frames and exchange control messages over a data channel. Not an official OpenAI package and no affiliation with OpenAI.
@@ -74,6 +74,7 @@
   <ItemGroup>
     <None Include="icon.png" Pack="true" PackagePath="" />
 	<None Include="README.md" Pack="true" PackagePath="" />
+	<None Include="..\..\LICENSE.md" Pack="true" PackagePath="" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/SIPSorcery.VP8/SIPSorcery.VP8.csproj
+++ b/src/SIPSorcery.VP8/SIPSorcery.VP8.csproj
@@ -13,7 +13,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Authors>Aaron Clauson</Authors>
     <Copyright>Copyright © 2026 Aaron Clauson</Copyright>
-    <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
+    <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
     <Title>SIPSorcery</Title>
     <Summary>A .NET library that implements the VP8 video codec.</Summary>
     <Description>
@@ -60,6 +60,7 @@ A .NET library that implements the VP8 video codec. This package is intended to 
   <ItemGroup>
      <None Include="icon.png" Pack="true" PackagePath="" />
      <None Include="README.md" Pack="true" PackagePath="" />
+     <None Include="..\..\LICENSE.md" Pack="true" PackagePath="" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SIPSorcery/SIPSorcery.csproj
+++ b/src/SIPSorcery/SIPSorcery.csproj
@@ -15,6 +15,7 @@
     <EmbeddedResource Include="media\testpattern.i420" />
     <None Include="icon.png" Pack="true" PackagePath="" />
     <None Include="..\..\README.md" Pack="true" PackagePath="\" />
+    <None Include="..\..\LICENSE.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
   <ItemGroup>
@@ -58,7 +59,7 @@
     <NoWarn>$(NoWarn);CS1591;CS1573;CS1587</NoWarn>
     <Authors>Aaron Clauson, Christophe Irles, Rafael Soares &amp; Contributors</Authors>
     <Copyright>Copyright © 2010-2026 Aaron Clauson</Copyright>
-    <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
+    <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
     <Title>SIPSorcery</Title>
     <Summary>A cross platform C# .NET library for SIP, VoIP and WebRTC.</Summary>
     <Description>Real-time communications library with full support for the Session Initiation Protocol (SIP) and WebRTC. No wrappers and no native libraries required.

--- a/src/SIPSorceryMedia.Abstractions/SIPSorceryMedia.Abstractions.csproj
+++ b/src/SIPSorceryMedia.Abstractions/SIPSorceryMedia.Abstractions.csproj
@@ -13,7 +13,7 @@
     <Authors>Aaron Clauson</Authors>
     <Copyright>Copyright © 2020-2026 Aaron Clauson</Copyright>
     <Company>SIP Sorcery PTY LTD</Company>
-    <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
+    <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
     <Title>SIPSorceryMedia.Abstractions</Title>
     <Summary>A set of interfaces and common structures used for building media end points for the SIPSorcery library.</Summary>
     <Description>Don't reference this package unless you are building a media end point to work with the SIPSorcery real-time communications library. In most cases a concrete implementation package such as SIPSorceryMedia.Windows should be referenced.
@@ -53,6 +53,7 @@
   <ItemGroup>
     <None Include="icon.png" Pack="true" PackagePath="" />
 	<None Include="README.md" Pack="true" PackagePath="" />
+	<None Include="..\..\LICENSE.md" Pack="true" PackagePath="" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SIPSorceryMedia.Windows/SIPSorceryMedia.Windows.csproj
+++ b/src/SIPSorceryMedia.Windows/SIPSorceryMedia.Windows.csproj
@@ -19,7 +19,7 @@
     <Authors>Aaron Clauson</Authors>
     <Copyright>Copyright © 2020-2026 Aaron Clauson</Copyright>
     <Company>SIP Sorcery PTY LTD</Company>
-    <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
+    <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
     <Title>SIPSorceryMedia.Windows</Title>
     <Summary>Audio and video end points for Windows capture devices.</Summary>
     <Description>Provides audio and video device access for Windows for use with the main SIPSorcery real-time communications library.</Description>
@@ -71,6 +71,7 @@
   <ItemGroup>
     <None Include="icon.png" Pack="true" PackagePath="" />
 	<None Include="README.md" Pack="true" PackagePath="" />
+	<None Include="..\..\LICENSE.md" Pack="true" PackagePath="" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Fixes #1766, and clarifies the license wording.

## 1. Packaging fix (the original issue)

The BSD-licensed NuGet packages declared `<PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>`, but `LICENSE.md` adds terms beyond plain BSD-3-Clause, so that SPDX expression misrepresented the actual license.

`PackageLicenseExpression` and `PackageLicenseFile` are mutually exclusive. This switches the BSD packages to `<PackageLicenseFile>LICENSE.md</PackageLicenseFile>` and packs `LICENSE.md` into each package so consumers get the complete, accurate terms.

Updated packages: `SIPSorcery`, `SIPSorceryMedia.Abstractions`, `SIPSorceryMedia.Windows`, `SIPSorcery.VP8`, `SIPSorcery.OpenAI.Realtime`, `SIPSorcery.Cli`, `SIPSorcery.Diagnostics`.

`SIPSorceryMedia.FFmpeg` intentionally keeps `PackageLicenseExpression=LGPL-2.1-only`.

Verified with `dotnet pack`: `LICENSE.md` is embedded at the package root and the nuspec emits `<license type="file">LICENSE.md</license>`.

## 2. License wording clarification

The BDS restriction in Section 2 previously used the Creative Commons **Attribution-NonCommercial-ShareAlike (CC BY-NC-SA)** framing. Combined with the "restriction is superior" clause, that read as imposing **NonCommercial** and **ShareAlike** obligations on *all* worldwide use — which was never intended and had confused users into thinking the library couldn't be used commercially.

Section 2 is rewritten as a plain additional use restriction: the BDS geographic restriction is retained, but everywhere else the software is explicitly BSD 3-Clause **with no commercial-use restriction and no ShareAlike/copyleft requirement**.

## 3. Removed duplicate VP8 BSD block

Section 4 (a separate BSD 3-Clause block for VP8.Net) was removed. VP8.Net ships in `SIPSorcery.VP8` under the same BSD 3-Clause terms as the other non-FFmpeg projects (Section 1), so the duplicate section was redundant.

The license now has three sections: 1) BSD 3-Clause, 2) Additional Use Restriction (BDS), 3) LGPL-2.1 for SIPSorceryMedia.FFmpeg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)