### PR TITLE
Validate SCTP SACK gap ack block and duplicate TSN counts

### DIFF
--- a/src/SIPSorcery/net/SCTP/Chunks/SctpSackChunk.cs
+++ b/src/SIPSorcery/net/SCTP/Chunks/SctpSackChunk.cs
@@ -17,6 +17,7 @@
 // BSD 3-Clause "New" or "Revised" License, see included LICENSE.md file.
 //-----------------------------------------------------------------------------
 
+using System;
 using System.Collections.Generic;
 using SIPSorcery.Sys;
 
@@ -134,12 +135,37 @@ namespace SIPSorcery.Net
             var sackChunk = new SctpSackChunk();
             ushort chunkLen = sackChunk.ParseFirstWord(buffer, posn);
 
+            // The chunk must be long enough to hold the fixed parameters before they are read. The caller
+            // only guarantees the chunk length is at least an SCTP chunk header and that the chunk fits in
+            // the buffer, so anything shorter than this would read bytes belonging to whatever follows.
+            if (chunkLen < SCTP_CHUNK_HEADER_LENGTH + FIXED_PARAMETERS_LENGTH)
+            {
+                throw new ApplicationException($"The SCTP SACK chunk was too short. The minimum length is {SCTP_CHUNK_HEADER_LENGTH + FIXED_PARAMETERS_LENGTH} bytes but the chunk specified {chunkLen} bytes.");
+            }
+
             ushort startPosn = (ushort)(posn + SCTP_CHUNK_HEADER_LENGTH);
 
             sackChunk.CumulativeTsnAck = NetConvert.ParseUInt32(buffer, startPosn);
             sackChunk.ARwnd = NetConvert.ParseUInt32(buffer, startPosn + 4);
             ushort numGapAckBlocks = NetConvert.ParseUInt16(buffer, startPosn + 8);
             ushort numDuplicateTSNs = NetConvert.ParseUInt16(buffer, startPosn + 10);
+
+            // The gap ack block and duplicate TSN counts are supplied by the remote party and each allows
+            // up to 65535 entries, so they must be checked against the length the chunk actually declared.
+            // Without this the loops below read whatever follows the chunk in the receive buffer: far
+            // enough past it and the read leaves the buffer entirely, and the resulting
+            // IndexOutOfRangeException is not one of the recoverable parse failures the SCTP receive loop
+            // expects, so it terminates the receive thread and with it the association. Short of that the
+            // reads stay in bounds and quietly turn stale bytes left by earlier packets into gap ack
+            // blocks and duplicate TSNs, corrupting the sender's retransmission state instead.
+            int requiredLen = SCTP_CHUNK_HEADER_LENGTH + FIXED_PARAMETERS_LENGTH
+                + numGapAckBlocks * GAP_REPORT_LENGTH
+                + numDuplicateTSNs * DUPLICATE_TSN_LENGTH;
+
+            if (requiredLen > chunkLen)
+            {
+                throw new ApplicationException($"The SCTP SACK chunk was too short for the gap ack block and duplicate TSN counts it specified. Required {requiredLen} bytes but the chunk specified {chunkLen} bytes.");
+            }
 
             int reportPosn = startPosn + FIXED_PARAMETERS_LENGTH;
 

--- a/src/SIPSorcery/net/WebRTC/RTCSctpTransport.cs
+++ b/src/SIPSorcery/net/WebRTC/RTCSctpTransport.cs
@@ -347,6 +347,17 @@ namespace SIPSorcery.Net
                     // Treat application exceptions as recoverable, things like SCTP packet parse failures.
                     logger.LogWarning("SCTP error processing RTCSctpTransport receive. {Message}", appExcp.Message);
                 }
