### PR TITLE
Add net481 test target and new SDP parsing tests

### DIFF
--- a/test/unit/SIPSorcery.UnitTests.csproj
+++ b/test/unit/SIPSorcery.UnitTests.csproj
@@ -5,7 +5,7 @@
          cannot host a test run, so it only ever proved the test code compiled — which
          the library's own netstandard2.0 build already establishes for its API surface.
          The library still ships netstandard2.0; the tests just don't target it. -->
-    <TargetFrameworks>net8.0;net10.0;net481</TargetFrameworks>
+    <TargetFrameworks>net8.0;net10.0;net472</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <LangVersion>14.0</LangVersion>

--- a/test/unit/SIPSorcery.UnitTests.csproj
+++ b/test/unit/SIPSorcery.UnitTests.csproj
@@ -5,7 +5,7 @@
          cannot host a test run, so it only ever proved the test code compiled — which
          the library's own netstandard2.0 build already establishes for its API surface.
          The library still ships netstandard2.0; the tests just don't target it. -->
-    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net10.0;net481</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <LangVersion>14.0</LangVersion>

--- a/test/unit/net/SDP/SDPConnectionInformationUnitTest.cs
+++ b/test/unit/net/SDP/SDPConnectionInformationUnitTest.cs
@@ -1,0 +1,112 @@
+﻿using System;
+using System.Net;
+using System.Net.Sockets;
+using Xunit;
+
+namespace SIPSorcery.Net.UnitTests;
+
+[Trait("Category", "unit")]
+public class SDPConnectionInformationUnitTest
+{
+    [Fact]
+    public void ParseConnectionInformationParsesIPv4Fields()
+    {
+        var address = GetRandomIPAddress(AddressFamily.InterNetwork);
+        var connectionLine = $"c=IN IP4 {address}";
+
+        var connectionInformation = SDPConnectionInformation.ParseConnectionInformation(connectionLine);
+
+        Assert.Equal("IN", connectionInformation.ConnectionNetworkType);
+        Assert.Equal(SDPConnectionInformation.CONNECTION_ADDRESS_TYPE_IPV4, connectionInformation.ConnectionAddressType);
+        Assert.Equal(address.ToString(), connectionInformation.ConnectionAddress);
+    }
+
+    [Fact]
+    public void ParseConnectionInformationParsesIPv6Fields()
+    {
+        var address = GetRandomIPAddress(AddressFamily.InterNetworkV6);
+        var connectionLine = $"c=IN IP6 {address}";
+
+        var connectionInformation = SDPConnectionInformation.ParseConnectionInformation(connectionLine);
+
+        Assert.Equal("IN", connectionInformation.ConnectionNetworkType);
+        Assert.Equal(SDPConnectionInformation.CONNECTION_ADDRESS_TYPE_IPV6, connectionInformation.ConnectionAddressType);
+        Assert.Equal(address.ToString(), connectionInformation.ConnectionAddress);
+    }
+
+    [Fact]
+    public void ParseConnectionInformationTrimsOuterWhitespace()
+    {
+        var address = GetRandomIPAddress(AddressFamily.InterNetwork);
+        var connectionLine = $"c=IN IP4 {address}   ";
+
+        var connectionInformation = SDPConnectionInformation.ParseConnectionInformation(connectionLine);
+
+        Assert.Equal("IN", connectionInformation.ConnectionNetworkType);
+        Assert.Equal(SDPConnectionInformation.CONNECTION_ADDRESS_TYPE_IPV4, connectionInformation.ConnectionAddressType);
+        Assert.Equal(address.ToString(), connectionInformation.ConnectionAddress);
+    }
+
+    [Fact]
+    public void ParseConnectionInformationIgnoresFieldsAfterAddress()
+    {
+        var address = GetRandomIPAddress(AddressFamily.InterNetwork);
+        var extraField = Guid.NewGuid().ToString("N");
+        var connectionLine = $"c=IN IP4 {address} {extraField}";
+
+        var connectionInformation = SDPConnectionInformation.ParseConnectionInformation(connectionLine);
+
+        Assert.Equal("IN", connectionInformation.ConnectionNetworkType);
+        Assert.Equal(SDPConnectionInformation.CONNECTION_ADDRESS_TYPE_IPV4, connectionInformation.ConnectionAddressType);
+        Assert.Equal(address.ToString(), connectionInformation.ConnectionAddress);
+    }
+
+    [Fact]
+    public void ParseConnectionInformationWithOnlyNetworkTypeRetainsDefaults()
+    {
+        var connectionInformation = SDPConnectionInformation.ParseConnectionInformation("c=IN");
+
+        Assert.Equal("IN", connectionInformation.ConnectionNetworkType);
+        Assert.Equal(SDPConnectionInformation.CONNECTION_ADDRESS_TYPE_IPV4, connectionInformation.ConnectionAddressType);
+        Assert.Null(connectionInformation.ConnectionAddress);
+    }
+
+    [Fact]
+    public void ParseConnectionInformationWithoutAddressRetainsNullAddress()
+    {
+        var connectionInformation = SDPConnectionInformation.ParseConnectionInformation("c=IN IP6");
+
+        Assert.Equal("IN", connectionInformation.ConnectionNetworkType);
+        Assert.Equal(SDPConnectionInformation.CONNECTION_ADDRESS_TYPE_IPV6, connectionInformation.ConnectionAddressType);
+        Assert.Null(connectionInformation.ConnectionAddress);
+    }
+
+    [Fact]
+    public void ToStringProducesIPv4ConnectionLineWithCrLf()
+    {
+        var address = GetRandomIPAddress(AddressFamily.InterNetwork);
+        var connectionInformation = new SDPConnectionInformation(address);
+
+        var result = connectionInformation.ToString();
+
+        Assert.Equal($"c=IN IP4 {address}\r\n", result);
+    }
+
+    [Fact]
+    public void ToStringProducesIPv6ConnectionLineWithCrLf()
+    {
+        var address = GetRandomIPAddress(AddressFamily.InterNetworkV6);
+        var connectionInformation = new SDPConnectionInformation(address);
+
+        var result = connectionInformation.ToString();
+
+        Assert.Equal($"c=IN IP6 {address}\r\n", result);
+    }
+
+    private static IPAddress GetRandomIPAddress(AddressFamily addressFamily)
+    {
+        var bytes = new byte[addressFamily == AddressFamily.InterNetwork ? 4 : 16];
+        new Random().NextBytes(bytes);
+        return new IPAddress(bytes);
+    }
+}

