### PR TITLE
Fix ICE-over-TCP receive path teardown and end of stream recursion

### DIFF
--- a/src/SIPSorcery/net/ICE/IceTcpReceiver.cs
+++ b/src/SIPSorcery/net/ICE/IceTcpReceiver.cs
@@ -92,6 +92,13 @@ public class IceTcpReceiver : UdpReceiver
     /// <param name="ar">Contains the results of the receive.</param>
     protected override void EndReceiveFrom(IAsyncResult ar)
     {
+        // Set when a receive completes with zero bytes. On a stream socket that is the end of stream
+        // indication, not an empty datagram as it would be on the UDP receive path, so the receive loop
+        // must not be re-armed. Socket.Connected remains true after the peer's FIN, so the guard in
+        // BeginReceiveFrom does not stop it: the re-arm would complete synchronously with zero bytes and
+        // call straight back into this method, recursing until the process died with a StackOverflowException.
+        bool endOfStream = false;
+
         try
         {
             EndPoint remoteEP = m_addressFamily == AddressFamily.InterNetwork ? new IPEndPoint(IPAddress.Any, 0) : new IPEndPoint(IPAddress.IPv6Any, 0);
@@ -103,6 +110,10 @@ public class IceTcpReceiver : UdpReceiver
                 if (bytesRead > 0)
                 {
                     ProcessRawBuffer(bytesRead + m_recvOffset, remoteEP as IPEndPoint);
+                }
+                else
+                {
+                    endOfStream = true;
                 }
             }
             else
@@ -138,6 +149,7 @@ public class IceTcpReceiver : UdpReceiver
                     }
                     else
                     {
+                        endOfStream = true;
                         break;
                     }
                 }
