### PR TITLE
Add a received non-INVITE transaction to the engine when it is created.

### DIFF
--- a/src/SIPSorcery/core/SIPTransactions/SIPNonInviteTransaction.cs
+++ b/src/SIPSorcery/core/SIPTransactions/SIPNonInviteTransaction.cs
@@ -44,6 +44,7 @@ namespace SIPSorcery.SIP
                 //   to be detected for.
                 // This block is for the second case. The tx request has been received and the tx engine
                 // needs to be signalled that it is now at the request processing stage.
+                sipTransport.AddTransaction(this);
                 base.UpdateTransactionState(SIPTransactionStatesEnum.Proceeding);
             }
         }

--- a/test/unit/core/SIPTransactions/SIPTransactionEngineUnitTest.cs
+++ b/test/unit/core/SIPTransactions/SIPTransactionEngineUnitTest.cs
@@ -73,6 +73,98 @@ namespace SIPSorcery.SIP.UnitTests
         }
 
         /// <summary>
+        /// Tests that a non-INVITE transaction created for a RECEIVED request is added to the
+        /// transaction engine straight away, rather than when it first sends a response.
+        /// </summary>
+        /// <remarks>
+        /// This is what lets a retransmitted request be recognised as a duplicate. An application
+        /// handling something slow - a REFER being relayed to another leg, a MESSAGE being handed
+        /// off - can take seconds to produce a final response, and every retransmission arriving in
+        /// that window would otherwise be delivered to it as a brand new request.
+        ///
+        /// The equivalent registration for INVITE lives in the UASInviteTransaction constructor.
+        /// This one was lost in Dec 2019 when the SIPTransport.CreateNonInviteTransaction factory,
+        /// which used to do the adding, was removed in an async refactor.
+        /// </remarks>
+        [Fact]
+        public void NonInviteServerTransactionAddedToEngineOnCreationTest()
+        {
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
+
+            SIPTransport sipTransport = new SIPTransport();
+            SIPTransactionEngine transactionEngine = sipTransport.m_transactionEngine;
+
+            SIPRequest referRequest = ReceivedReferRequest();
+
+            Assert.Null(transactionEngine.GetTransaction(referRequest));
+
+            SIPNonInviteTransaction tx = new SIPNonInviteTransaction(sipTransport, referRequest, null);
+
+            // Note what has deliberately NOT happened: no response of any kind has been sent.
+            var matched = transactionEngine.GetTransaction(referRequest);
+
+            Assert.NotNull(matched);
+            Assert.Equal(tx.TransactionId, matched.TransactionId);
+        }
+
+        /// <summary>
+        /// Tests that a non-INVITE transaction the application creates to SEND a request is not
+        /// added to the engine until it is sent.
+        /// </summary>
+        /// <remarks>
+        /// The other half of the rule, pinned so a change to one direction cannot quietly alter the
+        /// other. The same class serves both roles and the received end point is what separates
+        /// them, so an outbound transaction that registered on construction would put a transaction
+        /// into the engine for a request that may never be sent at all.
+        /// </remarks>
+        [Fact]
+        public void NonInviteClientTransactionNotAddedToEngineOnCreationTest()
+        {
+            logger.LogDebug("--> {MethodName}", TestHelper.GetCurrentMethodName());
+            logger.BeginScope(TestHelper.GetCurrentMethodName());
+
+            SIPTransport sipTransport = new SIPTransport();
+            SIPTransactionEngine transactionEngine = sipTransport.m_transactionEngine;
+
+            // Parsed from a string rather than from a receive buffer, so it carries no remote end
+            // point: this is a request the application is about to send.
+            SIPRequest referRequest = SIPRequest.ParseSIPRequest(ReferRequestText());
+
+            Assert.Null(referRequest.RemoteSIPEndPoint);
+
+            _ = new SIPNonInviteTransaction(sipTransport, referRequest, null);
+
+            Assert.Null(transactionEngine.GetTransaction(referRequest));
+        }
+
+        /// <summary>
+        /// A REFER as it arrives off the wire, with the end point it was received from set.
+        /// </summary>
+        private SIPRequest ReceivedReferRequest()
+        {
+            var buffer = SIPMessageBuffer.ParseSIPMessage(
+                System.Text.Encoding.UTF8.GetBytes(ReferRequestText()),
+                new SIPEndPoint(SIPProtocolsEnum.udp, IPAddress.Loopback, 5060),
+                new SIPEndPoint(SIPProtocolsEnum.udp, IPAddress.Loopback, 1234));
+
+            return SIPRequest.ParseSIPRequest(buffer);
+        }
+
+        private string ReferRequestText() =>
+            $"REFER sip:dummy@127.0.0.1:12014 SIP/2.0{m_CRLF}" +
+            $"Via: SIP/2.0/UDP 127.0.0.1:1234;branch=z9hG4bK4e2f1c9d1b4a4f0d9a6e2c7b3f8a5d1e{m_CRLF}" +
+            $"To: <sip:dummy@127.0.0.1:12014>;tag=8675309{m_CRLF}" +
+            $"From: <sip:unittest@mysipswitch.com>;tag=2062917371{m_CRLF}" +
+            $"Call-ID: 4d8f2a1b6c3e4a7d9b0f5e8c2a1d6b3f{m_CRLF}" +
+            $"CSeq: 4 REFER{m_CRLF}" +
+            $"Contact: <sip:127.0.0.1:1234>{m_CRLF}" +
+            $"Refer-To: <sip:target@mysipswitch.com>{m_CRLF}" +
+            $"Max-Forwards: 70{m_CRLF}" +
+            $"User-Agent: unittest{m_CRLF}" +
+            $"Content-Length: 0{m_CRLF}{m_CRLF}";
+
+        /// <summary>
         /// Tests the production and recognition of an ACK request for this transaction engine.
         /// The test uses two different transaction engine instances with one acting as the client and one as the server.
         /// </summary>


