### PR TITLE
Add unit tests for message parsing and validation

### DIFF
--- a/test/unit/net/WebRTC/DataChannelOpenMessageUnitTest.cs
+++ b/test/unit/net/WebRTC/DataChannelOpenMessageUnitTest.cs
@@ -1,4 +1,4 @@
-//-----------------------------------------------------------------------------
+﻿//-----------------------------------------------------------------------------
 // Filename: DataChannelOpenMessageUnitTest.cs
 //
 // Description: Unit tests for the DataChannelOpenMessage class.
@@ -157,6 +157,22 @@ namespace SIPSorcery.Net.UnitTests
             byte[] buffer = GetDcepOpenBuffer(0, 0, null);
 
             Assert.Throws<ApplicationException>(() => DataChannelOpenMessage.Parse(buffer, 1));
+        }
+
+        /// <summary>
+        /// Tests that a valid DCEP OPEN message can omit both variable-length fields.
+        /// </summary>
+        [Fact]
+        public void ParseEmptyLabelAndProtocolUnitTest()
+        {
+            var buffer = GetDcepOpenBuffer(0, 0, null);
+
+            var parsed = DataChannelOpenMessage.Parse(buffer, 0);
+
+            Assert.Equal((byte)DataChannelMessageTypes.OPEN, parsed.MessageType);
+            Assert.Equal((byte)DataChannelTypes.DATA_CHANNEL_RELIABLE, parsed.ChannelType);
+            Assert.Null(parsed.Label);
+            Assert.Null(parsed.Protocol);
         }
     }
 }

--- a/test/unit/net/WebRTC/RTCIceServerUnitTest.cs
+++ b/test/unit/net/WebRTC/RTCIceServerUnitTest.cs
@@ -1,0 +1,31 @@
+﻿//-----------------------------------------------------------------------------
+// Filename: RTCIceServerUnitTest.cs
+//
+// Description: Unit tests for the RTCIceServer class.
+//
+// License:
+// BSD 3-Clause "New" or "Revised" License, see included LICENSE.md file.
+//-----------------------------------------------------------------------------
+
+using Xunit;
+
+namespace SIPSorcery.Net.UnitTests
+{
+    [Trait("Category", "unit")]
+    public class RTCIceServerUnitTest
+    {
+        [Theory]
+        [InlineData("stun:stun.example.com", null, null)]
+        [InlineData("turn:turn.example.com;user", "user", null)]
+        [InlineData("turn:turn.example.com;user;pass", "user", "pass")]
+        public void ParseUnitTest(string value, string expectedUsername, string expectedCredential)
+        {
+            var server = RTCIceServer.Parse(value);
+
+            Assert.Equal(value.Split(';')[0], server.urls);
+            Assert.Equal(expectedUsername, server.username);
+            Assert.Equal(expectedCredential, server.credential);
+            Assert.Equal(RTCIceCredentialType.password, server.credentialType);
+        }
+    }
+}

--- a/test/unit/net/WebRTC/RTCPeerConnectionDtlsFingerprintUnitTest.cs
+++ b/test/unit/net/WebRTC/RTCPeerConnectionDtlsFingerprintUnitTest.cs
@@ -1,4 +1,4 @@
-//-----------------------------------------------------------------------------
+﻿//-----------------------------------------------------------------------------
 // Filename: RTCPeerConnectionDtlsFingerprintUnitTest.cs
 //
 // Description: Unit tests for the handling of the DTLS fingerprint attribute in
@@ -368,6 +368,46 @@ namespace SIPSorcery.Net.UnitTests
 
             setter.Invoke(pc, new object[] { true });
             Assert.True(pc.IsDtlsNegotiationComplete);
+        }
+
+        /// <summary>
+        /// Tests inputs that cannot identify a supported fingerprint algorithm and value.
+        /// </summary>
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("sha-256")]
+        [InlineData("sha-999 AA:BB")]
+        public void TryParseInvalidDtlsFingerprintUnitTest(string value)
+        {
+            Assert.False(RTCDtlsFingerprint.TryParse(value, out var fingerprint));
+            Assert.Null(fingerprint);
+        }
+
+        /// <summary>
+        /// Tests parsing a fingerprint that uses a supported digest.
+        /// </summary>
+        [Fact]
+        public void TryParseValidDtlsFingerprintUnitTest()
+        {
+            Assert.True(RTCDtlsFingerprint.TryParse("sha-256 aa:bb", out var fingerprint));
+            Assert.Equal("sha-256", fingerprint.algorithm);
+            Assert.Equal("aa:bb", fingerprint.value);
+        }
+
+        /// <summary>
+        /// Tests the SDP representation, including the uppercase fingerprint required by Firefox.
+        /// </summary>
+        [Fact]
+        public void ToStringDtlsFingerprintUnitTest()
+        {
+            var fingerprint = new RTCDtlsFingerprint
+            {
+                algorithm = "sha-256",
+                value = "aa:bb:0c"
+            };
+
+            Assert.Equal("sha-256 AA:BB:0C", fingerprint.ToString());
         }
     }
 }

--- a/test/unit/net/WebRTC/RTCSessionDescriptionInitUnitTest.cs
+++ b/test/unit/net/WebRTC/RTCSessionDescriptionInitUnitTest.cs
@@ -70,5 +70,39 @@ namespace SIPSorcery.Net.UnitTests
             Assert.Equal(RTCSdpType.answer, init.type);
             Assert.NotNull(init.sdp);
         }
+
+        /// <summary>
+        /// Tests that values without JSON content are rejected without producing a description.
+        /// </summary>
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData(" \t\r\n")]
+        public void TryParseEmptyJsonUnitTest(string json)
+        {
+            Assert.False(RTCSessionDescriptionInit.TryParse(json, out var init));
+            Assert.Null(init);
+        }
+
+        /// <summary>
+        /// Tests that a JSON null value is rejected.
+        /// </summary>
+        [Fact]
+        public void TryParseJsonNullUnitTest()
+        {
+            Assert.False(RTCSessionDescriptionInit.TryParse("null", out var init));
+            Assert.Null(init);
+        }
+
+        /// <summary>
+        /// Tests that the required SDP property must be present.
+        /// </summary>
+        [Fact]
+        public void TryParseJsonWithoutSdpUnitTest()
+        {
+            Assert.False(RTCSessionDescriptionInit.TryParse("{\"type\":\"offer\"}", out var init));
+            Assert.NotNull(init);
+            Assert.Null(init.sdp);
+        }
     }
 }


### PR DESCRIPTION
#### PR Classification
Adds and extends unit tests to improve coverage and consistency for several classes.

#### PR Summary
This pull request introduces new and extended unit tests for SIPSorcery.Net, focusing on parsing and validation logic, and updates file headers for consistency.
- DataChannelOpenMessageUnitTest.cs: Added a test for parsing DCEP OPEN messages with empty label and protocol fields.
- RTCIceServerUnitTest.cs: Introduced parameterized tests for parsing RTCIceServer strings, including username and credential extraction.
- RTCPeerConnectionDtlsFingerprintUnitTest.cs: Added tests for invalid/valid DTLS fingerprint parsing and string representation formatting.
- RTCSessionDescriptionInitUnitTest.cs: Added tests for handling invalid, empty, or incomplete JSON session descriptions.
- Updated file headers across test files for consistency.
