### PR TITLE
fix(sctp): serialise the state cookie without reflection so data channels work under Native AOT

### DIFF
--- a/src/SIPSorcery/net/SCTP/SctpTransport.cs
+++ b/src/SIPSorcery/net/SCTP/SctpTransport.cs
@@ -19,13 +19,13 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Net;
 using System.Security.Cryptography;
 using System.Text;
 using Microsoft.Extensions.Logging;
 using SIPSorcery.Sys;
-using TinyJson;
 
 namespace SIPSorcery.Net
 {
@@ -56,6 +56,310 @@ namespace SIPSorcery.Net
         {
             return _isEmpty;
         }
+
+        /// <summary>
+        /// Serialises the cookie to the JSON form carried in the COOKIE ECHO chunk.
+        /// </summary>
+        /// <remarks>
+        /// Written by hand rather than by a reflection-based serialiser, and the
+        /// reason is that this type must survive trimming: under Native AOT the
+        /// members below are removed, TinyJson then produces an empty document,
+        /// and the COOKIE ECHO arrives with a null chunk value. GetCookie throws
+        /// before it can validate anything, the packet is dropped, no COOKIE ACK
+        /// is sent, and the association stalls in CookieEchoed until it times
+        /// out - so data channels never open at all.
+        ///
+        /// It is also deterministic, which this type needs more than most: the
+        /// HMAC in GetCookieHMAC is computed over these exact bytes, so member
+        /// order and formatting are load-bearing rather than cosmetic. Reflection
+        /// order is not guaranteed by the runtime; this is.
+        ///
+        /// The shape matches what TinyJson produced - members in declaration
+        /// order, no whitespace - so the bytes on the wire are unchanged. Nothing
+        /// here is a compatibility concern either way: the cookie is opaque, the
+        /// peer that writes it is the only peer that reads it, and the remote end
+        /// echoes it back verbatim.
+        /// </remarks>
+        public string ToJson()
+        {
+            var json = new StringBuilder(256);
+
+            json.Append('{');
+            Number(json, nameof(SourcePort), SourcePort, first: true);
+            Number(json, nameof(DestinationPort), DestinationPort);
+            Number(json, nameof(RemoteTag), RemoteTag);
+            Number(json, nameof(RemoteTSN), RemoteTSN);
+            Number(json, nameof(RemoteARwnd), RemoteARwnd);
+            Text(json, nameof(RemoteEndPoint), RemoteEndPoint);
+            Number(json, nameof(Tag), Tag);
+            Number(json, nameof(TSN), TSN);
+            Number(json, nameof(ARwnd), ARwnd);
+            Text(json, nameof(CreatedAt), CreatedAt);
+            Number(json, nameof(Lifetime), (ulong)Lifetime);
+            Text(json, nameof(HMAC), HMAC);
+            json.Append('}');
+
+            return json.ToString();
+        }
+
+        /// <summary>
+        /// Parses a cookie from the JSON carried in a COOKIE ECHO chunk.
+        /// </summary>
+        /// <remarks>
+        /// A remote peer controls these bytes, so anything unparseable is an
+        /// empty cookie rather than an exception: the caller already treats an
+        /// empty cookie as a packet to drop, and an exception here lands in the
+        /// receive loop.
+        /// </remarks>
+        /// <summary>How many members a complete cookie has.</summary>
+        private const int MemberCount = 12;
+
+        public static SctpTransportCookie FromJson(string json)
+        {
+            if (string.IsNullOrWhiteSpace(json))
+            {
+                return Empty;
+            }
+
+            var cookie = new SctpTransportCookie();
+            var members = Members(json);
+
+            // EVERY MEMBER, OR NONE. The cookie is written and read by the same
+            // peer - the remote end only echoes it back - so a document missing
+            // a member is malformed rather than a version older than this one,
+            // and a partial parse would build a cookie out of defaults. The
+            // HMAC check below would reject that anyway; refusing it here says
+            // which of the two things went wrong.
+            if (members.Count != MemberCount)
+            {
+                return Empty;
+            }
+
+            cookie.SourcePort = UInt16(members, nameof(SourcePort));
+            cookie.DestinationPort = UInt16(members, nameof(DestinationPort));
+            cookie.RemoteTag = UInt32(members, nameof(RemoteTag));
+            cookie.RemoteTSN = UInt32(members, nameof(RemoteTSN));
+            cookie.RemoteARwnd = UInt32(members, nameof(RemoteARwnd));
+            cookie.RemoteEndPoint = String(members, nameof(RemoteEndPoint));
+            cookie.Tag = UInt32(members, nameof(Tag));
+            cookie.TSN = UInt32(members, nameof(TSN));
+            cookie.ARwnd = UInt32(members, nameof(ARwnd));
+            cookie.CreatedAt = String(members, nameof(CreatedAt));
+            cookie.Lifetime = Int32(members, nameof(Lifetime));
+            cookie.HMAC = String(members, nameof(HMAC));
+
+            return cookie;
+        }
+
+        private static void Number(StringBuilder json, string name, ulong value, bool first = false)
+        {
+            if (!first)
+            {
+                json.Append(',');
+            }
+
+            json.Append('"').Append(name).Append("\":")
+                .Append(value.ToString(CultureInfo.InvariantCulture));
+        }
+
+        private static void Text(StringBuilder json, string name, string value)
+        {
+            json.Append(",\"").Append(name).Append("\":");
+
+            if (value == null)
+            {
+                json.Append("null");
+                return;
+            }
+
+            json.Append('"');
+
+            foreach (var c in value)
+            {
+                switch (c)
+                {
+                    case '"': json.Append("\\\""); break;
+                    case '\\': json.Append("\\\\"); break;
+                    case '\n': json.Append("\\n"); break;
+                    case '\r': json.Append("\\r"); break;
+                    case '\t': json.Append("\\t"); break;
+                    default:
+                        if (c < ' ')
+                        {
+                            json.Append("\\u").Append(((int)c).ToString("X4", CultureInfo.InvariantCulture));
+                        }
+                        else
+                        {
+                            json.Append(c);
+                        }
+                        break;
+                }
+            }
+
+            json.Append('"');
+        }
+
+        /// <summary>Splits a flat JSON object into its members. No nesting, by design.</summary>
+        private static Dictionary<string, string> Members(string json)
+        {
+            var members = new Dictionary<string, string>(StringComparer.Ordinal);
+            var i = json.IndexOf('{');
+
+            if (i < 0)
+            {
+                return members;
+            }
+
+            i++;
+
+            while (i < json.Length)
+            {
+                while (i < json.Length && (json[i] == ',' || char.IsWhiteSpace(json[i])))
+                {
+                    i++;
+                }
+
+                if (i >= json.Length || json[i] == '}')
+                {
+                    break;
+                }
+
+                if (json[i] != '"' || !Quoted(json, ref i, out var name))
+                {
+                    return new Dictionary<string, string>(StringComparer.Ordinal);
+                }
+
+                while (i < json.Length && char.IsWhiteSpace(json[i]))
+                {
+                    i++;
+                }
+
+                if (i >= json.Length || json[i] != ':')
+                {
+                    return new Dictionary<string, string>(StringComparer.Ordinal);
+                }
+
+                i++;
+
+                while (i < json.Length && char.IsWhiteSpace(json[i]))
+                {
+                    i++;
+                }
+
+                if (i >= json.Length)
+                {
+                    return new Dictionary<string, string>(StringComparer.Ordinal);
+                }
+
+                if (json[i] == '"')
+                {
+                    if (!Quoted(json, ref i, out var text))
+                    {
+                        return new Dictionary<string, string>(StringComparer.Ordinal);
+                    }
+
+                    members[name] = text;
+                }
+                else
+                {
+                    var start = i;
+
+                    while (i < json.Length && json[i] != ',' && json[i] != '}')
+                    {
+                        i++;
+                    }
+
+                    members[name] = json.Substring(start, i - start).Trim();
+                }
+            }
+
+            return members;
+        }
+
+        private static bool Quoted(string json, ref int i, out string value)
+        {
+            value = null;
+            i++;
+
+            var text = new StringBuilder();
+
+            while (i < json.Length)
+            {
+                var c = json[i];
+
+                if (c == '"')
+                {
+                    i++;
+                    value = text.ToString();
+                    return true;
+                }
+
+                if (c == '\\')
+                {
+                    i++;
+
+                    if (i >= json.Length)
+                    {
+                        return false;
+                    }
+
+                    switch (json[i])
+                    {
+                        case '"': text.Append('"'); break;
+                        case '\\': text.Append('\\'); break;
+                        case 'n': text.Append('\n'); break;
+                        case 'r': text.Append('\r'); break;
+                        case 't': text.Append('\t'); break;
+                        case 'b': text.Append('\b'); break;
+                        case 'f': text.Append('\f'); break;
+                        case 'u':
+                            if (i + 4 >= json.Length
+                                || !ushort.TryParse(
+                                    json.Substring(i + 1, 4),
+                                    NumberStyles.HexNumber,
+                                    CultureInfo.InvariantCulture,
+                                    out var rune))
+                            {
+                                return false;
+                            }
+
+                            text.Append((char)rune);
+                            i += 4;
+                            break;
+                        default: return false;
+                    }
+                }
+                else
+                {
+                    text.Append(c);
+                }
+
+                i++;
+            }
+
+            return false;
+        }
+
+        private static string String(Dictionary<string, string> members, string name) =>
+            members.TryGetValue(name, out var value) ? value : string.Empty;
+
+        private static ushort UInt16(Dictionary<string, string> members, string name) =>
+            members.TryGetValue(name, out var value)
+            && ushort.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed)
+                ? parsed
+                : (ushort)0;
+
+        private static uint UInt32(Dictionary<string, string> members, string name) =>
+            members.TryGetValue(name, out var value)
+            && uint.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed)
+                ? parsed
+                : 0;
+
+        private static int Int32(Dictionary<string, string> members, string name) =>
+            members.TryGetValue(name, out var value)
+            && int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed)
+                ? parsed
+                : 0;
     }
 
     /// <summary>
