### PR TITLE
Use domain name to connect via wss (#1806)

### DIFF
--- a/src/SIPSorcery/core/SIP/Channels/SIPClientWebSocketChannel.cs
+++ b/src/SIPSorcery/core/SIP/Channels/SIPClientWebSocketChannel.cs
@@ -101,12 +101,29 @@ namespace SIPSorcery.SIP
         /// <summary>
         /// Creates a SIP channel to establish outbound connections and send SIP messages 
         /// over a web socket communications layer.
+        /// <param name="isSecure">Whether the channel is being used with ws or wss.</param>
         /// </summary>
-        public SIPClientWebSocketChannel(Encoding sipEncoding, Encoding sipBodyEncoding) : base(sipEncoding, sipBodyEncoding)
+        public SIPClientWebSocketChannel(bool isSecure) : this(isSecure, SIPConstants.DEFAULT_ENCODING, SIPConstants.DEFAULT_ENCODING)
+        {
+
+        }
+
+        /// <summary>
+        /// Creates a SIP channel to establish outbound connections and send SIP messages 
+        /// over a web socket communications layer.
+        /// </summary>
+        public SIPClientWebSocketChannel(Encoding sipEncoding, Encoding sipBodyEncoding) : this(false, sipEncoding, sipBodyEncoding)
+        {
+
+        }
+
+        public SIPClientWebSocketChannel(bool isSecure, Encoding sipEncoding, Encoding sipBodyEncoding)
+            : base(sipEncoding, sipBodyEncoding)
         {
             IsReliable = true;
-            SIPProtocol = SIPProtocolsEnum.ws;
-
+            IsSecure = isSecure;
+            SIPProtocol = isSecure ? SIPProtocolsEnum.wss : SIPProtocolsEnum.ws;
+            
             // TODO: These values need to be adjusted. The problem is the source end point isn't available from
             // the client web socket connection.
             ListeningIPAddress = IPAddress.Any;
@@ -133,7 +150,11 @@ namespace SIPSorcery.SIP
                 throw new ArgumentException("buffer", "The buffer must be set and non empty for Send in SIPClientWebSocketChannel.");
             }
 
-            return SendAsync(dstEndPoint, buffer);
+            // keeps legacy behaviour. Disregards set protocol of the SIPChannel and uses the one set in the endpoint
+            string uriPrefix = (dstEndPoint.Protocol == SIPProtocolsEnum.wss) ? WEB_SOCKET_SECURE_URI_PREFIX : WEB_SOCKET_URI_PREFIX;
+            var serverUri = new Uri($"{uriPrefix}{dstEndPoint.GetIPEndPoint()}");
+
+            return SendAsync(dstEndPoint, buffer, serverUri);
         }
 
         /// <summary>
@@ -150,7 +171,20 @@ namespace SIPSorcery.SIP
                 throw new ArgumentException("buffer", "The buffer must be set and non empty for SendSecure in SIPClientWebSocketChannel.");
             }
 
-            return SendAsync(dstEndPoint, buffer);
+            if (!IsSecure)
+            {
+                throw new ArgumentException("Cannot send secure. SIP Channel is not a wss channel.");
+            }
+
+            if (dstEndPoint.Protocol != SIPProtocol)
+            {
+                throw new ArgumentException("Protocol of the destination endpoint did not match the Channel, expected wss.");
+            }
+
+
+            var serverUri = new Uri($"{WEB_SOCKET_SECURE_URI_PREFIX}{serverCertificateName}:{dstEndPoint.Port}");
+
+            return SendAsync(dstEndPoint, buffer, serverUri);
         }
 
         /// <summary>
@@ -160,13 +194,10 @@ namespace SIPSorcery.SIP
         /// <param name="serverEndPoint">The remote web socket server URI to send to.</param>
         /// <param name="buffer">The data buffer to send.</param>
         /// <returns>A success value or an error for failure.</returns>