+                catch (Exception parseExcp) when (parseExcp is IndexOutOfRangeException || parseExcp is ArgumentException)
+                {
+                    // Defence in depth for the same class of failure. Malformed input reaching a parser that
+                    // indexes the receive buffer without its own length check surfaces as one of these rather
+                    // than as an ApplicationException, and the generic handler below would break out of the
+                    // loop and end the receive thread for good. A single bad packet from the remote party must
+                    // not cost the association, so drop it and carry on. Anything that genuinely leaves the
+                    // transport unusable will fail again on the next iteration through the socket or DTLS
+                    // exception paths.
+                    logger.LogWarning(parseExcp, "SCTP error parsing packet received on RTCSctpTransport, packet dropped. {Message}", parseExcp.Message);
+                }
                 catch (TlsFatalAlert alert) when (alert.InnerException is SocketException)
                 {
                     var sockExcp = alert.InnerException as SocketException;

--- a/test/unit/net/SCTP/SctpChunkUnitTest.cs
+++ b/test/unit/net/SCTP/SctpChunkUnitTest.cs
@@ -13,6 +13,7 @@
 // BSD 3-Clause "New" or "Revised" License, see included LICENSE.md file.
 //-----------------------------------------------------------------------------
 
+using System;
 using System.Linq;
 using Microsoft.Extensions.Logging;
 using SIPSorcery.Sys;
@@ -69,6 +70,101 @@ namespace SIPSorcery.Net.UnitTests
             Assert.NotNull(sackPkt);
             Assert.Single(sackPkt.Chunks);
             Assert.Equal(2806612857U, (sackPkt.Chunks.Single() as SctpSackChunk).DuplicateTSN.Single());
+        }
+
+        /// <summary>
+        /// The gap ack block and duplicate TSN counts in a SACK chunk are supplied by the remote party and
+        /// each allows up to 65535 entries. They must be validated against the length the chunk declared.
+        /// The maximum counts drive the parse loops past the end of the receive buffer, and the resulting
+        /// IndexOutOfRangeException is not one of the recoverable parse failures the SCTP receive loop
+        /// expects, so it terminated the receive thread and with it the association and every data channel.
+        /// The counts must be rejected as a recoverable parse failure instead.
+        /// </summary>
+        [Theory]
+        [InlineData(0xFFFF, 0x0000)]   // gap ack blocks alone are enough.
+        [InlineData(0x0000, 0xFFFF)]   // as are duplicate TSNs alone.
+        [InlineData(0xFFFF, 0xFFFF)]
+        [InlineData(0x0064, 0x0000)]   // a count small enough to stay in bounds must be rejected too - it
+        [InlineData(0x0000, 0x0064)]   // silently parses stale bytes from earlier packets instead.
+        public void ParseSACKChunkWithOversizedCountsIsRejected(int numGapAckBlocks, int numDuplicateTSNs)
+        {
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
+
+            // A SACK chunk declaring only the fixed parameters (chunk length 16) but claiming it carries
+            // gap ack blocks and/or duplicate TSNs, parsed from a buffer the size of the real receive
+            // buffer so an unbounded read has somewhere to run before it leaves the array.
+            var buffer = new byte[(int)SctpAssociation.DEFAULT_ADVERTISED_RECEIVE_WINDOW];
+
+            buffer[0] = (byte)SctpChunkType.SACK;
+            buffer[1] = 0x00;                                       // Chunk flags.
+            NetConvert.ToBuffer((ushort)16, buffer, 2);             // Chunk length, fixed parameters only.
+            NetConvert.ToBuffer(1000U, buffer, 4);                  // Cumulative TSN ack.
+            NetConvert.ToBuffer(262144U, buffer, 8);                // ARwnd.
+            NetConvert.ToBuffer((ushort)numGapAckBlocks, buffer, 12);
+            NetConvert.ToBuffer((ushort)numDuplicateTSNs, buffer, 14);
+
+            var ex = Assert.Throws<ApplicationException>(() => SctpSackChunk.ParseChunk(buffer, 0));
+
+            logger.LogDebug("Parse rejected with: {Message}", ex.Message);
+        }
+
+        /// <summary>
+        /// A SACK chunk too short to even hold the fixed parameters must also be rejected. SctpPacket only
+        /// checks a chunk is at least an SCTP chunk header long, so without this the fixed parameter reads
+        /// run past the end of the chunk.
+        /// </summary>
+        [Fact]
+        public void ParseSACKChunkShorterThanFixedParametersIsRejected()
+        {
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
+
+            var buffer = new byte[64];
+
+            buffer[0] = (byte)SctpChunkType.SACK;
+            buffer[1] = 0x00;
+            NetConvert.ToBuffer((ushort)4, buffer, 2);              // Chunk header only.
+
+            Assert.Throws<ApplicationException>(() => SctpSackChunk.ParseChunk(buffer, 0));
+        }
+
+        /// <summary>
+        /// A SACK chunk whose counts match its declared length must still parse, including when it sits
+        /// after the SCTP common header in a full packet.
+        /// </summary>
+        [Fact]
+        public void ParseSACKChunkWithMatchingCountsSucceeds()
+        {
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
+
+            // Chunk length 16 fixed + 2 gap ack blocks (8) + 1 duplicate TSN (4) = 28.
+            var buffer = new byte[64];
+
+            buffer[0] = (byte)SctpChunkType.SACK;
+            buffer[1] = 0x00;
+            NetConvert.ToBuffer((ushort)28, buffer, 2);
+            NetConvert.ToBuffer(1000U, buffer, 4);
+            NetConvert.ToBuffer(262144U, buffer, 8);
+            NetConvert.ToBuffer((ushort)2, buffer, 12);             // Gap ack blocks.
+            NetConvert.ToBuffer((ushort)1, buffer, 14);             // Duplicate TSNs.
+            NetConvert.ToBuffer((ushort)3, buffer, 16);             // Gap block 1 start.
+            NetConvert.ToBuffer((ushort)5, buffer, 18);             // Gap block 1 end.
+            NetConvert.ToBuffer((ushort)8, buffer, 20);             // Gap block 2 start.
+            NetConvert.ToBuffer((ushort)9, buffer, 22);             // Gap block 2 end.
+            NetConvert.ToBuffer(1234U, buffer, 24);                 // Duplicate TSN.
+
+            var sackChunk = SctpSackChunk.ParseChunk(buffer, 0);
+
+            Assert.Equal(1000U, sackChunk.CumulativeTsnAck);
+            Assert.Equal(262144U, sackChunk.ARwnd);
+            Assert.Equal(2, sackChunk.GapAckBlocks.Count);
+            Assert.Equal(3, sackChunk.GapAckBlocks[0].Start);
+            Assert.Equal(5, sackChunk.GapAckBlocks[0].End);
+            Assert.Equal(8, sackChunk.GapAckBlocks[1].Start);
+            Assert.Equal(9, sackChunk.GapAckBlocks[1].End);
+            Assert.Equal(1234U, sackChunk.DuplicateTSN.Single());
         }
     }
 }