### PR DESCRIPTION
A `SIPNonInviteTransaction` created for a request that **arrived from a remote end point** was
never added to the transaction engine. It only got there when it sent a final response, so for
as long as the application took to produce one, the engine did not know the transaction existed
and every retransmission of the request was delivered as a brand new one.

That matters wherever handling is not instant. A REFER being relayed onto the far leg of a
bridged call, or a MESSAGE handed to something slow, can take seconds. The sender retransmits
meanwhile — quite correctly, since it has had no response at all — and the application runs
again for each copy. In the case that turned this up, a back-to-back user agent relaying a
REFER issued a second REFER downstream, with a fresh CSeq, for what the transferor considered
one transfer request.

## The constructor already knew

```csharp
if (sipRequest.RemoteSIPEndPoint != null)
{
    // This transaction type can be used to represent two different things:
    // - a tx that the application wants to use to send a request reliably,
    // - a tx for a request that has been received from a remote end point and that duplicates need
    //   to be detected for.
    // This block is for the second case. ...
    base.UpdateTransactionState(SIPTransactionStatesEnum.Proceeding);
}
```

It identifies the received case, names duplicate detection as the reason that case exists, and
advances the state machine for it — but never registered the transaction. So `SIPTransport`'s
`"Transaction already exists, ignoring duplicate request"` path was unreachable for every
non-INVITE server transaction that had not yet responded.

One line, inside the block already written for it.

## It matches the rule INVITE already follows

`UASInviteTransaction` has done this in its constructor all along, with the rule in a comment:

```csharp
// UAS transactions need to be added to the engine immediately so that CANCEL
// requests can be matched. Outbound transaction types don't need to be added to the 
// engine until they need to be sent.
sipTransport.AddTransaction(this);
```

This applies the same rule to the other half. Nothing new is introduced — inbound registers on
construction, outbound on send, exactly as documented.

## Where it went

`SIPTransport.CreateNonInviteTransaction` used to construct **and** add in one step:

```csharp
SIPNonInviteTransaction nonInviteTransaction = new SIPNonInviteTransaction(this, sipRequest, outboundProxy);
m_transactionEngine.AddTransaction(nonInviteTransaction);
```

It was removed in `7a05e99c4` (Dec 2019, the TAP/async refactor) and call sites became direct
construction. The adding went with it. Nothing noticed for nearly seven years, because nothing
tested it — which is the main argument for the tests below.

## Tests

Two, one per direction, in `SIPTransactionEngineUnitTest`:

- **`NonInviteServerTransactionAddedToEngineOnCreationTest`** — a REFER built through
  `SIPMessageBuffer.ParseSIPMessage` so it carries a received end point; the engine must match it
  with **no response of any kind sent**.
- **`NonInviteClientTransactionNotAddedToEngineOnCreationTest`** — the same class parsed from a
  string, so no received end point; the engine must not have it.

The second one is there deliberately. Both roles share one constructor and only the received end
point separates them, so an outbound transaction registering on construction would put
transactions into the engine for requests that may never be sent. Pinning both directions means a
change to either cannot quietly alter the other.

Verified the server-side test fails with the line removed and passes with it, so it is a real
regression test rather than one that would pass either way.

## Risk

No behaviour change when there is no transaction engine — `AddTransaction` already no-ops with a
warning in stateless mode, which is the SIP proxy case, rather than throwing as the old factory
did.

Full unit suite passes on net8.0, net10.0 and net472: 1016 passed, 7 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