-        private async Task<SocketError> SendAsync(SIPEndPoint serverEndPoint, byte[] buffer)
+        private async Task<SocketError> SendAsync(SIPEndPoint serverEndPoint, byte[] buffer, Uri serverUri)
         {
             try
             {
-                string uriPrefix = (serverEndPoint.Protocol == SIPProtocolsEnum.wss) ? WEB_SOCKET_SECURE_URI_PREFIX : WEB_SOCKET_URI_PREFIX;
-                var serverUri = new Uri($"{uriPrefix}{serverEndPoint.GetIPEndPoint()}");
-
                 string connectionID = GetConnectionID(serverUri);
                 serverEndPoint.ChannelID = this.ID;
                 serverEndPoint.ConnectionID = connectionID;

--- a/src/SIPSorcery/core/SIP/Channels/SIPClientWebSocketChannel.cs
+++ b/src/SIPSorcery/core/SIP/Channels/SIPClientWebSocketChannel.cs
@@ -101,29 +101,12 @@ namespace SIPSorcery.SIP
         /// <summary>
         /// Creates a SIP channel to establish outbound connections and send SIP messages 
         /// over a web socket communications layer.
-        /// <param name="isSecure">Whether the channel is being used with ws or wss.</param>
         /// </summary>
-        public SIPClientWebSocketChannel(bool isSecure) : this(isSecure, SIPConstants.DEFAULT_ENCODING, SIPConstants.DEFAULT_ENCODING)
-        {
-
-        }
-
-        /// <summary>
-        /// Creates a SIP channel to establish outbound connections and send SIP messages 
-        /// over a web socket communications layer.
-        /// </summary>
-        public SIPClientWebSocketChannel(Encoding sipEncoding, Encoding sipBodyEncoding) : this(false, sipEncoding, sipBodyEncoding)
-        {
-
-        }
-
-        public SIPClientWebSocketChannel(bool isSecure, Encoding sipEncoding, Encoding sipBodyEncoding)
-            : base(sipEncoding, sipBodyEncoding)
+        public SIPClientWebSocketChannel(Encoding sipEncoding, Encoding sipBodyEncoding) : base(sipEncoding, sipBodyEncoding)
         {
             IsReliable = true;
-            IsSecure = isSecure;
-            SIPProtocol = isSecure ? SIPProtocolsEnum.wss : SIPProtocolsEnum.ws;
-            
+            SIPProtocol = SIPProtocolsEnum.ws;
+
             // TODO: These values need to be adjusted. The problem is the source end point isn't available from
             // the client web socket connection.
             ListeningIPAddress = IPAddress.Any;
@@ -150,7 +133,6 @@ namespace SIPSorcery.SIP
                 throw new ArgumentException("buffer", "The buffer must be set and non empty for Send in SIPClientWebSocketChannel.");
             }
 
-            // keeps legacy behaviour. Disregards set protocol of the SIPChannel and uses the one set in the endpoint
             string uriPrefix = (dstEndPoint.Protocol == SIPProtocolsEnum.wss) ? WEB_SOCKET_SECURE_URI_PREFIX : WEB_SOCKET_URI_PREFIX;
             var serverUri = new Uri($"{uriPrefix}{dstEndPoint.GetIPEndPoint()}");
 
@@ -158,7 +140,8 @@ namespace SIPSorcery.SIP
         }
 
         /// <summary>
-        /// Send to a secure web socket server.
+        /// Send to a secure web socket server. The connection is made using the server's host name, rather than its
+        /// resolved IP address, so that the name presented in the server's certificate is able to validate.
         /// </summary>
         public override Task<SocketError> SendSecureAsync(SIPEndPoint dstEndPoint, byte[] buffer, string serverCertificateName, bool canInitiateConnection, string connectionIDHint)
         {
@@ -171,18 +154,11 @@ namespace SIPSorcery.SIP
                 throw new ArgumentException("buffer", "The buffer must be set and non empty for SendSecure in SIPClientWebSocketChannel.");
             }
 
-            if (!IsSecure)
-            {
-                throw new ArgumentException("Cannot send secure. SIP Channel is not a wss channel.");
-            }
-
-            if (dstEndPoint.Protocol != SIPProtocol)
-            {
-                throw new ArgumentException("Protocol of the destination endpoint did not match the Channel, expected wss.");
-            }
-
-
-            var serverUri = new Uri($"{WEB_SOCKET_SECURE_URI_PREFIX}{serverCertificateName}:{dstEndPoint.Port}");
+            // Without a host name the certificate can never validate. Fall back to the IP address form so that the
+            // failure surfaces from the TLS handshake rather than from the URI parse.
+            var serverUri = !string.IsNullOrWhiteSpace(serverCertificateName) ?
+                new Uri($"{WEB_SOCKET_SECURE_URI_PREFIX}{serverCertificateName}:{dstEndPoint.Port}") :
+                new Uri($"{WEB_SOCKET_SECURE_URI_PREFIX}{dstEndPoint.GetIPEndPoint()}");
 
             return SendAsync(dstEndPoint, buffer, serverUri);
         }