@@ -145,33 +157,40 @@ public class IceTcpReceiver : UdpReceiver
         }
         catch (SocketException resetSockExcp) when (resetSockExcp.SocketErrorCode == SocketError.ConnectionReset)
         {
-            // ConnectionReset is raised when the OS receives an ICMP "port unreachable" message.
-            // On a UDP socket this commonly occurs when:
-            //  - The remote party has not yet opened its RTP socket (e.g. during call setup),
-            //  - The remote endpoint changed (hold, transfer) and the old port is no longer listening,
-            //  - The remote process terminated and the OS rejected a subsequent outgoing packet.
-            // In all cases the local socket is still perfectly usable — the error relates to a
-            // single outbound send, not to the health of the receive path. The receive loop must
-            // continue so that packets arriving from the (possibly new) remote endpoint are not lost.
-            logger.LogWarning(resetSockExcp, "SocketException RtpIceChannel.EndReceiveFrom ({SocketErrorCode}). {ErrorMessage}", resetSockExcp.SocketErrorCode, resetSockExcp.Message);
+            // This is a connected TCP socket to a STUN/TURN server, so unlike the UDP case this is a real
+            // RST from the peer rather than a possibly spurious ICMP "port unreachable": the connection is
+            // genuinely gone. It is still not a reason to close the receiver. The socket is reconnected
+            // lazily by RtpIceChannel.SendOverTCP the next time a message needs to go to that ICE server,
+            // and that reconnect only re-arms this receive loop while the receiver has not been closed.
+            // Closing here would make the reconnect permanently unable to resume receiving. Re-arming is
+            // safe because BeginReceiveFrom returns immediately while the socket is not connected.
+            logger.LogWarning(resetSockExcp, "SocketException IceTcpReceiver.EndReceiveFrom ({SocketErrorCode}). {ErrorMessage}", resetSockExcp.SocketErrorCode, resetSockExcp.Message);
         }
         catch (SocketException sockExcp)
         {
-            // Other socket errors are also non-fatal for a UDP receive path. The same transient
-            // scenarios described above apply.
-            logger.LogWarning(sockExcp, "SocketException RtpIceChannel.EndReceiveFrom ({SocketErrorCode}). {ErrorMessage}", sockExcp.SocketErrorCode, sockExcp.Message);
+            // Other socket errors are handled the same way and for the same reason: the reconnect in
+            // SendOverTCP is what recovers the connection, and it needs this receiver left open to do it.
+            logger.LogWarning(sockExcp, "SocketException IceTcpReceiver.EndReceiveFrom ({SocketErrorCode}). {ErrorMessage}", sockExcp.SocketErrorCode, sockExcp.Message);
         }
         catch (ObjectDisposedException) // Thrown when socket is closed. Can be safely ignored.
         { }
         catch (Exception excp)
         {
+            // A non-socket exception here almost always originates from processing a single inbound packet
+            // (e.g. a malformed STUN/TURN packet throwing in the packet-received handler). Closing the
+            // receiver on one bad packet permanently kills the ICE-over-TCP path for the session because
+            // Close sets m_isClosed and the re-arm in the finally block below then becomes a no-op. Log and
+            // drop the offending packet instead and let the receive loop continue, mirroring the
+            // drop-and-continue behaviour of the base UdpReceiver.EndReceiveFrom. Genuine socket failures
+            // are handled by the SocketException/ObjectDisposedException catches above.
             logger.LogError(excp, "Exception IceTcpReceiver.EndReceiveFrom. {ErrorMessage}", excp.Message);
-            Close(excp.Message);
         }
         finally
         {
             m_isRunningReceive = false;
-            if (!m_isClosed)
+            // On end of stream the receiver is left open but idle rather than closed, so the reconnect in
+            // RtpIceChannel.SendOverTCP (which re-arms while !IsRunningReceive && !IsClosed) can resume it.
+            if (!m_isClosed && !endOfStream)
             {
                 BeginReceiveFrom();
             }
@@ -228,7 +247,19 @@ public class IceTcpReceiver : UdpReceiver
                         byte[] packetBuffer = new byte[stunMsgBytes];
                         Buffer.BlockCopy(recvRemainingSegment.Array, recvRemainingSegment.Offset, packetBuffer, 0, stunMsgBytes);
 
-                        CallOnPacketReceivedCallback(m_localEndPoint.Port, remoteEP, packetBuffer);
+                        // A throw from the packet handler must not escape the framing loop. Unwinding here
+                        // would leave m_recvOffset at the value set above and skip the fragmentation
+                        // bookkeeping at the end of the method, so the next read would be written at a stale
+                        // offset and every subsequent message on the stream would be mis-framed. Log the bad
+                        // packet, keep the framing state consistent and carry on with the rest of the buffer.
+                        try
+                        {
+                            CallOnPacketReceivedCallback(m_localEndPoint.Port, remoteEP, packetBuffer);
+                        }
+                        catch (Exception excp)
+                        {
+                            logger.LogError(excp, "Exception IceTcpReceiver processing a received packet from {RemoteEndPoint}. {ErrorMessage}", remoteEP, excp.Message);
+                        }
 
                         var newOffset = recvRemainingSegment.Offset + stunMsgBytes;
                         var newCount = recvRemainingSegment.Count - stunMsgBytes;

--- a/src/SIPSorcery/net/RTP/RTPChannel.cs
+++ b/src/SIPSorcery/net/RTP/RTPChannel.cs
@@ -415,6 +415,16 @@ public class RTPChannel : IDisposable
 
                 var peerAddrAttribute = dataIndication.Attributes.Where(x => x.AttributeType == STUNAttributeTypesEnum.XORPeerAddress).FirstOrDefault();
                 remoteEndPoint = (peerAddrAttribute as STUNXORAddressAttribute)?.GetIPEndPoint();
+
+                // The length guard above was applied to the original data indication, not to the relayed
+                // payload extracted from it. A data indication with no DATA attribute, or with a zero length
+                // one (STUNAttribute.ParseMessageAttributes leaves Value null in that case), leaves the
+                // payload null and the discriminator byte reads below would throw. Drop it here instead.
+                if (packet == null || packet.Length == 0)
+                {
+                    logger.LogWarning("RTPChannel dropped a TURN data indication from {RemoteEndPoint} with a missing or empty DATA attribute.", remoteEndPoint);
+                    return;
+                }
             }
 
             LastRtpDestination = remoteEndPoint;

