### PR TITLE
Isolate TurnServer datagram and message processing from the receive loops

### DIFF
--- a/src/SIPSorcery/net/TURN/TurnServer.cs
+++ b/src/SIPSorcery/net/TURN/TurnServer.cs
@@ -485,7 +485,14 @@ namespace SIPSorcery.Net
                                 break;
                         }
 
-                        HandleChannelData(allocation, channelNumber, data, 0, data.Length);
+                        try
+                        {
+                            HandleChannelData(allocation, channelNumber, data, 0, data.Length);
+                        }
+                        catch (Exception channelDataExcp)
+                        {
+                            logger.LogWarning(channelDataExcp, "TURN server dropped channel data from TCP client {Client} that could not be processed. {ErrorMessage}", clientId, channelDataExcp.Message);
+                        }
                     }
                     else
                     {
@@ -498,17 +505,41 @@ namespace SIPSorcery.Net
                         if (remaining > 0 && !await ReadExactAsync(stream, fullMsg, 4, remaining).ConfigureAwait(false))
                             break;
 
-                        var stunMsg = STUNMessage.ParseSTUNMessage(fullMsg, fullMsg.Length);
+                        // Parsing and processing are isolated from the read loop for the same reason as
+                        // the UDP path. The framing above has already consumed exactly this message's
+                        // bytes, so the stream stays in a consistent position and the connection can
+                        // carry on with the next message rather than being dropped over one bad one.
+                        // The reads themselves stay outside this try so a genuinely broken connection
+                        // still exits via the IOException handler below instead of spinning.
+                        STUNMessage stunMsg;
+
+                        try
+                        {
+                            stunMsg = STUNMessage.ParseSTUNMessage(fullMsg, fullMsg.Length);
+                        }
+                        catch (Exception parseExcp)
+                        {
+                            logger.LogWarning(parseExcp, "TURN server dropped an unparseable STUN message from TCP client {Client}. {ErrorMessage}", clientId, parseExcp.Message);
+                            continue;
+                        }
+
                         if (stunMsg == null)
                         {
                             logger.LogWarning("Failed to parse STUN message from TCP client {Client}.", clientId);
                             continue;
                         }
 
-                        ProcessMessage(stunMsg, clientId, clientEndPoint,
-                            (responseBytes) => SendTcpResponseAsync(stream, responseBytes),
-                            ref allocation,
-                            stream, null, null);
+                        try
+                        {
+                            ProcessMessage(stunMsg, clientId, clientEndPoint,
+                                (responseBytes) => SendTcpResponseAsync(stream, responseBytes),
+                                ref allocation,
+                                stream, null, null);
+                        }
+                        catch (Exception processExcp) when (!(processExcp is System.IO.IOException) && !(processExcp is OperationCanceledException))
+                        {
+                            logger.LogWarning(processExcp, "TURN server failed to process a STUN message from TCP client {Client}. {ErrorMessage}", clientId, processExcp.Message);
+                        }
                     }
                 }
             }
@@ -566,7 +597,21 @@ namespace SIPSorcery.Net
                     catch (ObjectDisposedException) { break; }
                     catch (SocketException) { break; }
 
-                    HandleUdpDatagram(result.Buffer, result.RemoteEndPoint);
+                    // Processing a datagram is isolated from the receive loop. The datagram is
+                    // unauthenticated and arbitrary, and the STUN parser throws on input it does not
+                    // recognise, so without this a single malformed datagram from anyone who can reach
+                    // the port unwinds past the loop. The loop is started fire and forget with no
+                    // supervision, so nothing would restart it and the UDP relay would stay down for
+                    // every client until the process was restarted.
+                    try
+                    {
+                        HandleUdpDatagram(result.Buffer, result.RemoteEndPoint);
+                    }
+                    catch (Exception datagramExcp)
+                    {
+                        logger.LogWarning(datagramExcp, "TURN server dropped a UDP datagram from {Remote} that could not be processed. {ErrorMessage}",
+                            result.RemoteEndPoint, datagramExcp.Message);
+                    }
                 }
             }
             catch (ObjectDisposedException) { }

--- a/test/unit/net/TURN/TurnServerUnitTest.cs
+++ b/test/unit/net/TURN/TurnServerUnitTest.cs
@@ -646,6 +646,62 @@ namespace SIPSorcery.Net.UnitTests
             // If the cleanup timer already ran, allocation count could be 0
         }
 