--- a/test/unit/net/SDP/SDPMediaAnnouncementUnitTests.cs
+++ b/test/unit/net/SDP/SDPMediaAnnouncementUnitTests.cs
@@ -1,8 +1,12 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using Microsoft.Extensions.Logging;
 using SIPSorcery.UnitTests;
+using SIPSorceryMedia.Abstractions;
 using Xunit;
+
+#pragma warning disable CS0618 // Type or member is obsolete
 
 namespace SIPSorcery.Net.UnitTests
 {
@@ -119,6 +123,194 @@ namespace SIPSorcery.Net.UnitTests
             sdp.Media[0].AddExtra(attribute);
 
             Assert.Equal(before, sdp.ToString());
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData(" \t\r\n")]
+        public void ParseMediaFormats_NullOrWhiteSpace_DoesNotAddFormats(string formatList)
+        {
+            var announcement = new SDPMediaAnnouncement();
+
+            announcement.ParseMediaFormats(formatList);
+
+            Assert.Empty(announcement.MediaFormats);
+            Assert.Empty(announcement.ApplicationMediaFormats);
+        }
+
+        [Fact]
+        public void ParseMediaFormats_ApplicationFormats_AddsEachFormat()
+        {
+            var firstFormatID = System.Guid.NewGuid().ToString("N");
+            var secondFormatID = System.Guid.NewGuid().ToString("N");
+            var announcement = new SDPMediaAnnouncement { Media = SDPMediaTypesEnum.application };
+
+            announcement.ParseMediaFormats($"{firstFormatID}\t{secondFormatID}");
+
+            Assert.Equal(2, announcement.ApplicationMediaFormats.Count);
+            Assert.Equal(firstFormatID, announcement.ApplicationMediaFormats[firstFormatID].ID);
+            Assert.Equal(secondFormatID, announcement.ApplicationMediaFormats[secondFormatID].ID);
+            Assert.Empty(announcement.MediaFormats);
+        }
+
+        [Fact]
+        public void ParseMediaFormats_MessageFormat_DoesNotAddFormats()
+        {
+            var announcement = new SDPMediaAnnouncement { Media = SDPMediaTypesEnum.message };
+
+            announcement.ParseMediaFormats(System.Guid.NewGuid().ToString("N"));
+
+            Assert.Empty(announcement.MediaFormats);
+            Assert.Empty(announcement.ApplicationMediaFormats);
+        }
+
+        [Fact]
+        public void ParseMediaFormats_AudioVideoFormats_AddsOnlyUniqueWellKnownFormats()
+        {
+            var wellKnownFormats = System.Enum.GetValues(typeof(SDPWellKnownMediaFormatsEnum))
+                .Cast<SDPWellKnownMediaFormatsEnum>()
+                .ToArray();
+            var wellKnown = wellKnownFormats[(int)((uint)System.Guid.NewGuid().GetHashCode() % wellKnownFormats.Length)];
+            var wellKnownID = (int)wellKnown;
+            var unknownIDs = Enumerable.Range(0, SDPAudioVideoMediaFormat.DYNAMIC_ID_MIN)
+                .Except(wellKnownFormats.Select(format => (int)format))
+                .ToArray();
+            var unknownID = unknownIDs[(int)((uint)System.Guid.NewGuid().GetHashCode() % unknownIDs.Length)];
+            var dynamicID = SDPAudioVideoMediaFormat.DYNAMIC_ID_MIN
+                + (int)((uint)System.Guid.NewGuid().GetHashCode()
+                    % (SDPAudioVideoMediaFormat.DYNAMIC_ID_MAX - SDPAudioVideoMediaFormat.DYNAMIC_ID_MIN + 1));
+            var invalidID = System.Guid.NewGuid().ToString("N");
+            var announcement = new SDPMediaAnnouncement();
+
+            announcement.ParseMediaFormats($"{wellKnownID} {wellKnownID}\t{unknownID}\r\n{dynamicID} {invalidID}");
+
+            var mediaFormat = Assert.Single(announcement.MediaFormats);
+            Assert.Equal(wellKnownID, mediaFormat.Key);
+            Assert.Equal(wellKnownID, mediaFormat.Value.ID);
+            Assert.Empty(announcement.ApplicationMediaFormats);
+        }
+
+        [Fact]
+        public void ToString_DefaultAnnouncement_ReturnsMediaLine()
+        {
+            var announcement = new SDPMediaAnnouncement();
+
+            var result = announcement.ToString();
+
+            Assert.Equal($"m=audio 0 RTP/AVP {SDP.CRLF}", result);
+        }
+
+        [Fact]
+        public void ToString_PopulatedAnnouncement_ReturnsAllAttributes()
+        {
+            var randomBytes = System.Guid.NewGuid().ToByteArray();
+            var port = 1024 + (randomBytes[0] << 4) + randomBytes[1];
+            var address = new IPAddress(new byte[] { 192, 0, 2, (byte)(1 + randomBytes[2] % 254) });
+            var mediaDescription = System.Guid.NewGuid().ToString("N");
+            var bandwidth = $"AS:{1 + (uint)System.Guid.NewGuid().GetHashCode() % 1000000}";
+            var iceUfrag = System.Guid.NewGuid().ToString("N");
+            var icePwd = System.Guid.NewGuid().ToString("N");
+            var fingerprint = $"sha-256 {System.Guid.NewGuid():N}";
+            var iceRoles = System.Enum.GetValues(typeof(IceRolesEnum)).Cast<IceRolesEnum>().ToArray();
+            var iceRole = iceRoles[randomBytes[3] % iceRoles.Length];
+            var candidate = System.Guid.NewGuid().ToString("N");
+            var iceOptions = System.Guid.NewGuid().ToString("N");
+            var mediaID = System.Guid.NewGuid().ToString("N");
+            var extensionID = 1 + randomBytes[4] % 14;
+            var headerExtension = new AbsSendTimeExtension(extensionID);
+            var extraAttribute = $"a=x-{System.Guid.NewGuid():N}";
+            var securityDescription = SDPSecurityDescription.CreateNew(
+                1 + (uint)System.Guid.NewGuid().GetHashCode() % 999999998);
+            var streamStatuses = System.Enum.GetValues(typeof(MediaStreamStatusEnum)).Cast<MediaStreamStatusEnum>().ToArray();
+            var streamStatus = streamStatuses[randomBytes[5] % streamStatuses.Length];
+            var firstSsrc = 1U + (uint)System.Guid.NewGuid().GetHashCode() % (uint.MaxValue - 1);
+            var secondSsrc = firstSsrc == uint.MaxValue ? firstSsrc - 1 : firstSsrc + 1;
+            var ssrcGroupID = System.Guid.NewGuid().ToString("N");
+            var cname = System.Guid.NewGuid().ToString("N");
+            var sctpPort = (ushort)(1 + (uint)System.Guid.NewGuid().GetHashCode() % ushort.MaxValue);
+            var maxMessageSize = 1L + (uint)System.Guid.NewGuid().GetHashCode();
+            var announcement = new SDPMediaAnnouncement
+            {
+                Media = SDPMediaTypesEnum.video,
+                Port = port,
+                Transport = System.Guid.NewGuid().ToString("N"),
+                MediaDescription = mediaDescription,
+                Connection = new SDPConnectionInformation(address),
+                TIASBandwidth = 1U + (uint)System.Guid.NewGuid().GetHashCode() % (uint.MaxValue - 1),
+                IceUfrag = iceUfrag,
+                IcePwd = icePwd,
+                DtlsFingerprint = fingerprint,
+                IceRole = iceRole,
+                IceCandidates = new List<string> { candidate },
+                IceOptions = iceOptions,
+                IceEndOfCandidates = true,
+                MediaID = mediaID,
+                MediaStreamStatus = streamStatus,
+                SsrcGroupID = ssrcGroupID,
+                SctpPort = sctpPort,
+                MaxMessageSize = maxMessageSize
+            };
+            announcement.BandwidthAttributes.Add(bandwidth);
+            announcement.HeaderExtensions.Add(extensionID, headerExtension);
+            announcement.ExtraMediaAttributes.Add(" \t");
+            announcement.ExtraMediaAttributes.Add(extraAttribute);
+            announcement.SecurityDescriptions.Add(securityDescription);
+            announcement.SsrcAttributes.Add(new SDPSsrcAttribute(firstSsrc, cname, ssrcGroupID));
+            announcement.SsrcAttributes.Add(new SDPSsrcAttribute(secondSsrc, null, ssrcGroupID));
+
+            var result = announcement.ToString();
+
+            var expected =
+                $"m={announcement.Media} {port} {announcement.Transport} {SDP.CRLF}" +
+                $"i={mediaDescription}{SDP.CRLF}" +
+                announcement.Connection.ToString() +
+                $"{SDPMediaAnnouncement.TIAS_BANDWIDTH_ATTRIBUE_PREFIX}{announcement.TIASBandwidth}{SDP.CRLF}" +
+                $"b={bandwidth}{SDP.CRLF}" +
+                $"a={SDP.ICE_UFRAG_ATTRIBUTE_PREFIX}:{iceUfrag}{SDP.CRLF}" +
+                $"a={SDP.ICE_PWD_ATTRIBUTE_PREFIX}:{icePwd}{SDP.CRLF}" +
+                $"a={SDP.DTLS_FINGERPRINT_ATTRIBUTE_PREFIX}:{fingerprint}{SDP.CRLF}" +
+                $"a={SDP.ICE_SETUP_ATTRIBUTE_PREFIX}:{iceRole}{SDP.CRLF}" +
+                $"a={SDP.ICE_CANDIDATE_ATTRIBUTE_PREFIX}:{candidate}{SDP.CRLF}" +
+                $"a={SDP.ICE_OPTIONS}:{iceOptions}{SDP.CRLF}" +
+                $"a={SDP.END_ICE_CANDIDATES_ATTRIBUTE}{SDP.CRLF}" +
+                $"a={SDP.MEDIA_ID_ATTRIBUTE_PREFIX}:{mediaID}{SDP.CRLF}" +
+                $"{SDPMediaAnnouncement.MEDIA_EXTENSION_MAP_ATTRIBUE_PREFIX}{extensionID} {headerExtension.Uri}{SDP.CRLF}" +
+                $"{extraAttribute}{SDP.CRLF}" +
+                $"{securityDescription}{SDP.CRLF}" +
+                $"{MediaStreamStatusType.GetAttributeForMediaStreamStatus(streamStatus)}{SDP.CRLF}" +
+                $"{SDPMediaAnnouncement.MEDIA_FORMAT_SSRC_GROUP_ATTRIBUE_PREFIX}{ssrcGroupID} {firstSsrc} {secondSsrc}{SDP.CRLF}" +
+                $"{SDPMediaAnnouncement.MEDIA_FORMAT_SSRC_ATTRIBUE_PREFIX}{firstSsrc} {SDPSsrcAttribute.MEDIA_CNAME_ATTRIBUE_PREFIX}:{cname}{SDP.CRLF}" +
+                $"{SDPMediaAnnouncement.MEDIA_FORMAT_SSRC_ATTRIBUE_PREFIX}{secondSsrc}{SDP.CRLF}" +
+                $"{SDPMediaAnnouncement.MEDIA_FORMAT_SCTP_PORT_ATTRIBUE_PREFIX}{sctpPort}{SDP.CRLF}" +
+                $"{SDPMediaAnnouncement.MEDIA_FORMAT_MAX_MESSAGE_SIZE_ATTRIBUE_PREFIX}{maxMessageSize}{SDP.CRLF}";
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void ToString_EmptyCollectionsAndSctpMap_ReturnsOnlySctpMapAttribute()
+        {
+            var sctpMap = System.Guid.NewGuid().ToString("N");
+            var announcement = new SDPMediaAnnouncement
+            {
+                MediaDescription = " \t",
+                IceUfrag = " \t",
+                IcePwd = " \t",
+                DtlsFingerprint = " \t",
+                IceCandidates = new List<string>(),
+                MediaID = " \t",
+                SsrcGroupID = System.Guid.NewGuid().ToString("N"),
+                SctpMap = sctpMap,
+                SctpPort = (ushort)(1 + (uint)System.Guid.NewGuid().GetHashCode() % ushort.MaxValue),
+                MaxMessageSize = 1L + (uint)System.Guid.NewGuid().GetHashCode()
+            };
+
+            var result = announcement.ToString();
+
+            Assert.Equal(
+                $"m=audio 0 RTP/AVP {SDP.CRLF}" +
+                $"{SDPMediaAnnouncement.MEDIA_FORMAT_SCTP_MAP_ATTRIBUE_PREFIX}{sctpMap}{SDP.CRLF}",
+                result);
         }
     }
 }

