### PR TITLE
Add Unknown to codec enums; improve OpusWebRTC property

### DIFF
--- a/src/SIPSorceryMedia.Abstractions/Enums/AudioCodecsEnum.cs
+++ b/src/SIPSorceryMedia.Abstractions/Enums/AudioCodecsEnum.cs
@@ -18,6 +18,8 @@ namespace SIPSorceryMedia.Abstractions;
 
 public enum AudioCodecsEnum
 {
+    Unknown,
+
     PCMU,
     GSM,
     G723,
@@ -34,6 +36,4 @@ public enum AudioCodecsEnum
     OPUS,
 
     PCM_S16LE,  // PCM signed 16-bit little-endian (equivalent to FFmpeg s16le). For use with Azure, not likely to be supported in VoIP/WebRTC.
-
-    Unknown
 }

--- a/src/SIPSorceryMedia.Abstractions/Enums/VideoCodecsEnum.cs
+++ b/src/SIPSorceryMedia.Abstractions/Enums/VideoCodecsEnum.cs
@@ -18,6 +18,8 @@ namespace SIPSorceryMedia.Abstractions;
 
 public enum VideoCodecsEnum
 {
+    Unknown,
+
     CELB,
     JPEG,
     NV,
@@ -30,6 +32,4 @@ public enum VideoCodecsEnum
     AV1,
     H264,
     H265,
-
-    Unknown
 }

--- a/src/SIPSorceryMedia.Abstractions/MediaFormats/AudioCommonlyUsedFormats.cs
+++ b/src/SIPSorceryMedia.Abstractions/MediaFormats/AudioCommonlyUsedFormats.cs
@@ -27,5 +27,5 @@ public static class AudioCommonlyUsedFormats
     /// <summary>
     /// The Opus audio format typical used for WebRTC scenarios.
     /// </summary>
-    public static AudioFormat OpusWebRTC => new AudioFormat(111, AudioCodecsEnum.OPUS.ToString(), OPUS_SAMPLE_RATE, OPUS_CHANNELS, "useinbandfec=1");
+    public static AudioFormat OpusWebRTC => new AudioFormat(111, nameof(AudioCodecsEnum.OPUS), OPUS_SAMPLE_RATE, OPUS_CHANNELS, "useinbandfec=1");
 }


### PR DESCRIPTION
#### PR Classification
Code cleanup and type safety improvement.

#### PR Summary
Improved enum default handling and enhanced type safety for audio codec references.
- AudioCodecsEnum and VideoCodecsEnum: Added Unknown as the first member to improve default handling.
- AudioCommonlyUsedFormats: Updated OpusWebRTC to use nameof(AudioCodecsEnum.OPUS) instead of ToString() for better maintainability.