+        /// <summary>
+        /// A UDP datagram arriving on the TURN port is unauthenticated and arbitrary, and the STUN parser
+        /// throws on input it does not recognise. Processing used to sit inside the receive loop but
+        /// outside any per datagram handler, so one malformed datagram unwound past the loop and ended it.
+        /// The loop is started fire and forget with no supervision, so nothing restarted it and the UDP
+        /// relay stayed down for every client until the process was restarted. The datagram must be
+        /// dropped and the loop must keep serving.
+        /// </summary>
+        /// <param name="malformed">
+        /// First case: an ApplicationException from the STUN header check, the first byte has bits set that
+        /// the parser rejects and it is not channel data. Second case: a datagram too short to hold a STUN
+        /// header, where the header parse returns null and dereferencing it throws.
+        /// </param>
+        [Theory]
+        [InlineData(new byte[] { 0x80, 0x00, 0x00, 0x00 })]
+        [InlineData(new byte[] { 0x00, 0x01, 0x00 })]
+        public async Task MalformedUdpDatagramDoesNotKillReceiveLoop(byte[] malformed)
+        {
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+
+            var (server, port) = CreateTurnServer(enableTcp: false, enableUdp: true);
+            var serverEndPoint = new IPEndPoint(IPAddress.Loopback, port);
+
+            using var client = new UdpClient(new IPEndPoint(IPAddress.Loopback, 0));
+
+            // Confirm the relay is answering before the malformed datagram, so a failure after it cannot be
+            // blamed on the server never having started.
+            Assert.True(await UdpAllocateGetsChallenge(client, serverEndPoint),
+                "The TURN server did not answer a valid UDP request before the malformed datagram.");
+
+            await client.SendAsync(malformed, malformed.Length, serverEndPoint);
+            await Task.Delay(250);
+
+            Assert.True(await UdpAllocateGetsChallenge(client, serverEndPoint),
+                "The TURN server stopped answering UDP requests after a malformed datagram; the receive loop died.");
+        }
+
+        /// <summary>
+        /// Sends an unauthenticated Allocate over UDP and returns true if the 401 challenge comes back.
+        /// </summary>
+        private static async Task<bool> UdpAllocateGetsChallenge(UdpClient client, IPEndPoint serverEndPoint)
+        {
+            var request = BuildAllocateRequest().ToByteBuffer(null, false);
+            await client.SendAsync(request, request.Length, serverEndPoint);
+
+            var receiveTask = client.ReceiveAsync();
+            if (await Task.WhenAny(receiveTask, Task.Delay(3000)) != receiveTask)
+            {
+                return false;
+            }
+
+            var response = STUNMessage.ParseSTUNMessage(receiveTask.Result.Buffer, receiveTask.Result.Buffer.Length);
+
+            return response != null && response.Header.MessageType == STUNMessageTypesEnum.AllocateErrorResponse;
+        }
+
         #region Test Helpers
 
         /// <summary>


### PR DESCRIPTION
Fixes GHSA-pfvm-w89x-94jw. Branched off `master`, independent of #1771, #1772 and #1773.

## The bug

A UDP datagram arriving on the TURN port is unauthenticated and arbitrary, and the STUN parser throws on input it does not recognise. `HandleUdpDatagram` was called inside the receive loop but outside any per-datagram handler, with the generic `catch` sitting outside the loop entirely, so a throw unwound past the loop and ended it. `ReceiveUdpAsync` is started fire-and-forget by `Start()` with no supervision, so nothing restarted it — the UDP relay stayed down for every client until the process was restarted.

## Two ways in, not one

The advisory describes the first only. Both are covered by tests:

1. **`ApplicationException`** — first byte with bits the STUN header check rejects (e.g. `0x80`), not channel data, throws from `STUNHeader.ParseSTUNHeader`.
2. **`NullReferenceException`** — a datagram too short to hold a STUN header but starting with an accepted first byte (e.g. `00 01 00`). `ParseSTUNHeader` returns null once the length check fails, and `STUNMessage.ParseSTUNMessage` then dereferences it for `MessageLength`.

Against unpatched code both kill the loop identically: `The TURN server stopped answering UDP requests after a malformed datagram; the receive loop died.`

## Changes

- `HandleUdpDatagram` is wrapped per datagram — the offending datagram is logged and dropped, the loop carries on.
- The TCP path had the same structure (parsing and `ProcessMessage` inside the per-client loop, generic catch outside it) and is fixed the same way. Blast radius there is one client's own connection rather than the whole server, so it is robustness rather than the same denial of service, but it was worth doing while here. The framing has already consumed exactly the bytes of the message being parsed, so the stream stays in a consistent position and the connection continues with the next message instead of being dropped over one bad one.

The reads are deliberately left **outside** the new try blocks, and `IOException`/`OperationCanceledException` are excluded from the `ProcessMessage` handler, so a genuinely broken connection still exits through the existing handlers rather than spinning.

I did not add loop supervision or restart. Per-datagram isolation is the actual fix and matches the drop-and-continue pattern used elsewhere in the library; a supervisor would add a restart path that should now never be needed.

## Tests

`MalformedUdpDatagramDoesNotKillReceiveLoop` — a `[Theory]` over both payloads. It asserts the relay answers a valid UDP Allocate *before* sending the malformed datagram as well as after, so a failure cannot be misread as the server never having started. Verified to fail on unpatched code for both cases.

All nine TFMs build clean. Unit suite on net8.0: 939 passed, 0 failed, 7 skipped.

## Note on classification

This lands alongside #1773, which marks `TurnServer` experimental precisely because it is not production-hardened. Fixing the bug and declining the CVE are not in tension: the defect is real and worth fixing, while the component is documented as unsuitable for production deployment. That argument applies to future reports rather than to versions already published without a machine-readable caveat.

Reported by zx (Jace) (@manus-use).