--- a/test/unit/net/SDP/SDPMediaAnnouncementUnitTests.cs
+++ b/test/unit/net/SDP/SDPMediaAnnouncementUnitTests.cs
@@ -62,5 +62,63 @@ namespace SIPSorcery.Net.UnitTests
             Assert.Contains(msrpMediaTypes, sdpOffer);
             Assert.Contains(mediaDescription, sdpOffer);
         }
+
+        [Fact]
+        public void AddExtra_Attribute_AddsMediaAttribute()
+        {
+            var videoAttribute = $"a=x-video-{System.Guid.NewGuid():N}";
+            var audioAttribute = $"a=x-audio-{System.Guid.NewGuid():N}";
+            var sdp = SDP.ParseSDPDescription(
+                $"v=0{SDP.CRLF}" +
+                $"o=- {(uint)System.Guid.NewGuid().GetHashCode()} 0 IN IP4 127.0.0.1{SDP.CRLF}" +
+                $"s=sipsorcery{SDP.CRLF}" +
+                $"t=0 0{SDP.CRLF}" +
+                $"a=group:BUNDLE 0 1{SDP.CRLF}" +
+                $"m=video 9 UDP/TLS/RTP/SAVP 96{SDP.CRLF}" +
+                $"c=IN IP4 0.0.0.0{SDP.CRLF}" +
+                $"a=ice-ufrag:LYMS{SDP.CRLF}" +
+                $"a=ice-pwd:PAZQAZXCCWZZZIPRTUKOBHRH{SDP.CRLF}" +
+                $"a=mid:0{SDP.CRLF}" +
+                $"a=rtpmap:96 VP8/90000{SDP.CRLF}" +
+                $"a=sendonly{SDP.CRLF}" +
+                $"m=audio 9 UDP/TLS/RTP/SAVP 0{SDP.CRLF}" +
+                $"c=IN IP4 0.0.0.0{SDP.CRLF}" +
+                $"a=mid:1{SDP.CRLF}" +
+                $"a=rtpmap:0 PCMU/8000{SDP.CRLF}" +
+                "a=recvonly");
+            var before = sdp.ToString();
+
+            sdp.Media[0].AddExtra(videoAttribute);
+            sdp.Media[1].AddExtra(audioAttribute);
+
+            var expected = before
+                .Replace(
+                    $"{SDP.CRLF}a=sendonly",
+                    $"{SDP.CRLF}{videoAttribute}{SDP.CRLF}a=sendonly")
+                .Replace(
+                    $"{SDP.CRLF}a=recvonly",
+                    $"{SDP.CRLF}{audioAttribute}{SDP.CRLF}a=recvonly");
+            Assert.Equal(expected, sdp.ToString());
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData(" ")]
+        public void AddExtra_NullOrWhiteSpaceAttribute_DoesNotAddMediaAttribute(string attribute)
+        {
+            var sdp = SDP.ParseSDPDescription(
+                $"v=0{SDP.CRLF}" +
+                $"o=- {(uint)System.Guid.NewGuid().GetHashCode()} 0 IN IP4 127.0.0.1{SDP.CRLF}" +
+                $"s=sipsorcery{SDP.CRLF}" +
+                $"t=0 0{SDP.CRLF}" +
+                $"m=audio 9 RTP/AVP 0{SDP.CRLF}" +
+                "a=rtpmap:0 PCMU/8000");
+            var before = sdp.ToString();
+
+            sdp.Media[0].AddExtra(attribute);
+
+            Assert.Equal(before, sdp.ToString());
+        }
     }
 }

