### PR TITLE
Allow the SIP TLS channel certificate to be replaced

### DIFF
--- a/src/SIPSorcery/core/SIP/Channels/SIPTLSChannel.cs
+++ b/src/SIPSorcery/core/SIP/Channels/SIPTLSChannel.cs
@@ -33,7 +33,7 @@ namespace SIPSorcery.SIP
         private const int CLOSE_CONNECTION_TIMEOUT = 500;
         private const int TLS_ATTEMPT_CONNECT_TIMEOUT = 5000;
 
-        private readonly X509Certificate2 m_serverCertificate;
+        private volatile X509Certificate2 m_serverCertificate;
         private readonly X509Certificate2Collection m_clientCertificates;
         private readonly RemoteCertificateValidationCallback m_remoteCertificateValidation;
 
@@ -44,6 +44,49 @@ namespace SIPSorcery.SIP
         /// Only applicable when no custom remote certificate validation is provided.
         /// </summary>
         public bool BypassCertificateValidation { get; set; } = false;
+
+        /// <summary>
+        /// The certificate presented to clients that connect to this channel.
+        /// </summary>
+        /// <remarks>
+        /// Settable so that a renewed certificate can replace an expiring one without the
+        /// channel being torn down. The certificate is used at the point a connection is
+        /// accepted rather than when the socket is bound, so a replacement applies to
+        /// connections accepted after it and leaves established ones on the session they
+        /// already negotiated.
+        ///
+        /// Long lived services need this: an automated issuer replaces a certificate every
+        /// few weeks, and without it the only way to pick one up is a restart, which for a
+        /// SIP server means dropping every connection it is holding.
+        /// </remarks>
+        public X509Certificate2 ServerCertificate
+        {
+            get => m_serverCertificate;
+            set
+            {
+                if (value == null)
+                {
+                    throw new ArgumentNullException(nameof(value),
+                        "A server certificate cannot be removed from a SIP TLS channel that is using one.");
+                }
+
+                if (!value.HasPrivateKey)
+                {
+                    // Refused here rather than at the next handshake, where it would fail
+                    // once per connection with nothing to say which certificate was at fault.
+                    throw new ArgumentException(
+                        "The replacement certificate has no private key so it cannot complete a handshake.",
+                        nameof(value));
+                }
+
+                var previous = m_serverCertificate;
+                m_serverCertificate = value;
+
+                logger.LogInformation(
+                    "SIP TLS Channel for {ListeningSIPEndPoint} replaced certificate {PreviousSubject} with {CertificateSubject}, expiring {Expiry}.",
+                    ListeningSIPEndPoint, previous?.Subject, value.Subject, value.NotAfter);
+            }
+        }
 
         public SIPTLSChannel(IPEndPoint endPoint, bool useDualMode = false, RemoteCertificateValidationCallback remoteCertificateValidation = null)
             : base(endPoint, SIPProtocolsEnum.tls, false, useDualMode)

