### PR TITLE
Detect a half closed ICE server TCP connection instead of sending into it

### DIFF
--- a/src/SIPSorcery/net/ICE/IceTcpReceiver.cs
+++ b/src/SIPSorcery/net/ICE/IceTcpReceiver.cs
@@ -27,10 +27,31 @@ public class IceTcpReceiver : UdpReceiver
     protected const int REVEIVE_TCP_BUFFER_SIZE = RECEIVE_BUFFER_SIZE * 2;
 
     protected int m_recvOffset;
+    protected bool m_isEndOfStream;
+
     public IceTcpReceiver(Socket socket, int mtu = REVEIVE_TCP_BUFFER_SIZE) : base(socket, mtu)
     {
         m_recvOffset = 0;
     }
+
+    /// <summary>
+    /// True once a receive has completed with zero bytes, which on a stream socket means the remote end
+    /// has closed the connection. Once set it stays set: the connection is finished and this receiver's
+    /// socket cannot serve another one.
+    /// </summary>
+    /// <remarks>
+    /// This is the reliable signal that the connection is gone. <see cref="Socket.Connected"/> is not: it
+    /// reports the state as of the last I/O operation and stays true after the remote end's FIN, so a half
+    /// closed connection still looks connected to any caller that checks it. Callers that need to know
+    /// whether the connection is usable should consult this as well.
+    /// <para>
+    /// There is no recovery in place. A connected socket cannot be reused once disconnected
+    /// (<see cref="Socket.Connect(EndPoint)"/> throws <see cref="InvalidOperationException"/> after
+    /// <see cref="Socket.Disconnect(bool)"/>, whatever endpoint is passed), so resuming means a new socket
+    /// and a new receiver.
+    /// </para>
+    /// </remarks>
+    public virtual bool IsEndOfStream => m_isEndOfStream;
 
     /// <summary>
     /// Starts the receive. This method returns immediately. An event will be fired in the corresponding "End" event to
@@ -97,6 +118,8 @@ public class IceTcpReceiver : UdpReceiver
         // must not be re-armed. Socket.Connected remains true after the peer's FIN, so the guard in
         // BeginReceiveFrom does not stop it: the re-arm would complete synchronously with zero bytes and
         // call straight back into this method, recursing until the process died with a StackOverflowException.
+        // It is also surfaced on IsEndOfStream so the send path can tell a half closed connection from a
+        // live one, which Socket.Connected cannot.
         bool endOfStream = false;
 
         try