--- a/test/unit/net/SDP/SDPUnitTests.cs
+++ b/test/unit/net/SDP/SDPUnitTests.cs
@@ -1243,6 +1243,48 @@ a=sendrecv
             Assert.Equal(256000U, rndTripSdp.Media.Where(x => x.Media == SDPMediaTypesEnum.video).Single().TIASBandwidth);
         }
 
+        [Fact]
+        public void AddExtra_Attribute_AddsSessionAttribute()
+        {
+            var attribute = $"a=x-{System.Guid.NewGuid():N}";
+            var sdp = SDP.ParseSDPDescription(
+                $"v=0{m_CRLF}" +
+                $"o=- {(uint)System.Guid.NewGuid().GetHashCode()} 0 IN IP4 127.0.0.1{m_CRLF}" +
+                $"s=sipsorcery{m_CRLF}" +
+                $"t=0 0{m_CRLF}" +
+                $"a=group:BUNDLE 0 1{m_CRLF}" +
+                $"m=video 9 RTP/AVP 96{m_CRLF}" +
+                $"c=IN IP4 0.0.0.0{m_CRLF}" +
+                $"a=mid:0{m_CRLF}" +
+                $"a=rtpmap:96 VP8/90000{m_CRLF}" +
+                $"m=audio 9 RTP/AVP 0{m_CRLF}" +
+                $"c=IN IP4 0.0.0.0{m_CRLF}" +
+                $"a=mid:1{m_CRLF}" +
+                "a=rtpmap:0 PCMU/8000");
+            var before = sdp.ToString();
+
+            sdp.AddExtra(attribute);
+
+            var expected = before.Replace(
+                $"{m_CRLF}m=video",
+                $"{m_CRLF}{attribute}{m_CRLF}m=video");
+            Assert.Equal(expected, sdp.ToString());
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData(" ")]
+        public void AddExtra_NullOrWhiteSpaceAttribute_DoesNotAddSessionAttribute(string attribute)
+        {
+            var sdp = new SDP();
+            var before = sdp.ToString();
+
+            sdp.AddExtra(attribute);
+
+            Assert.Equal(before, sdp.ToString());
+        }
+
         [Theory]
         [InlineData(nameof(Helpers.SdpFixtures.AudioOnlyOfferPcmu), Helpers.SdpFixtures.AudioOnlyOfferPcmu   )]
         [InlineData(nameof(Helpers.SdpFixtures.AudioOfferPcmuWithDtmf), Helpers.SdpFixtures.AudioOfferPcmuWithDtmf)]