### PR DESCRIPTION
Fixes GHSA-jwjp-4649-v8jp. Branched off `master`, independent of #1771.

## The bug

`SctpSackChunk.ParseChunk` read the gap ack block and duplicate TSN counts straight from the chunk and looped that many times, 4 bytes per iteration, without checking either count against the length the chunk declared. Both come from the remote party and each allows up to 65535 entries, and `NetConvert.ParseUInt16/32` index the buffer with no bounds check of their own.

With the maximum count the gap ack loop reaches offset 262144 in the 262144 byte receive buffer on the 65529th iteration (`28 + 65529*4`) and throws `IndexOutOfRangeException`. That is a `SystemException`, so the recoverable `catch (ApplicationException)` in `RTCSctpTransport.DoReceive` is skipped and the generic handler `break`s out of the loop. `_receiveThread` is created and started once with no restart, so one crafted SACK chunk from a negotiated peer left the association and every data channel permanently dead.

## The failure mode the advisory missed

Below the buffer size there is **no exception at all**. `recvBuffer` is allocated once and reused across receives, so a chunk declaring `chunkLength=16` with a count of 100 parses 100 gap ack blocks out of bytes left by earlier packets and hands them to the data sender — silently corrupting retransmission state, no crash, no log.

That drove the shape of the fix. Bounds-checking `NetConvert`, or catching `IndexOutOfRangeException` in `DoReceive`, only addresses the crash and leaves this path fully open. The validation has to be against the declared chunk length, not against the buffer.

Both failure modes are reproduced in the tests; against unpatched code the max-count cases fail with `IndexOutOfRangeException` and the count-of-100 cases fail with "No exception was thrown".

## Changes

- `SctpSackChunk.ParseChunk` rejects a SACK chunk shorter than the fixed parameters, and one whose counts do not fit its declared length, with `ApplicationException`. That is this codebase's convention for malformed SCTP (`SctpPacket.ParseChunks` does the same) and `DoReceive` already treats it as recoverable, so the packet is dropped with a warning and the association survives. No change to the catch structure needed for this bug.
- `DoReceive` additionally treats `IndexOutOfRangeException` and `ArgumentException` as recoverable. This is **defence in depth, not part of the fix above** — any parser that indexes the receive buffer without its own length check surfaces malformed input as one of these, and the generic handler would again end the receive thread permanently. Conditions that genuinely leave the transport unusable still exit via the socket and DTLS paths on the next iteration.

## Scope check

I swept the other chunk parsers for the same pattern. `SctpSackChunk` is the only one whose loop bound comes from the wire — the `SctpInitChunk` and `SctpErrorChunk` loops are bounded by the length of the parameter value already parsed out of the buffer. I also checked `SctpChunk.GetParameters` for the zero-length-advance bug that GHSA-qmvg-569h-hqrh fixed elsewhere: a zero-length TLV still advances 4 bytes via `PadTo4ByteBoundary`, so there is no infinite loop there.

## Tests

Added to `SctpChunkUnitTest`, all verified to fail on unpatched code:

- `ParseSACKChunkWithOversizedCountsIsRejected` — a `[Theory]` over `0xFFFF` gap blocks, `0xFFFF` duplicate TSNs, both, and the in-bounds count of 100 for each. Parsed from a full-size 262144 byte buffer so an unbounded read has somewhere to run.
- `ParseSACKChunkShorterThanFixedParametersIsRejected` — `chunkLength=4`, which `SctpPacket` accepts.
- `ParseSACKChunkWithMatchingCountsSucceeds` — well-formed chunk with 2 gap blocks and 1 duplicate TSN still parses.

The existing `ParseSACKChunk` test (real capture, 1 duplicate TSN, `chunkLength=20`) is unaffected. Full unit suite on net8.0: 937 passed, 0 failed, 7 skipped.

## Severity

For what it is worth I agree with the reporter's `AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H` (7.5) on this one. Unlike GHSA-mwf8-6m4x-pgmm it needs no MITM and no particular configuration — any peer that completes DTLS can send it, which for a public-facing data channel endpoint is any client. Blast radius is data channels only; the RTP media path is unaffected.

Reported by zx (Jace) (@manus-use).