@@ -191,8 +167,9 @@ namespace SIPSorcery.SIP
         /// Attempts a send to a remote web socket server. If there is an existing connection it will be used
         /// otherwise an attempt will made to establish a new one.
         /// </summary>
-        /// <param name="serverEndPoint">The remote web socket server URI to send to.</param>
+        /// <param name="serverEndPoint">The remote web socket server end point to send to.</param>
         /// <param name="buffer">The data buffer to send.</param>
+        /// <param name="serverUri">The remote web socket server URI to connect to.</param>
         /// <returns>A success value or an error for failure.</returns>
         private async Task<SocketError> SendAsync(SIPEndPoint serverEndPoint, byte[] buffer, Uri serverUri)
         {
@@ -278,11 +255,12 @@ namespace SIPSorcery.SIP
         /// </summary>
         public override bool HasConnection(SIPEndPoint serverEndPoint)
         {
-            string uriPrefix = (serverEndPoint.Protocol == SIPProtocolsEnum.wss) ? WEB_SOCKET_SECURE_URI_PREFIX : WEB_SOCKET_URI_PREFIX;
-            var serverUri = new Uri($"{uriPrefix}{serverEndPoint.GetIPEndPoint()}");
-            string connectionID = GetConnectionID(serverUri);
+            // Connections are keyed on the server URI which, for secure connections, uses the server's host name
+            // rather than its IP address. That means the connection ID can't be derived from the end point on its own.
+            var dstEndPoint = serverEndPoint.GetIPEndPoint();
 
-            return m_egressConnections.ContainsKey(connectionID);
+            return m_egressConnections.Any(x => x.Value.RemoteEndPoint.Protocol == serverEndPoint.Protocol
+                && x.Value.RemoteEndPoint.GetIPEndPoint().Equals(dstEndPoint));
         }
 
         /// <summary>

--- a/src/SIPSorcery/core/SIP/SIPTransport.cs
+++ b/src/SIPSorcery/core/SIP/SIPTransport.cs
@@ -614,9 +614,18 @@ namespace SIPSorcery.SIP
 
             SIPRequestOutTraceEvent?.Invoke(sendFromSIPEndPoint, dstEndPoint, sipRequest);
 
-            if (sipChannel.IsSecure)
+            // The client web socket channel serves both ws and wss destinations, so whether a secure send is required
+            // can't be determined from the channel alone and the destination protocol has to be taken into account.
+            if (sipChannel.IsSecure || dstEndPoint.Protocol == SIPProtocolsEnum.wss)
             {
-                return sipChannel.SendSecureAsync(dstEndPoint, sipRequest.GetBytes(), sipRequest.URI.HostAddress, true, sipRequest.SendFromHintConnectionID);
+                // The certificate name needs to match the host the connection is actually being made to. When a route
+                // set is present the destination end point was resolved from the top route, not the request URI, so
+                // it's the top route's host that will be presented in the server's certificate.
+                var routeSet = sipRequest.Header.Routes;
+                string serverCertificateName = (routeSet != null && routeSet.Length > 0) ?
+                    routeSet.TopRoute.URI.HostAddress : sipRequest.URI.HostAddress;
+
+                return sipChannel.SendSecureAsync(dstEndPoint, sipRequest.GetBytes(), serverCertificateName, true, sipRequest.SendFromHintConnectionID);
             }
             else
             {


### PR DESCRIPTION
Uses the passed domain name instead of the resolved IP address to create a connection in the `SIPClientWebSocketChannel`.

Fixes issue #1806 by changing the URI that is used to connect.