--- a/test/unit/net/ICE/IceTcpReceiverUnitTest.cs
+++ b/test/unit/net/ICE/IceTcpReceiverUnitTest.cs
@@ -27,6 +27,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using SIPSorcery.UnitTests;
 using Xunit;
@@ -207,6 +209,123 @@ namespace SIPSorcery.Net.UnitTests
                 Assert.Empty(packets);
             }
             finally { socket.Close(); }
+        }
+
+        /// <summary>
+        /// A throw from the packet handler (e.g. a malformed TURN data indication) must not escape the
+        /// framing loop. If it did it would unwind into EndReceiveFrom, close the receiver and permanently
+        /// kill the ICE-over-TCP path for the session. The bad packet is dropped, the framing state stays
+        /// consistent and the next message on the stream is still delivered.
+        /// </summary>
+        [Fact]
+        public void ThrowingPacketHandler_DoesNotBreakFramingOrCloseReceiver()
+        {
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+
+            var socket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+            socket.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+
+            try
+            {
+                var receiver = new TestableIceTcpReceiver(socket);
+                var delivered = new List<byte[]>();
+                receiver.OnPacketReceived += (r, port, ep, pkt) =>
+                {
+                    delivered.Add(pkt);
+                    if (delivered.Count == 1)
+                    {
+                        throw new NullReferenceException("Simulated malformed packet.");
+                    }
+                };
+
+                var bad = StunMessage("bad");
+                var good = StunMessage("good");
+
+                int extracted = receiver.Feed(bad.Concat(good).ToArray());
+
+                Assert.Equal(2, extracted);
+                Assert.Equal(2, delivered.Count);         // the throw did not abort the framing loop.
+                Assert.Equal(good, delivered[1]);
+                Assert.Equal(0, receiver.CachedOffset);   // fragmentation bookkeeping still ran.
+                Assert.False(receiver.IsClosed);          // receiver survives a bad packet.
+            }
+            finally { socket.Close(); }
+        }
+
+        /// <summary>
+        /// A zero byte receive on a stream socket is the end of stream indication, not an empty datagram.
+        /// Re-arming on it recursed (the re-arm completes synchronously with zero bytes and calls straight
+        /// back into EndReceiveFrom) until the process died with a StackOverflowException, which is not
+        /// catchable. Any TURN over TCP server closing the connection gracefully - idle timeout, restart -
+        /// was enough to trigger it. The receiver must instead go idle, staying open so that the reconnect
+        /// in RtpIceChannel.SendOverTCP can resume it.
+        ///
+        /// The harness caps the re-arm count rather than asserting on it after the fact, so a regression
+        /// fails this test instead of taking the test host down with it.
+        /// </summary>
+        [Fact]
+        public async Task RemoteGracefulClose_StopsReArmingWithoutClosing()
+        {
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+
+            const int REARM_CAP = 50;
+
+            var listener = new TcpListener(IPAddress.Loopback, 0);
+            listener.Start();
+
+            var client = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+            Socket server = null;
+
+            try
+            {
+                client.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+                client.Connect((IPEndPoint)listener.LocalEndpoint);
+                server = listener.AcceptSocket();
+
+                var receiver = new CappedReceiver(client, REARM_CAP);
+                receiver.BeginReceiveFrom();
+                await Task.Delay(100);
+
+                // Graceful close from the far end - the receive completes with zero bytes.
+                server.Shutdown(SocketShutdown.Both);
+                server.Close();
+                server = null;
+                await Task.Delay(500);
+
+                Assert.True(receiver.ReArmCount < REARM_CAP, $"The receive loop re-armed {receiver.ReArmCount} times after the remote closed; it is spinning.");
+                Assert.False(receiver.IsRunningReceive);   // gone idle.
+                Assert.False(receiver.IsClosed);           // but still open so a reconnect can resume it.
+            }
+            finally
+            {
+                server?.Close();
+                client.Close();
+                listener.Stop();
+            }
+        }
+
+        /// <summary>
+        /// Counts re-arms and refuses to issue any past the cap, so an unbounded re-arm loop is contained
+        /// instead of overflowing the stack.
+        /// </summary>
+        private sealed class CappedReceiver : IceTcpReceiver
+        {
+            private readonly int _cap;
+            private int _reArmCount;
+
+            public CappedReceiver(Socket socket, int cap) : base(socket) { _cap = cap; }
+
+            public int ReArmCount => _reArmCount;
+
+            public override void BeginReceiveFrom()
+            {
+                if (Interlocked.Increment(ref _reArmCount) > _cap)
+                {
+                    return;
+                }
+
+                base.BeginReceiveFrom();
+            }
         }
 
         [Fact]