--- a/test/unit/core/SIP/Channels/SIPTLSChannelUnitTest.cs
+++ b/test/unit/core/SIP/Channels/SIPTLSChannelUnitTest.cs
@@ -1,0 +1,242 @@
+//-----------------------------------------------------------------------------
+// Filename: SIPTLSChannelUnitTest.cs
+//
+// Description: Unit tests for the SIPTLSChannel class.
+//
+// History:
+// 19 Aug 2026	Aaron Clauson	Created.
+//
+// License:
+// BSD 3-Clause "New" or "Revised" License, see included LICENSE.md file.
+//-----------------------------------------------------------------------------
+
+using System;
+using System.Net;
+using System.Net.Security;
+using System.Net.Sockets;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using SIPSorcery.UnitTests;
+using Xunit;
+
+namespace SIPSorcery.SIP.UnitTests
+{
+    [Trait("Category", "unit")]
+    public class SIPTLSChannelUnitTest
+    {
+        private Microsoft.Extensions.Logging.ILogger logger = null;
+
+        public SIPTLSChannelUnitTest(Xunit.Abstractions.ITestOutputHelper output)
+        {
+            logger = SIPSorcery.UnitTests.TestLogHelper.InitTestLogger(output);
+        }
+
+        /// <summary>
+        /// Creates a throwaway self signed certificate usable as a TLS server certificate.
+        /// </summary>
+        private static X509Certificate2 CreateCertificate(string commonName)
+        {
+            using (var key = RSA.Create(2048))
+            {
+                var request = new CertificateRequest($"CN={commonName}", key, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+
+                var subjectAlternativeName = new SubjectAlternativeNameBuilder();
+                subjectAlternativeName.AddDnsName(commonName);
+                request.CertificateExtensions.Add(subjectAlternativeName.Build());
+
+                var certificate = request.CreateSelfSigned(DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddDays(30));
+
+                // A certificate created in memory holds its private key in an ephemeral key
+                // set, which the Windows TLS stack will not use to serve a handshake. The
+                // PKCS#12 round trip gives back one whose key is usable on every platform.
+                return LoadPkcs12(certificate.Export(X509ContentType.Pkcs12));
+            }
+        }
+
+        private static X509Certificate2 LoadPkcs12(byte[] pkcs12)
+        {
+#if NET9_0_OR_GREATER
+            return X509CertificateLoader.LoadPkcs12(pkcs12, null);
+#else
+            return new X509Certificate2(pkcs12);
+#endif
+        }
+
+        private static X509Certificate2 LoadPublicOnly(byte[] raw)
+        {
+#if NET9_0_OR_GREATER
+            return X509CertificateLoader.LoadCertificate(raw);
+#else
+            return new X509Certificate2(raw);
+#endif
+        }
+
+        /// <summary>
+        /// Connects to the channel and returns the subject of the certificate it presented.
+        /// </summary>
+        private static async Task<string> GetPresentedSubjectAsync(int port)
+        {
+            using (var client = new TcpClient())
+            {
+                await client.ConnectAsync(IPAddress.Loopback, port);
+
+                string subject = null;
+
+                using (var sslStream = new SslStream(client.GetStream(), false,
+                    (sender, certificate, chain, errors) =>
+                    {
+                        // Self signed, so the chain will not validate. What is under test is
+                        // which certificate arrives, not whether it is trusted.
+                        subject = certificate.Subject;
+                        return true;
+                    }))
+                {
+                    await sslStream.AuthenticateAsClientAsync("first.example.com");
+                }
+
+                return subject;
+            }
+        }
+
+        /// <summary>
+        /// Tests that the certificate a TLS channel presents can be replaced while the
+        /// channel is listening, which is what lets a renewed certificate be picked up
+        /// without a restart that would drop every connection the server is holding.
+        /// </summary>
+        [Fact]
+        public async Task ReplaceServerCertificateUnitTest()
+        {
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
+
+            using (var first = CreateCertificate("first.example.com"))
+            using (var second = CreateCertificate("second.example.com"))
+            {
+                var channel = new SIPTLSChannel(first, new IPEndPoint(IPAddress.Loopback, 0));
+
+                try
+                {
+                    int port = channel.ListeningSIPEndPoint.Port;
+
+                    Assert.Equal("CN=first.example.com", await GetPresentedSubjectAsync(port));
+
+                    channel.ServerCertificate = second;
+
+                    // Same channel, same socket, no rebinding - only what it presents changes.
+                    Assert.Equal("CN=second.example.com", await GetPresentedSubjectAsync(port));
+                    Assert.Equal(port, channel.ListeningSIPEndPoint.Port);
+                }
+                finally
+                {
+                    channel.Close();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Tests that a connection established before the certificate was replaced is left
+        /// alone by the replacement. This is the reason the swap is worth doing at all: a
+        /// restart to pick up a renewed certificate drops every connection the server is
+        /// holding, and for a SIP server those are its registered clients.
+        /// </summary>
+        [Fact]
+        public async Task ReplaceServerCertificateLeavesEstablishedConnectionsUnitTest()
+        {
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
+
+            using (var first = CreateCertificate("first.example.com"))
+            using (var second = CreateCertificate("second.example.com"))
+            {
+                var channel = new SIPTLSChannel(first, new IPEndPoint(IPAddress.Loopback, 0));
+
+                try
+                {
+                    using (var established = new TcpClient())
+                    {
+                        await established.ConnectAsync(IPAddress.Loopback, channel.ListeningSIPEndPoint.Port);
+
+                        using (var sslStream = new SslStream(established.GetStream(), false, (s1, c, ch, e) => true))
+                        {
+                            await sslStream.AuthenticateAsClientAsync("first.example.com");
+
+                            channel.ServerCertificate = second;
+
+                            // A read that times out means the connection is still up. Had the
+                            // channel been torn down and rebuilt, this would complete with
+                            // zero bytes for the close instead.
+                            var buffer = new byte[1];
+                            var read = sslStream.ReadAsync(buffer, 0, 1);
+                            var finished = await Task.WhenAny(read, Task.Delay(2000));
+
+                            Assert.NotSame(read, finished);
+                            Assert.True(established.Client.Connected);
+                        }
+                    }
+                }
+                finally
+                {
+                    channel.Close();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Tests that a certificate with no private key is refused when it is set rather
+        /// than being accepted and then failing every subsequent handshake, where nothing
+        /// would say which certificate was at fault.
+        /// </summary>
+        [Fact]
+        public void ReplaceWithCertificateMissingPrivateKeyUnitTest()
+        {
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
+
+            using (var certificate = CreateCertificate("first.example.com"))
+            {
+                var channel = new SIPTLSChannel(certificate, new IPEndPoint(IPAddress.Loopback, 0));
+
+                try
+                {
+                    using (var publicOnly = LoadPublicOnly(certificate.RawData))
+                    {
+                        Assert.Throws<ArgumentException>(() => { channel.ServerCertificate = publicOnly; });
+                    }
+
+                    Assert.Equal("CN=first.example.com", channel.ServerCertificate.Subject);
+                }
+                finally
+                {
+                    channel.Close();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Tests that the certificate cannot be removed from a channel that is using one,
+        /// which would leave it listening but unable to complete any handshake.
+        /// </summary>
+        [Fact]
+        public void ReplaceWithNullCertificateUnitTest()
+        {
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
+
+            using (var certificate = CreateCertificate("first.example.com"))
+            {
+                var channel = new SIPTLSChannel(certificate, new IPEndPoint(IPAddress.Loopback, 0));
+
+                try
+                {
+                    Assert.Throws<ArgumentNullException>(() => { channel.ServerCertificate = null; });
+                }
+                finally
+                {
+                    channel.Close();
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
`SIPTLSChannel` held its certificate in a `readonly` field, so the only way to pick up a renewed one was to construct a new channel — which for a listening server means unbinding the port and dropping every connection it is holding.

Nothing about the listener actually depends on the certificate. It is read in `OnAcceptAsync`:

```csharp
var authTask = sslStream.AuthenticateAsServerAsync(m_serverCertificate);
```

That is per accepted connection, not at bind time. So allowing a replacement needs no more than making the field settable — no rebinding, no reconnection, no change to the accept path.

A replacement applies to connections accepted after it, and leaves established ones on the session they already negotiated. That is the point: anything long lived behind an automated issuer gets its certificate replaced every few weeks, and without this a SIP server has to restart to serve the new one.

Two details:

- The field is `volatile`. The accept path and whatever performs the replacement are different threads; reference assignment is already atomic, so this is only about a reader observing the new value promptly.
- The setter refuses `null` and a certificate with no private key. Refusing at the point of replacement rather than at the next handshake matters — a handshake failure says nothing about which certificate was at fault, and it would repeat once per connection.

## Tests

Four, in a new `SIPTLSChannelUnitTest`, passing on net8.0 and net10.0:

- a client connects and gets the first certificate, the certificate is replaced, the next client gets the second one — same channel, same port
- **a connection established before the replacement is still up afterwards**, asserted by a read that times out rather than completing with zero bytes for a close. This is the property the whole change is for
- a certificate with no private key is refused and the channel keeps the one it had
- `null` is refused

`X509CertificateLoader` is .NET 9+, so the test helpers are conditional on `NET9_0_OR_GREATER` to keep the net8.0 target building.
