### PR TITLE
Set SIP TLS channel bypass certificate validation to off by default.

### DIFF
--- a/src/SIPSorcery/core/SIP/Channels/SIPTLSChannel.cs
+++ b/src/SIPSorcery/core/SIP/Channels/SIPTLSChannel.cs
@@ -10,6 +10,7 @@
 // 13 Mar 2009	Aaron Clauson             Created, Hobart, Australia.
 // 16 Oct 2019  Aaron Clauson             Added IPv6 support.
 // 4 July 2022  Jean-Christophe Grondin   Added custom server certificate callback
+// 18 Aug 2026  Aaron Clauson             Changed bypass remote certificate validation default from true to false.
 //
 // License: 
 // BSD 3-Clause "New" or "Revised" License, see included LICENSE.md file.
@@ -42,7 +43,7 @@ namespace SIPSorcery.SIP
         /// Allows to ignore any ssl policy errors regarding the received certificate.
         /// Only applicable when no custom remote certificate validation is provided.
         /// </summary>
-        public bool BypassCertificateValidation { get; set; } = true;
+        public bool BypassCertificateValidation { get; set; } = false;
 
         public SIPTLSChannel(IPEndPoint endPoint, bool useDualMode = false, RemoteCertificateValidationCallback remoteCertificateValidation = null)
             : base(endPoint, SIPProtocolsEnum.tls, false, useDualMode)

--- a/test/integration/core/SIPTransportIntegrationTest.cs
+++ b/test/integration/core/SIPTransportIntegrationTest.cs
@@ -363,8 +363,10 @@ namespace SIPSorcery.SIP.IntegrationTests
                 logger.LogDebug("Server Certificate loaded from file, Subject={Subject}, valid={Valid}.", serverCertificate.Subject, verifyCert);
 
                 var serverChannel = new SIPTLSChannel(serverCertificate, IPAddress.IPv6Loopback, 0);
+                serverChannel.BypassCertificateValidation = true;
                 serverChannel.DisableLocalTCPSocketsCheck = true;
                 var clientChannel = new SIPTLSChannel(new IPEndPoint(IPAddress.IPv6Loopback, 0));
+                clientChannel.BypassCertificateValidation = true;
                 clientChannel.DisableLocalTCPSocketsCheck = true;
 
                 var serverTask = Task.Run(() => { RunServer(serverChannel, cancelServer, serverReadyEvent); }, cancelServer.Token);
@@ -434,8 +436,10 @@ namespace SIPSorcery.SIP.IntegrationTests
                 logger.LogDebug("Server Certificate loaded from file, Subject={Subject}, valid={Valid}.", serverCertificate.Subject, verifyCert);
 
                 var serverChannel = new SIPTLSChannel(serverCertificate, IPAddress.Loopback, 0);
+                serverChannel.BypassCertificateValidation = true;
                 serverChannel.DisableLocalTCPSocketsCheck = true;
                 var clientChannel = new SIPTLSChannel(new IPEndPoint(IPAddress.Loopback, 0));
+                clientChannel.BypassCertificateValidation = true;
                 clientChannel.DisableLocalTCPSocketsCheck = true;
 
                 var serverTask = Task.Run(() => { RunServer(serverChannel, cancelServer, serverReadyEvent); }, cancelServer.Token);
@@ -709,10 +713,12 @@ namespace SIPSorcery.SIP.IntegrationTests
             serverCertificate.Verify();
 
             var serverChannel = new SIPTLSChannel(serverCertificate, IPAddress.Loopback, 0);
+            serverChannel.BypassCertificateValidation = true;
             serverChannel.DisableLocalTCPSocketsCheck = true;
             var serverTask = Task.Run(() => { RunServer(serverChannel, cancelServer, serverReadyEvent); }, cancelServer.Token);
 
             var tlsClientChannel = new SIPTLSChannel(new IPEndPoint(IPAddress.Loopback, 0));
+            tlsClientChannel.BypassCertificateValidation = true;
             tlsClientChannel.DisableLocalTCPSocketsCheck = true;
 
             var tcpConnection = new TcpClient(new IPEndPoint(IPAddress.Loopback, 0));


### PR DESCRIPTION
Means self signed certificates will no longer be accepted unless the SIP channel `BypassCertificateValidation` is explicitly set to `true`.

TLS channel connection example
```
dotnet run -- sip options sips:sip.api.openai.com --verbose
info: SIPSorcery.SIP.SIPChannel[0]
      SIP TLS Channel created for tls:0.0.0.0:64854.
dbug: SIPSorcery.SIP.SIPTransport[0]
      Request sent: tls:192.168.1.123:64854->tls:172.65.182.150:5061 OPTIONS sips:sip.api.openai.com SIP/2.0
trce: SIPSorcery.SIP.SIPTransport[0]
      Request sent: OPTIONS sips:sip.api.openai.com SIP/2.0
      Via: SIP/2.0/TLS 192.168.1.123:64854;rport;branch=z9hG4bKa8e68651eb9d4d9eb6de11ce420fb8f4
      To: <sips:sip.api.openai.com>
      From: <sips:192.168.1.123:64854>;tag=JDBPMDBEAB
      Call-ID: 0dad3684654b4333b679036df890af6f
      CSeq: 1 OPTIONS
      Max-Forwards: 70
      Allow: ACK, BYE, CANCEL, INFO, INVITE, NOTIFY, OPTIONS, PRACK, REFER, REGISTER, SUBSCRIBE
      Content-Length: 0


dbug: SIPSorcery.SIP.SIPChannel[0]
      ConnectClientAsync SIP TLS Channel local end point of tls:0.0.0.0:64854 selected for connection to 172.65.182.150:5061.
dbug: SIPSorcery.SIP.SIPChannel[0]
      Attempting TCP connection from tls:0.0.0.0:64854 to 172.65.182.150:5061.
dbug: SIPSorcery.SIP.SIPChannel[0]
      ConnectAsync SIP TLS Channel connect completed result for tls:0.0.0.0:64854->172.65.182.150:5061 Success.
dbug: SIPSorcery.SIP.SIPChannel[0]
      Successfully validated X509 certificate for CN=api.openai.com.
dbug: SIPSorcery.SIP.SIPChannel[0]
      SIP TLS Channel successfully upgraded client connection to SSL stream for tls:0.0.0.0:64854->tls:172.65.182.150:5061.
dbug: SIPSorcery.SIP.SIPTransport[0]
      Response received: tls:192.168.1.123:64854<-tls:172.65.182.150:5061 OPTIONS 405 Method Not Allowed
trce: SIPSorcery.SIP.SIPTransport[0]
      Response received: SIP/2.0 405 Method Not Allowed
      Via: SIP/2.0/TLS 192.168.1.123:64854;received=162.158.230.152;rport=35602;branch=z9hG4bKa8e68651eb9d4d9eb6de11ce420fb8f4
      To: <sips:sip.api.openai.com>;tag=43bd3522-b0aa-46a3-af2a-63aedd580435
      From: <sips:192.168.1.123:64854>;tag=JDBPMDBEAB
      Call-ID: 0dad3684654b4333b679036df890af6f
      CSeq: 1 OPTIONS
      Content-Length: 0
```