--- a/test/unit/net/RTP/RTPChannelUnitTest.cs
+++ b/test/unit/net/RTP/RTPChannelUnitTest.cs
@@ -263,5 +263,66 @@ namespace SIPSorcery.Net.UnitTests
 
             logger.LogDebug("Test complete.");
         }
+
+        /// <summary>
+        /// Test harness that drives the protected packet received handler directly, the same way the socket
+        /// receive loop does, so a malformed packet can be exercised without live socket traffic.
+        /// </summary>
+        private sealed class TestableRTPChannel : RTPChannel
+        {
+            public TestableRTPChannel() : base(false, IPAddress.Loopback) { }
+
+            public void Receive(byte[] packet) => OnRTPPacketReceived(null, RTPPort, new IPEndPoint(IPAddress.Loopback, 9), packet);
+        }
+
+        /// <summary>
+        /// A TURN data indication with no DATA attribute (or a zero length one) leaves the relayed payload
+        /// null after it is extracted, which is after the length guard on the original packet has already
+        /// run. The discriminator byte reads must not be reached with that null payload. On the ICE-over-TCP
+        /// receive path the resulting NullReferenceException closed the receiver outright, permanently
+        /// killing the relay path for the session.
+        /// </summary>
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void RtpChannelDataIndicationWithoutPayloadIsDropped(bool includeEmptyDataAttribute)
+        {
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
+
+            var dataIndication = new STUNMessage(STUNMessageTypesEnum.DataIndication);
+            if (includeEmptyDataAttribute)
+            {
+                dataIndication.Attributes.Add(new STUNAttribute(STUNAttributeTypesEnum.Data, new byte[0]));
+            }
+
+            var buffer = dataIndication.ToByteBuffer(null, false);
+
+            Assert.Equal(0x00, buffer[0]);
+            Assert.Equal(0x17, buffer[1]);
+
+            var channel = new TestableRTPChannel();
+
+            try
+            {
+                bool dataReceived = false;
+                bool stunReceived = false;
+                channel.OnRTPDataReceived += (lep, rep, pkt) => dataReceived = true;
+                channel.OnStunMessageReceived += (msg, rep, relayed) => stunReceived = true;
+
+                // Must not throw - previously a NullReferenceException on the null payload.
+                channel.Receive(buffer);
+
+                Assert.False(dataReceived);
+                Assert.False(stunReceived);
+                Assert.False(channel.IsClosed);
+            }
+            finally
+            {
+                channel.Close("normal");
+            }
+
+            logger.LogDebug("Test complete.");
+        }
     }
 }


### PR DESCRIPTION
Fixes two ways the ICE-over-TCP receive path could be lost. The first is the advisory report; the second was found while checking how this path behaves against an unreachable or closed TCP destination, and is the more serious of the two.

## 1. Malformed TURN data indication (GHSA-mwf8-6m4x-pgmm)