@@ -188,8 +211,16 @@ public class IceTcpReceiver : UdpReceiver
         finally
         {
             m_isRunningReceive = false;
-            // On end of stream the receiver is left open but idle rather than closed, so the reconnect in
-            // RtpIceChannel.SendOverTCP (which re-arms while !IsRunningReceive && !IsClosed) can resume it.
+            // On end of stream the receiver is left open but idle rather than closed. Closing here would
+            // fire OnClosed and tear down state for what is a normal way for a connection to end. The flag
+            // is published after m_isRunningReceive is cleared so a caller that observes the receiver as
+            // idle also sees why it went idle, which is what RtpIceChannel.SendOverTCP checks before it
+            // tries to send anything else to that ICE server.
+            if (endOfStream)
+            {
+                m_isEndOfStream = true;
+            }
+
             if (!m_isClosed && !endOfStream)
             {
                 BeginReceiveFrom();

--- a/src/SIPSorcery/net/ICE/RtpIceChannel.cs
+++ b/src/SIPSorcery/net/ICE/RtpIceChannel.cs
@@ -2367,6 +2367,28 @@ namespace SIPSorcery.Net
                     }
                     else
                     {
+                        m_rtpTcpReceiverByUri.TryGetValue(iceServer?._uri, out IceTcpReceiver rtpTcpReceiver);
+
+                        // Socket.Connected reports the state as of the last I/O operation and stays true
+                        // after the remote end closes the connection gracefully, so it cannot detect a half
+                        // closed connection on its own. The receiver can: a zero byte receive on a stream
+                        // socket is the end of stream.
+                        //
+                        // The connection cannot be recovered in place. A connected socket cannot be reused
+                        // once disconnected (Socket.Connect throws InvalidOperationException after
+                        // Socket.Disconnect regardless of the endpoint), and for a TURN server a new
+                        // connection is a new 5-tuple, so the allocation is gone with the old one and would
+                        // have to be re-established from scratch anyway. Reporting the failure is therefore
+                        // the correct outcome: the caller records it against the ICE server, which takes that
+                        // server out of the running and lets the checklist move to the next one. Without this
+                        // the send below is issued into a dead connection and the failure is only noticed
+                        // indirectly, once the retry and timeout heuristics happen to give up.
+                        if (rtpTcpReceiver != null && rtpTcpReceiver.IsEndOfStream)
+                        {
+                            logger.LogWarning("SendOverTCP the connection to ICE server {Uri} was closed by the remote party.", iceServer?._uri);
+                            return SocketError.NotConnected;
+                        }
+
                         if (!sendSocket.Connected || !(sendSocket.RemoteEndPoint is IPEndPoint) || !equals(sendSocket.RemoteEndPoint as IPEndPoint, dstEndPoint))
                         {
                             if (sendSocket.Connected)
@@ -2380,7 +2402,6 @@ namespace SIPSorcery.Net
                         }
 
                         //Fix ReceiveFrom logic if any previous exception happens
-                        m_rtpTcpReceiverByUri.TryGetValue(iceServer?._uri, out IceTcpReceiver rtpTcpReceiver);
                         if (rtpTcpReceiver != null && !rtpTcpReceiver.IsRunningReceive && !rtpTcpReceiver.IsClosed)
                         {
                             rtpTcpReceiver.BeginReceiveFrom();

--- a/test/unit/net/ICE/IceTcpReceiverUnitTest.cs
+++ b/test/unit/net/ICE/IceTcpReceiverUnitTest.cs
@@ -295,12 +295,56 @@ namespace SIPSorcery.Net.UnitTests
                 Assert.True(receiver.ReArmCount < REARM_CAP, $"The receive loop re-armed {receiver.ReArmCount} times after the remote closed; it is spinning.");
                 Assert.False(receiver.IsRunningReceive);   // gone idle.
                 Assert.False(receiver.IsClosed);           // but still open so a reconnect can resume it.
+                Assert.True(receiver.IsEndOfStream);       // and the reason is visible to the send path.
+
+                // Socket.Connected is why the send path cannot work this out for itself. It still reports
+                // true even though the remote end has gone, which is what left SendOverTCP unable to tell a
+                // half closed connection from a live one.
+                Assert.True(client.Connected);
             }
             finally
             {
                 server?.Close();
                 client.Close();
                 listener.Stop();
+            }
+        }
+
+        /// <summary>
+        /// Pins the platform behaviour the end of stream handling is built on: a connected socket cannot be
+        /// reused. Socket.Connect throws InvalidOperationException after Socket.Disconnect whatever endpoint
+        /// is passed, so there is no recovering the connection in place and RtpIceChannel.SendOverTCP has to
+        /// report the failure rather than attempt a reconnect. If a future runtime relaxes this, this test
+        /// flags it and the send path could be revisited.
+        /// </summary>
+        [Fact]
+        public void DisconnectedSocket_CannotBeReconnectedInPlace()
+        {
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+
+            var listener = new TcpListener(IPAddress.Loopback, 0);
+            listener.Start();
+            var other = new TcpListener(IPAddress.Loopback, 0);
+            other.Start();
+
+            var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+
+            try
+            {
+                socket.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+                socket.Connect((IPEndPoint)listener.LocalEndpoint);
+                listener.AcceptSocket().Close();
+
+                socket.Disconnect(true);   // reuseSocket: true, which still does not permit a sync reconnect.
+
+                Assert.Throws<InvalidOperationException>(() => socket.Connect((IPEndPoint)listener.LocalEndpoint));
+                Assert.Throws<InvalidOperationException>(() => socket.Connect((IPEndPoint)other.LocalEndpoint));
+            }
+            finally
+            {
+                socket.Close();
+                listener.Stop();
+                other.Stop();
             }
         }
 


### PR DESCRIPTION
Fixes #1775.

## The problem

`Socket.Connected` reports the state as of the last I/O operation and stays true after the remote end closes gracefully, so `SendOverTCP` could not tell a half closed connection from a live one. It sent into the dead connection and the ICE server check retried until the request count or timeout heuristics happened to give up.

## What changed

`IceTcpReceiver` already detects the close for real — a zero byte receive on a stream socket is end of stream. That is now surfaced as `IsEndOfStream`, and `SendOverTCP` checks it before sending, returning `SocketError.NotConnected`. The caller records that against the ICE server, which takes it out of the running and lets the checklist move to the next one. Same end state as before, reached deterministically and immediately rather than incidentally.

## Why there is no reconnect

The issue suggested forcing a disconnect and reconnect. That is not possible, and finding out why changed the shape of the fix:

**A connected socket cannot be reused.** `Socket.Connect` throws `InvalidOperationException` after `Socket.Disconnect` — and not only for the same endpoint as the exception message implies, but for **any** endpoint, with `reuseSocket: true`. Measured, and pinned by `DisconnectedSocket_CannotBeReconnectedInPlace` so a future runtime change would surface it.

**Even a fresh socket would have nothing to resume.** For a TURN server a new connection is a new 5-tuple, so the allocation went with the old one. Recovery means re-establishing the ICE server from scratch — which is exactly what failing it over already triggers.

So reporting the failure is the correct outcome rather than a lesser one.

## Correction to #1771

Two comments added in that PR described `SendOverTCP` as able to resume the receiver after end of stream. That was wrong for the reason above, and both are corrected here. The behaviour #1771 fixed (not closing the receiver, not recursing) was right; only the stated reason was wrong.

## Known remaining issue

This leaves the pre-existing endpoint-change branch of `SendOverTCP` still calling `Disconnect` then `Connect`, which throws for the same reason and is caught by the generic handler as `SocketError.Fault`. It is only reached when an ICE server's endpoint changes on an already connected socket. Fixing it needs the same socket-replacement work described above, so I have left it rather than half addressing it. Happy to raise a separate issue if you want it tracked.

## Tests

- `RemoteGracefulClose_StopsReArmingWithoutClosing` extended to assert `IsEndOfStream` is set, and to assert `Socket.Connected` is still `true` at that point — pinning the exact platform behaviour that made this bug possible.
- `DisconnectedSocket_CannotBeReconnectedInPlace` — new, documents the constraint the fix is built on.

All nine TFMs build clean. Unit suite on net8.0: 940 passed, 0 failed, 7 skipped.
