### PR TITLE
Mark TurnServer experimental with diagnostic SIPSORCERY001

### DIFF
--- a/docs/diagnostics/SIPSORCERY001.md
+++ b/docs/diagnostics/SIPSORCERY001.md
@@ -1,0 +1,52 @@
+# SIPSORCERY001
+
+**`TurnServer` is not hardened for production use.**
+
+`SIPSorcery.Net.TurnServer` is a lightweight TURN relay (RFC 5766) written for development, testing,
+and small scale or embedded scenarios. It is marked with
+[`ExperimentalAttribute`](https://learn.microsoft.com/dotnet/api/system.diagnostics.codeanalysis.experimentalattribute),
+so referencing it is a compile error until this diagnostic is suppressed. That is deliberate: the
+limitations below should be an explicit decision rather than something discovered after deployment.
+
+For a production TURN deployment use [coturn](https://github.com/coturn/coturn) or an equivalent
+hardened server.
+
+## What is missing
+
+- **No nonce validation or expiry.** Nonces are generated but never verified on subsequent requests,
+  so replay attacks are possible within the allocation lifetime.
+- **No rate limiting and no per-IP allocation caps.** A misbehaving or hostile client can exhaust
+  server resources.
+- **No TLS/DTLS on the control channel.** Credentials travel in the clear unless the transport is
+  already secured. The default listen address is loopback for this reason.
+- **Allocation lifetime is not capped.** Clients can request arbitrarily long lifetimes.
+- **Weak default credentials** (`turn-user` / `turn-pass`), intentionally, to encourage replacement.
+- **No per-user credential database** outside of REST-style ephemeral credentials.
+- **UDP-only relay.** No TCP relay (RFC 6062) and no TURN-over-TLS.
+- **IPv4 only.** No IPv6 relay addresses.
+- **Unimplemented:** REQUESTED-TRANSPORT validation, EVEN-PORT, RESERVATION-TOKEN, ALTERNATE-SERVER.
+
+The XML documentation on the type carries the same list and stays authoritative if the two drift.
+
+## Suppressing it
+
+For a whole project, in the csproj:
+
+```xml
+<PropertyGroup>
+  <NoWarn>$(NoWarn);SIPSORCERY001</NoWarn>
+</PropertyGroup>
+```
+
+For a single file or region:
+
+```csharp
+#pragma warning disable SIPSORCERY001
+```
+
+`examples/TurnServerExample/Program.cs` shows the file scoped form.
+
+## Reporting issues
+
+Bugs in `TurnServer` are welcome as ordinary issues. Because it is not a supported production
+component, defects in it are not treated as security advisories against the SIPSorcery library.

--- a/examples/TurnServerExample/Program.cs
+++ b/examples/TurnServerExample/Program.cs
@@ -26,6 +26,13 @@ using Serilog;
 using Serilog.Extensions.Logging;
 using SIPSorcery.Net;
 
+// TurnServer is marked experimental because it is intended for development, testing and small scale or
+// embedded scenarios rather than production use, so referencing it is a compile error until this
+// diagnostic is suppressed. This example is exactly that sort of scenario. A project using TurnServer
+// can suppress it the same way, or add <NoWarn>$(NoWarn);SIPSORCERY001</NoWarn> to its csproj. See
+// docs/diagnostics/SIPSORCERY001.md for what the limitations are.
+#pragma warning disable SIPSORCERY001
+
 namespace TurnServerExample
 {
     class Program

--- a/src/SIPSorcery/SIPSorcery.csproj
+++ b/src/SIPSorcery/SIPSorcery.csproj
@@ -77,7 +77,8 @@
     <RepositoryBranch>master</RepositoryBranch>
     <PolyArgumentExceptions>true</PolyArgumentExceptions>
     <PackageTags>SIP WebRTC VoIP RTP SDP STUN ICE SIPSorcery</PackageTags>
-    <PackageReleaseNotes>-v10.0.13: Fix license file.
+    <PackageReleaseNotes>-v10.0.14: TurnServer marked experimental (diagnostic SIPSORCERY001); it is intended for development and testing, not production. Suppress the diagnostic to continue using it.
+-v10.0.13: Fix license file.
 -v10.0.12: Fix for SCTP packet zero length infinite loop vulnerability.
 -v10.0.11: Add support for additional video codecs (VP9, AV1, H265). WHIP and WHEP support. Bug fixes.
 -v10.0.10: Bug fixes. Adjust restriction on remote peer endpoints when blocking WebRTC RTP traffic.

--- a/src/SIPSorcery/net/TURN/TurnServer.cs
+++ b/src/SIPSorcery/net/TURN/TurnServer.cs
@@ -18,6 +18,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Net;
 using System.Net.NetworkInformation;
@@ -186,6 +187,14 @@ namespace SIPSorcery.Net
     ///   <item>Allocation lifetime is not capped — clients can request arbitrarily long lifetimes.</item>
     ///   <item>No ALTERNATE-SERVER support.</item>
     /// </list>
+    /// <para>
+    /// Because of the above this type is marked with
+    /// <see cref="System.Diagnostics.CodeAnalysis.ExperimentalAttribute"/> and using it is a compile
+    /// error until the <c>SIPSORCERY001</c> diagnostic is suppressed, so that the limitations are
+    /// acknowledged rather than discovered in production. To suppress it for a project add
+    /// <c>&lt;NoWarn&gt;$(NoWarn);SIPSORCERY001&lt;/NoWarn&gt;</c> to the csproj, or use
+    /// <c>#pragma warning disable SIPSORCERY001</c> around the usage.
+    /// </para>
     /// <para><strong>Security considerations:</strong></para>
     /// <list type="bullet">
     ///   <item>Default credentials (<c>turn-user</c> / <c>turn-pass</c>) — callers MUST configure
@@ -211,6 +220,7 @@ namespace SIPSorcery.Net
     /// server.Dispose(); // or server.Stop();
     /// </code>
     /// </example>
+    [Experimental("SIPSORCERY001", UrlFormat = "https://github.com/sipsorcery-org/sipsorcery/blob/master/docs/diagnostics/{0}.md")]
     public class TurnServer : IDisposable
     {
         private const int PERMISSION_LIFETIME_SECONDS = 300; // RFC 5766 Section 8
@@ -389,6 +399,13 @@ namespace SIPSorcery.Net
 
             logger.LogInformation("TURN server started on {Address}:{Port} (TCP={Tcp}, UDP={Udp}).",
                 _config.ListenAddress, _config.Port, _config.EnableTcp, _config.EnableUdp);
+
+            // The compile time SIPSORCERY001 diagnostic can be suppressed once and then forgotten, so the
+            // same caveat is repeated here for whoever is looking at the logs of a running process.
+            logger.LogWarning("TURN server is intended for development, testing and small scale or embedded " +
+                "scenarios and is not hardened for production use. It has no nonce validation, no rate limiting " +
+                "or per-IP allocation caps and no TLS/DTLS on the control channel. Use coturn or an equivalent " +
+                "for production deployments.");
         }
 
         /// <summary>

--- a/test/unit/net/TURN/TurnServerUnitTest.cs
+++ b/test/unit/net/TURN/TurnServerUnitTest.cs
@@ -24,6 +24,10 @@ using SIPSorcery.Sys;
 using SIPSorcery.UnitTests;
 using Xunit;
 
+// TurnServer is marked experimental because it is not hardened for production use. These tests are
+// exercising it deliberately, so the diagnostic is suppressed for this file.
+#pragma warning disable SIPSORCERY001
+
 namespace SIPSorcery.Net.UnitTests
 {
     [Trait("Category", "unit")]


### PR DESCRIPTION
`TurnServer` is written for development, testing, and small scale or embedded scenarios, not for production. The XML documentation says so and lists the limitations in detail, but a doc comment is easy to miss and carries no weight at build time, so package consumers have had no real signal.

## Change

`ExperimentalAttribute` is the purpose-built mechanism for this. Referencing `TurnServer` is now a compile **error** until `SIPSORCERY001` is suppressed, which makes using it a deliberate decision rather than something discovered after deployment. `UrlFormat` points the diagnostic at a new `docs/diagnostics/SIPSORCERY001.md` spelling out what is missing — no nonce validation or expiry, no rate limiting or per-IP allocation caps, no TLS/DTLS on the control channel, uncapped allocation lifetimes, UDP-only relay, IPv4 only.

The attribute comes from the `Polyfill` package already referenced, so it applies across all nine target frameworks including net462 and netstandard2.0 with no project changes.

The diagnostic can be suppressed once and then forgotten, so `Start()` also logs a warning naming the main gaps for whoever is reading the logs of a running process.

## Alternatives considered

- **`[Obsolete]`** — only a warning, renders with strikethrough implying imminent removal, and `TurnServer` is not deprecated. Its one advantage is a custom message string; `ExperimentalAttribute`'s text is fixed by the compiler, which is why the `UrlFormat` link matters.
- **`[EditorBrowsable(Never)]`** — only hides the type from IntelliSense in other assemblies and warns about nothing. Makes the supported testing use harder without discouraging the unsupported production use.

## Breaking change

This breaks the build for anyone already referencing `TurnServer`, which has shipped since v10.0.5. The fix is one `<NoWarn>SIPSORCERY001</NoWarn>` entry or one `#pragma`, and the release notes call it out. That friction is the point, but it is worth being explicit about.

`<Version>` is deliberately not bumped here — the release notes entry is written against v10.0.14 on the assumption that happens as a separate release step.

## Verified

- All nine TFMs build clean (`netstandard2.0`, `netstandard2.1`, `netcoreapp3.1`, `net462`, `net5.0`, `net6.0`, `net8.0`, `net9.0`, `net10.0`).
- The diagnostic genuinely fires. With the suppression removed, the example fails with:
  `error SIPSORCERY001: 'SIPSorcery.Net.TurnServer' is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed. (https://github.com/sipsorcery-org/sipsorcery/blob/master/docs/diagnostics/SIPSORCERY001.md)`
  confirming `UrlFormat` resolves.
- Unit suite on net8.0: 937 passed, 0 failed, 7 skipped.

## In-repo consumers

`TurnServerUnitTest.cs` and `examples/TurnServerExample/Program.cs` suppress the diagnostic at file scope with a comment explaining why. The example's comment doubles as documentation of how a consumer does the same.

## Note on security reports

`docs/diagnostics/SIPSORCERY001.md` states that `TurnServer` defects are welcome as ordinary issues but are not treated as security advisories against the library. That makes the position defensible for future reports. It does not apply retroactively to versions already on NuGet, which shipped `TurnServer` as public API with no machine-readable caveat.