A TURN data indication with no DATA attribute, or with a zero length one, leaves the relayed payload null once it is extracted in `OnRTPPacketReceived`. The length guard in that handler is applied to the *original* data indication, before the payload is extracted, so the discriminator byte reads after it dereferenced the null payload and threw.

On the UDP path the base `UdpReceiver` logs and drops such a packet, so the throw is contained. `IceTcpReceiver` overrides `EndReceiveFrom` and had kept the `catch (Exception) { … Close(…); }` that the base class dropped when the same anti-pattern was fixed for CVE-2026-54632. `Close()` sets `m_isClosed`, which makes the re-arm in the `finally` a no-op *and* permanently disables the re-arm in `RtpIceChannel.SendOverTCP` (gated on `!IsClosed`), so one malformed packet left the ICE-over-TCP receive path dead for the rest of the session.

- `OnRTPPacketReceived` drops a data indication whose payload is missing or empty rather than dereferencing it.
- `IceTcpReceiver.EndReceiveFrom` logs and drops a non-socket exception and lets the loop re-arm, matching the base `UdpReceiver`.
- `ProcessRawBuffer` contains a throw from the packet handler so it cannot unwind out of the framing loop. Without this the drop-and-continue above would resume with `m_recvOffset` left at a stale value and the fragmentation bookkeeping skipped, mis-framing every subsequent message on the stream. This part is not in the advisory.

The catch-all in `BeginReceiveFrom` is deliberately left alone — it still matches the base class, and a throw there means a bad argument or disposed socket rather than a bad packet.

## 2. End of stream recursion (StackOverflowException)

A zero byte receive on a stream socket is end of stream, not an empty datagram as it would be on the UDP path this code was inherited from. It was treated as "nothing to do" and the loop re-armed. `Socket.Connected` stays true after the peer's FIN, so the guard in `BeginReceiveFrom` did not stop it: the re-arm completed synchronously with zero bytes and called straight back into `EndReceiveFrom`, recursing until the process died with a `StackOverflowException` — which .NET cannot catch.

Any TURN-over-TCP server closing the connection gracefully (idle timeout, restart, shutdown) was enough. No malformed input and no malicious peer required. `EndReceiveFrom` now stops re-arming on end of stream, leaving the receiver open but idle so the reconnect in `SendOverTCP` can resume it.

Confirmed pre-existing: the probe crashes the test host identically on unpatched `master`.

## Comments

The `ConnectionReset` and general `SocketException` comments were carried over verbatim from `UdpReceiver` in the refactor and described UDP/ICMP semantics. On a connected TCP socket a reset is real rather than possibly spurious, but not closing is still correct for a different reason: the reconnect in `SendOverTCP` is what recovers the connection, and it needs the receiver left open to do it. Reworded, along with two log messages that still named `RtpIceChannel`.

## Tests

Three added, all verified to fail on the unpatched code and pass with the fix:

- `ThrowingPacketHandler_DoesNotBreakFramingOrCloseReceiver` — a handler throw must not abort framing or close the receiver.
- `RemoteGracefulClose_StopsReArmingWithoutClosing` — the receiver goes idle but stays open after a FIN. The harness caps re-arms at 50 rather than asserting after the fact, so a regression fails the test instead of taking the test host down with it (unpatched: "re-armed 51 times ... it is spinning").
- `RtpChannelDataIndicationWithoutPayloadIsDropped` — a `[Theory]` covering both malformed shapes, no DATA attribute and a zero length one.

Full unit suite on net8.0: 930 passed, 0 failed, 7 skipped.

## Note on the advisory metadata

The affected range in the advisory (`>= 10.0.10`) looks wrong. `git show d5df28c78~1` shows the identical override with `Close(excp.Message)` as a nested class in `RtpIceChannel.cs` back through v10.0.0 — it only became exploitable on its own once the base class was fixed.

Reported by zx (Jace) (@manus-use).