--- a/test/unit/net/SDP/SDPUnitTests.cs
+++ b/test/unit/net/SDP/SDPUnitTests.cs
@@ -1127,5 +1127,146 @@ a=ssrc-group:FID 3366495178 777490417";
             Assert.True(sdp.Media[0].Port == 12228, "The connection port was not parsed correctly.");
             Assert.True(sdp.Media[0].PortCount == 2, "The port count was not parsed correctly.");
         }
+
+        /// <summary>
+        /// Tests that parsing an SDP media format attribute for a Mission Critical Push To Talk (MCPTT)
+        /// announcement works correctly.
+        /// </summary>
+        [Fact]
+        public void ParseMcpttMediaNameTest()
+        {
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
+
+            var sdpStr =
+                @"v=0
+o=root 5936658357711814578 0 IN IP4 0.0.0.0
+s=-
+t=0 0
+m=audio 55316 RTP/AVP 0 101
+a=rtpmap:0 PCMU/8000
+a=label:1
+a=rtpmap:101 telephone-event/8000
+a=fmtp:101 0-15
+a=ptime:20
+a=sendrecv
+m=application 55317 udp MCPTT
+a=fmtp:MCPTT mc_queueing;mc_priority=4";
+
+            var sdp = SDP.ParseSDPDescription(sdpStr);
+
+            logger.LogDebug("{sdp}", sdp.ToString());
+
+            var rndTripSdp = SDP.ParseSDPDescription(sdp.ToString());
+
+            Assert.Equal("MCPTT", rndTripSdp.Media.Where(x => x.Media == SDPMediaTypesEnum.application).Single().ApplicationMediaFormats.Single().Key);
+            Assert.Equal("mc_queueing;mc_priority=4", rndTripSdp.Media.Where(x => x.Media == SDPMediaTypesEnum.application).Single().ApplicationMediaFormats.Single().Value.Fmtp);
+        }
+
+        /// <summary>
+        /// Tests that a description attribute can be successfully round tripped.
+        /// </summary>
+        [Fact]
+        public void DescriptionAttributeRoundTripMediaNameTest()
+        {
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
+
+            var sdpStr =
+                @"v=0
+o=root 5936658357711814578 0 IN IP4 0.0.0.0
+s=-
+i=A session description
+t=0 0
+m=audio 55316 RTP/AVP 0 101
+a=rtpmap:0 PCMU/8000
+a=label:1
+i=speech
+a=rtpmap:101 telephone-event/8000
+a=fmtp:101 0-15
+a=ptime:20
+a=sendrecv
+m=video 61682 UDP/TLS/RTP/SAVPF 96
+c=IN IP4 192.168.11.50
+a=rtpmap:96 VP8/90000
+a=label:2
+i=video title
+a=sendrecv
+";
+
+            var sdp = SDP.ParseSDPDescription(sdpStr);
+
+            logger.LogDebug("{sdp}", sdp.ToString());
+
+            var rndTripSdp = SDP.ParseSDPDescription(sdp.ToString());
+
+            Assert.Equal("A session description", rndTripSdp.SessionDescription);
+            Assert.Equal("speech", rndTripSdp.Media.Where(x => x.Media == SDPMediaTypesEnum.audio).Single().MediaDescription);
+            Assert.Equal("video title", rndTripSdp.Media.Where(x => x.Media == SDPMediaTypesEnum.video).Single().MediaDescription);
+        }
+
+        /// <summary>
+        /// Tests that a TIAS bandwidth attribute (RFC3890) can be successfully round tripped.
+        /// </summary>
+        [Fact]
+        public void TIASBandwidthAttributeRoundTripMediaNameTest()
+        {
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
+
+            var sdpStr =
+                @"v=0
+o=root 5936658357711814578 0 IN IP4 0.0.0.0
+s=-
+t=0 0
+m=audio 55316 RTP/AVP 0 101
+a=rtpmap:0 PCMU/8000
+a=label:1
+a=rtpmap:101 telephone-event/8000
+a=fmtp:101 0-15
+a=ptime:20
+a=sendrecv
+m=video 61682 UDP/TLS/RTP/SAVPF 96
+c=IN IP4 192.168.11.50
+b=TIAS:256000
+a=rtpmap:96 VP8/90000
+a=label:2
+a=sendrecv
+";
+
+            var sdp = SDP.ParseSDPDescription(sdpStr);
+
+            logger.LogDebug("{sdp}", sdp.ToString());
+
+            var rndTripSdp = SDP.ParseSDPDescription(sdp.ToString());
+
+            Assert.Equal(256000U, rndTripSdp.Media.Where(x => x.Media == SDPMediaTypesEnum.video).Single().TIASBandwidth);
+        }
+
+        [Theory]
+        [InlineData(nameof(Helpers.SdpFixtures.AudioOnlyOfferPcmu), Helpers.SdpFixtures.AudioOnlyOfferPcmu   )]
+        [InlineData(nameof(Helpers.SdpFixtures.AudioOfferPcmuWithDtmf), Helpers.SdpFixtures.AudioOfferPcmuWithDtmf)]
+        [InlineData(nameof(Helpers.SdpFixtures.VideoOnlyOfferVp8), Helpers.SdpFixtures.VideoOnlyOfferVp8)]
+        [InlineData(nameof(Helpers.SdpFixtures.AudioVideoOfferAudioFirst), Helpers.SdpFixtures.AudioVideoOfferAudioFirst)]
+        [InlineData(nameof(Helpers.SdpFixtures.AudioVideoOfferVideoFirst), Helpers.SdpFixtures.AudioVideoOfferVideoFirst)]
+        [InlineData(nameof(Helpers.SdpFixtures.AudioOfferSendOnly), Helpers.SdpFixtures.AudioOfferSendOnly)]
+        [InlineData(nameof(Helpers.SdpFixtures.AudioOfferRecvOnly), Helpers.SdpFixtures.AudioOfferRecvOnly)]
+        [InlineData(nameof(Helpers.SdpFixtures.AudioOfferInactive), Helpers.SdpFixtures.AudioOfferInactive)]
+        [InlineData(nameof(Helpers.SdpFixtures.AudioOfferHoldNullConnectionAddress), Helpers.SdpFixtures.AudioOfferHoldNullConnectionAddress)]
+        [InlineData(nameof(Helpers.SdpFixtures.ReInviteRejectsVideoPortZero), Helpers.SdpFixtures.ReInviteRejectsVideoPortZero)]
+        [InlineData(nameof(Helpers.SdpFixtures.WebRtcAudioOfferOpus), Helpers.SdpFixtures.WebRtcAudioOfferOpus)]
+        [InlineData(nameof(Helpers.SdpFixtures.WebRtcAudioVideoOfferBundled), Helpers.SdpFixtures.WebRtcAudioVideoOfferBundled)]
+        [InlineData(nameof(Helpers.SdpFixtures.AudioOfferWithSdesCrypto), Helpers.SdpFixtures.AudioOfferWithSdesCrypto)]
+        [InlineData(nameof(Helpers.SdpFixtures.ChromeAudioVideoWebRtcOffer), Helpers.SdpFixtures.ChromeAudioVideoWebRtcOffer)]
+        [InlineData(nameof(Helpers.SdpFixtures.FirefoxAudioOnlyWebRtcOffer), Helpers.SdpFixtures.FirefoxAudioOnlyWebRtcOffer)]
+        public void ParseSDPDescription_DescriptionsParsedByOtherTests_ReturnsSdp(string scenario, string description)
+        {
+            logger.LogDebug("--> {MethodName}({Scenario})", TestHelper.GetCurrentMethodName(), scenario);
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
+
+            var result = SDP.ParseSDPDescription(description);
+
+            Assert.True(result is not null, $"Failed to parse {scenario}.");
+        }
     }
 }


### PR DESCRIPTION
#### PR Classification
Adds new unit tests and expands test framework support.

#### PR Summary
This pull request adds several new SDP parsing and round-trip tests and updates the test project to support .NET Framework 4.8.1.
- SIPSorcery.UnitTests.csproj: Adds net481 as a target framework.
- SDPUnitTests.cs: Adds tests for MCPTT media name parsing, description and TIAS bandwidth attribute round-tripping, and a theory test for parsing multiple SDP descriptions.