@@ -237,7 +541,24 @@ namespace SIPSorcery.Net
         {
             var cookieEcho = sctpPacket.Chunks.Single(x => x.KnownType == SctpChunkType.COOKIE_ECHO);
             var cookieBuffer = cookieEcho.ChunkValue;
-            var cookie = JSONParser.FromJson<SctpTransportCookie>(Encoding.UTF8.GetString(cookieBuffer));
+
+            // A REMOTE PEER CONTROLS THIS BUFFER. Without the guard a COOKIE ECHO
+            // carrying no chunk value reaches Encoding.GetString(null), and the
+            // ArgumentNullException lands in the receive loop rather than being
+            // handled as the malformed packet it is.
+            if (cookieBuffer == null || cookieBuffer.Length == 0)
+            {
+                logger.LogWarning("SCTP COOKIE ECHO chunk had no cookie, ignoring.");
+                return SctpTransportCookie.Empty;
+            }
+
+            var cookie = SctpTransportCookie.FromJson(Encoding.UTF8.GetString(cookieBuffer));
+
+            if (cookie.IsEmpty())
+            {
+                logger.LogWarning("SCTP COOKIE ECHO chunk could not be parsed, ignoring.");
+                return SctpTransportCookie.Empty;
+            }
 
             logger.LogDebug("Cookie: {Cookie}", cookie.ToJson());
 
@@ -279,7 +600,7 @@ namespace SIPSorcery.Net
         /// <returns>True if the cookie is determined as valid, false if not.</returns>
         protected string GetCookieHMAC(byte[] buffer)
         {
-            var cookie = JSONParser.FromJson<SctpTransportCookie>(Encoding.UTF8.GetString(buffer));
+            var cookie = SctpTransportCookie.FromJson(Encoding.UTF8.GetString(buffer));
             string hmacCalculated = null;
             cookie.HMAC = string.Empty;
 

--- a/test/unit/net/SCTP/SctpTransportUnitTest.cs
+++ b/test/unit/net/SCTP/SctpTransportUnitTest.cs
@@ -36,6 +36,115 @@ namespace SIPSorcery.Net.UnitTests
         /// Tests getting an INIT ACK packet in response to an INIT packet
         /// works correctly and generates a usable state cookie.
         /// </summary>
+        /// <summary>
+        /// Tests that the state cookie serialises to the same JSON the reflection based
+        /// serialiser produced. The HMAC in GetCookieHMAC is computed over these exact
+        /// bytes, so member order and formatting are load-bearing rather than cosmetic.
+        /// </summary>
+        [Fact]
+        public void CookieSerialisesToTheSameJsonAsBefore()
+        {
+            logger.LogDebug("--> {method}", System.Reflection.MethodBase.GetCurrentMethod().Name);
+
+            var cookie = new SctpTransportCookie
+            {
+                SourcePort = 5000,
+                DestinationPort = 5001,
+                RemoteTag = 3163987031,
+                RemoteTSN = 2502329300,
+                RemoteARwnd = 131072,
+                RemoteEndPoint = "192.168.1.42:56400",
+                Tag = 987654321,
+                TSN = 123456789,
+                ARwnd = 131072,
+                CreatedAt = "2026-09-07T15:25:18.6826960-07:00",
+                Lifetime = 60,
+                HMAC = string.Empty
+            };
+
+            Assert.Equal(JSONWriter.ToJson(cookie), cookie.ToJson());
+        }
+
+        /// <summary>
+        /// Tests that a state cookie survives a round trip. This is what fails under
+        /// Native AOT with a reflection based serialiser: the members are trimmed, the
+        /// cookie does not survive, and the SCTP association stalls in CookieEchoed.
+        /// </summary>
+        [Fact]
+        public void CookieRoundTripsThroughJson()
+        {
+            logger.LogDebug("--> {method}", System.Reflection.MethodBase.GetCurrentMethod().Name);
+
+            var cookie = new SctpTransportCookie
+            {
+                SourcePort = 5000,
+                DestinationPort = 5001,
+                RemoteTag = 3163987031,
+                RemoteTSN = 2502329300,
+                RemoteARwnd = 131072,
+                RemoteEndPoint = "[fe80::1%en0]:56400",
+                Tag = 987654321,
+                TSN = 123456789,
+                ARwnd = 131072,
+                CreatedAt = "2026-09-07T15:25:18.6826960-07:00",
+                Lifetime = 60,
+                HMAC = "abc123"
+            };
+
+            var parsed = SctpTransportCookie.FromJson(cookie.ToJson());
+
+            Assert.False(parsed.IsEmpty());
+            Assert.Equal(cookie.SourcePort, parsed.SourcePort);
+            Assert.Equal(cookie.DestinationPort, parsed.DestinationPort);
+            Assert.Equal(cookie.RemoteTag, parsed.RemoteTag);
+            Assert.Equal(cookie.RemoteTSN, parsed.RemoteTSN);
+            Assert.Equal(cookie.RemoteARwnd, parsed.RemoteARwnd);
+            Assert.Equal(cookie.RemoteEndPoint, parsed.RemoteEndPoint);
+            Assert.Equal(cookie.Tag, parsed.Tag);
+            Assert.Equal(cookie.TSN, parsed.TSN);
+            Assert.Equal(cookie.ARwnd, parsed.ARwnd);
+            Assert.Equal(cookie.CreatedAt, parsed.CreatedAt);
+            Assert.Equal(cookie.Lifetime, parsed.Lifetime);
+            Assert.Equal(cookie.HMAC, parsed.HMAC);
+            Assert.Equal(cookie.ToJson(), parsed.ToJson());
+        }
+
+        /// <summary>
+        /// Tests that a malformed cookie is an empty cookie rather than an exception. A
+        /// remote peer controls these bytes, and the previous behaviour threw an
+        /// ArgumentNullException inside the SCTP receive loop.
+        /// </summary>
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("not json at all")]
+        [InlineData("{\"SourcePort\":50")]
+        [InlineData("{}")]
+        [InlineData("{\"SourcePort\":5000}")]
+        public void MalformedCookieIsEmptyRatherThanAnException(string json)
+        {
+            logger.LogDebug("--> {method}", System.Reflection.MethodBase.GetCurrentMethod().Name);
+
+            Assert.True(SctpTransportCookie.FromJson(json).IsEmpty());
+        }
+
+        /// <summary>
+        /// Tests that a COOKIE ECHO chunk carrying no cookie is ignored rather than
+        /// throwing. This is the packet that arrives when the peer's serialiser produced
+        /// nothing, and it reached Encoding.GetString(null).
+        /// </summary>
+        [Fact]
+        public void CookieEchoWithNoCookieIsIgnored()
+        {
+            logger.LogDebug("--> {method}", System.Reflection.MethodBase.GetCurrentMethod().Name);
+
+            var transport = new MockSctpTransport();
+            var packet = new SctpPacket(5000, 5001, 0);
+            packet.AddChunk(new SctpChunk(SctpChunkType.COOKIE_ECHO) { ChunkValue = null });
+
+            Assert.True(transport.GetCookieForTest(packet).IsEmpty());
+        }
+
         [Fact]
         public void GetInitAckPacket()
         {
@@ -88,6 +197,11 @@ namespace SIPSorcery.Net.UnitTests
         public new string GetCookieHMAC(byte[] buffer)
         {
             return base.GetCookieHMAC(buffer);
+        }
+
+        public SctpTransportCookie GetCookieForTest(SctpPacket packet)
+        {
+            return base.GetCookie(packet);
         }
 
         public override void Send(string associationID, byte[] buffer, int offset, int length)


### PR DESCRIPTION
Fixes #1816.

## The problem

Under `PublishAot=true`, ICE and DTLS complete but the SCTP association never
does, so **data channels never open**. The same source published without AOT
works. The association stalls in `CookieEchoed` and times out after 2s.

The cause is the state cookie being carried as reflection-serialized JSON. The
trimmer removes `SctpTransportCookie`'s members, TinyJson then produces a
document without them, the COOKIE ECHO arrives with a null `ChunkValue`, and
`GetCookie` throws out of `Encoding.GetString` before it can validate anything.
The packet is dropped, no COOKIE ACK is sent, and the initiator waits until it
gives up.

The publish warnings predicted it — 7 of the 9 were `TinyJson.JSONParser` and
`TinyJson.JSONWriter`. (`TrimmerSingleWarn=false` is what makes them name the
library; with the default they collapse into one line per assembly and the
connection is invisible.) Notably there were **no `IL3050` warnings at all** —
nothing here needs runtime code generation, so this is purely member discovery
on trimmed types.

## The change

The four TinyJson call sites become a hand-written serializer on the cookie
itself.

**Hand-written rather than source-generated `System.Text.Json`,** which I
realise runs against the direction of #1805. The reason is scope: this project
targets nine frameworks down to `net462` and does not currently reference
`System.Text.Json`, so taking the source-generated route here means adding a
package across all of them. Twelve members of primitives and strings don't
warrant that. Happy to redo it that way if you'd rather have one approach
everywhere — the call sites are the same either way.

**The output is byte-identical to TinyJson's,** which matters more than it
looks: `GetCookieHMAC` computes the HMAC over these exact bytes, so member order
and formatting are load-bearing rather than cosmetic. Reflection member order
isn't guaranteed by the runtime; declaration order is. There's a test asserting
the two serializers agree.

**No wire compatibility concern.** `GetCookie` is only reached on COOKIE ECHO
receipt, so the peer that writes a cookie is the only peer that reads it — the
remote end echoes it back verbatim. A patched peer and an unpatched peer
interoperate.

**Also guards the parse,** because a remote peer controls those bytes. A COOKIE
ECHO with no chunk value, or one that doesn't parse, is now an ignored packet
rather than an exception in the receive loop. That's worth having independently
of the AOT issue.

## Verification

Two processes exchanging SDP through files, both published Native AOT
(osx-arm64, .NET SDK 10.0.102):

| | before | after |
|---|---|---|
| ICE | connected | connected |
| DTLS 1.2 | complete | complete |
| SCTP association | `Connecting` → `CookieEchoed` → `Closed` | **established** |
| Data channel | never opens, 30s timeout | **opens; messages cross both ways** |
| Trim warnings on the WebRTC path | 9 | 2 (both `Common.Logging`) |

Tests: 4 added to `SctpTransportUnitTest` — serializer parity with TinyJson,
round trip including an IPv6 endpoint, malformed input as a `Theory`, and a
COOKIE ECHO with a null chunk value. `SctpTransportUnitTest` 10 passed; the SCTP
suite 71 passed, 2 skipped, 0 failed. Existing tests unchanged.

## One note on formatting

I ran `dotnet format` per CONTRIBUTING and reverted it: it rewrites these files
wholesale, because `SctpTransport.cs` is LF in the repo while `.editorconfig`
asks for CRLF (and `SctpTransportUnitTest.cs` is CRLF, so the two differ).
`dotnet format --verify-no-changes` reports 516 errors on pristine `master` for
`SctpTransport.cs` alone. The diff here therefore matches each file's existing
conventions rather than the formatter's, to keep it reviewable — happy to run it
if you'd prefer, but it seemed like a separate change.

## Why I care

We're evaluating WebRTC data channels as a peer-to-peer path between a CLI and a
remote agent, so log output can reach an operator without transiting a control
plane that isn't permitted to see it. The library fits that unusually well —
ICE preserves the agent's outbound-only posture, signalling is metadata a broker
can carry without being in the data path, and DTLS isn't optional. Native AOT is
a hard requirement for us, and this was the one thing in the way.